### PR TITLE
fix: fix the demo app to fit ipad

### DIFF
--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
@@ -21,5 +21,5 @@ struct AmplitudeSwiftUIExampleApp: App {
 }
 
 extension Amplitude {
-    static var main = Amplitude(configuration: Configuration(apiKey: "TEST-API-KEY"))
+    static var testInstance = Amplitude(configuration: Configuration(apiKey: "TEST-API-KEY"))
 }

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ContentView.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ContentView.swift
@@ -44,7 +44,7 @@ struct ContentView: View {
                                 TextField("UserId", text: $userId)
                                 Button(action: {
                                     print("Set UserId")
-                                    _ = Amplitude.main.setUserId(userId: userId)
+                                    _ = Amplitude.testInstance.setUserId(userId: userId)
                                 }) {
                                     Text("Set UserId")
                                 }.buttonStyle(AmplitudeButton())
@@ -52,7 +52,7 @@ struct ContentView: View {
                             HStack {
                                 TextField("DeviceId", text: $deviceId)
                                 Button(action: {
-                                    _ = Amplitude.main.setDeviceId(deviceId: deviceId)
+                                    _ = Amplitude.testInstance.setDeviceId(deviceId: deviceId)
                                 }) {
                                     Text("Reset DeviceId")
                                 }.buttonStyle(AmplitudeButton())
@@ -65,7 +65,7 @@ struct ContentView: View {
                                 Button(action: {
                                     print("Log event.")
                                     let event = BaseEvent(eventType: eventType)
-                                    _ = Amplitude.main.track(event: event)
+                                    _ = Amplitude.testInstance.track(event: event)
                                 }) {
                                     Text("Send Event")
                                 }.buttonStyle(AmplitudeButton())
@@ -109,7 +109,7 @@ struct ContentView: View {
                             }.buttonStyle(AmplitudeButton())
                         }
                         Button(action: {
-                            _ = Amplitude.main.flush()
+                            _ = Amplitude.testInstance.flush()
                         }) {
                             Text("Flush All Events")
                                 .frame(maxWidth: .infinity)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Should not use `NavigationView`, in an iPad, it's a foldable navigation. 
Update to use a sticky header for the title.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
