### PR TITLE
fix: change storage to use sync queue, fix retry issues

### DIFF
--- a/Sources/Amplitude/EventBridge.swift
+++ b/Sources/Amplitude/EventBridge.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  EventBridge.swift
 //
 //
 //  Created by Marvin Liu on 10/27/22.

--- a/Sources/Amplitude/Storages/InMemoryStorage.swift
+++ b/Sources/Amplitude/Storages/InMemoryStorage.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  InMemoryStorage.swift
 //
 //
 //  Created by Marvin Liu on 10/28/22.
@@ -10,31 +10,31 @@ import Foundation
 class InMemoryStorage: Storage {
     typealias EventBlock = URL
 
-    func write(key: StorageKey, value: Any?) async {
+    func write(key: StorageKey, value: Any?) {
 
     }
 
-    func read<T>(key: StorageKey) async -> T? {
+    func read<T>(key: StorageKey) -> T? {
         return nil
     }
 
-    func reset() async {
+    func reset() {
 
     }
 
-    func rollover() async {
+    func rollover() {
 
     }
 
-    func getEventsString(eventBlock: EventBlock) async -> String? {
+    func getEventsString(eventBlock: EventBlock) -> String? {
         return nil
     }
 
-    func remove(eventBlock: EventBlock) async {
+    func remove(eventBlock: EventBlock) {
 
     }
 
-    func splitBlock(eventBlock: EventBlock, events: [BaseEvent]) async {
+    func splitBlock(eventBlock: EventBlock, events: [BaseEvent]) {
 
     }
 

--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -26,13 +26,13 @@ public typealias EventCallBack = (BaseEvent, Int, String) -> Void
 // It cannot be dynamically associated with this protocol.
 // https://github.com/apple/swift/issues/62219#issuecomment-1326531801
 public protocol Storage {
-    func write(key: StorageKey, value: Any?) async throws
-    func read<T>(key: StorageKey) async -> T?
-    func getEventsString(eventBlock: URL) async -> String?
-    func remove(eventBlock: URL) async
-    func splitBlock(eventBlock: URL, events: [BaseEvent]) async
-    func rollover() async
-    func reset() async
+    func write(key: StorageKey, value: Any?) throws
+    func read<T>(key: StorageKey) -> T?
+    func getEventsString(eventBlock: URL) -> String?
+    func remove(eventBlock: URL)
+    func splitBlock(eventBlock: URL, events: [BaseEvent])
+    func rollover()
+    func reset()
     func getResponseHandler(
         configuration: Configuration,
         eventPipeline: EventPipeline,
@@ -94,9 +94,9 @@ extension Plugin {
 
 public protocol ResponseHandler {
     func handle(result: Result<Int, Error>)
-    func handleSuccessResponse(code: Int) async
-    func handleBadRequestResponse(data: [String: Any]) async
-    func handlePayloadTooLargeResponse(data: [String: Any]) async
+    func handleSuccessResponse(code: Int)
+    func handleBadRequestResponse(data: [String: Any])
+    func handlePayloadTooLargeResponse(data: [String: Any])
     func handleTooManyRequestsResponse(data: [String: Any])
     func handleTimeoutResponse(data: [String: Any])
     func handleFailedResponse(data: [String: Any])

--- a/Sources/Amplitude/Utilities/UrlExtension.swift
+++ b/Sources/Amplitude/Utilities/UrlExtension.swift
@@ -1,0 +1,18 @@
+//
+//  UrlExtension.swift
+//
+//
+//  Created by Marvin Liu on 12/7/22.
+//
+
+import Foundation
+
+extension URL {
+    func appendFileNameSuffix(suffix: String) -> URL {
+        var filename = deletingPathExtension().lastPathComponent + "\(suffix)"
+        if !pathExtension.isEmpty {
+            filename += ".\(pathExtension)"
+        }
+        return deletingLastPathComponent().appendingPathComponent(filename)
+    }
+}

--- a/Tests/AmplitudeTests/ConfigurationTests.swift
+++ b/Tests/AmplitudeTests/ConfigurationTests.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  ConfigurationTests.swift
 //
 //
 //  Created by Marvin Liu on 11/3/22.

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -10,43 +10,43 @@ import XCTest
 @testable import Amplitude_Swift
 
 final class PersistentStorageTests: XCTestCase {
-    func testIsBasicType() async {
+    func testIsBasicType() {
         let persistentStorage = PersistentStorage()
-        var isValueBasicType = await persistentStorage.isBasicType(value: 111)
+        var isValueBasicType = persistentStorage.isBasicType(value: 111)
         XCTAssertEqual(isValueBasicType, true)
 
-        isValueBasicType = await persistentStorage.isBasicType(value: 11.11)
+        isValueBasicType = persistentStorage.isBasicType(value: 11.11)
         XCTAssertEqual(isValueBasicType, true)
 
-        isValueBasicType = await persistentStorage.isBasicType(value: true)
+        isValueBasicType = persistentStorage.isBasicType(value: true)
         XCTAssertEqual(isValueBasicType, true)
 
-        isValueBasicType = await persistentStorage.isBasicType(value: "test")
+        isValueBasicType = persistentStorage.isBasicType(value: "test")
         XCTAssertEqual(isValueBasicType, true)
 
-        isValueBasicType = await persistentStorage.isBasicType(value: NSString("test"))
+        isValueBasicType = persistentStorage.isBasicType(value: NSString("test"))
         XCTAssertEqual(isValueBasicType, true)
 
-        isValueBasicType = await persistentStorage.isBasicType(value: nil)
+        isValueBasicType = persistentStorage.isBasicType(value: nil)
         XCTAssertEqual(isValueBasicType, true)
 
-        isValueBasicType = await persistentStorage.isBasicType(value: Date())
+        isValueBasicType = persistentStorage.isBasicType(value: Date())
         XCTAssertEqual(isValueBasicType, false)
     }
 
-    func testWrite() async {
+    func testWrite() {
         let persistentStorage = PersistentStorage(apiKey: "xxx-api-key")
-        try? await persistentStorage.write(
+        try? persistentStorage.write(
             key: StorageKey.EVENTS,
             value: BaseEvent(eventType: "test1")
         )
-        try? await persistentStorage.write(
+        try? persistentStorage.write(
             key: StorageKey.EVENTS,
             value: BaseEvent(eventType: "test2")
         )
-        let eventFiles: [URL]? = await persistentStorage.read(key: StorageKey.EVENTS)
+        let eventFiles: [URL]? = persistentStorage.read(key: StorageKey.EVENTS)
         XCTAssertEqual(eventFiles?[0].absoluteString.contains("xxx-api-key.events.index"), true)
         XCTAssertNotEqual(eventFiles?[0].pathExtension, PersistentStorage.TEMP_FILE_EXTENSION)
-        await persistentStorage.reset()
+        persistentStorage.reset()
     }
 }

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -47,14 +47,14 @@ class OutputReaderPlugin: Plugin {
     }
 }
 
-actor FakeInMemoryStorage: Storage {
+class FakeInMemoryStorage: Storage {
     typealias EventBlock = URL
 
     var keyValueStore = [String: Any?]()
     var eventsStore = [URL: [BaseEvent]]()
     var index = URL(string: "0")!
 
-    func write(key: StorageKey, value: Any?) async throws {
+    func write(key: StorageKey, value: Any?) throws {
         switch key {
         case .EVENTS:
             if let event = value as? BaseEvent {
@@ -67,7 +67,7 @@ actor FakeInMemoryStorage: Storage {
         }
     }
 
-    func read<T>(key: StorageKey) async -> T? {
+    func read<T>(key: StorageKey) -> T? {
         var result: T?
         switch key {
         case .EVENTS:
@@ -78,7 +78,7 @@ actor FakeInMemoryStorage: Storage {
         return result
     }
 
-    func getEventsString(eventBlock: EventBlock) async -> String? {
+    func getEventsString(eventBlock: EventBlock) -> String? {
         var content: String?
         content = "["
         content = content! + (eventsStore[eventBlock] ?? []).map { $0.toString() }.joined(separator: ", ")
@@ -86,18 +86,18 @@ actor FakeInMemoryStorage: Storage {
         return content
     }
 
-    func rollover() async {
+    func rollover() {
     }
 
-    func reset() async {
+    func reset() {
         keyValueStore.removeAll()
         eventsStore.removeAll()
     }
 
-    func remove(eventBlock: EventBlock) async {
+    func remove(eventBlock: EventBlock) {
     }
 
-    func splitBlock(eventBlock: EventBlock, events: [BaseEvent]) async {
+    func splitBlock(eventBlock: EventBlock, events: [BaseEvent]) {
     }
 
     nonisolated func getResponseHandler(
@@ -125,13 +125,13 @@ class FakeResponseHandler: ResponseHandler {
     func handle(result: Result<Int, Error>) {
     }
 
-    func handleSuccessResponse(code: Int) async {
+    func handleSuccessResponse(code: Int) {
     }
 
-    func handleBadRequestResponse(data: [String: Any]) async {
+    func handleBadRequestResponse(data: [String: Any]) {
     }
 
-    func handlePayloadTooLargeResponse(data: [String: Any]) async {
+    func handlePayloadTooLargeResponse(data: [String: Any]) {
     }
 
     func handleTooManyRequestsResponse(data: [String: Any]) {

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -41,9 +41,9 @@ final class EventPipelineTests: XCTestCase {
         _ = XCTWaiter.wait(for: [asyncExpectation], timeout: 3)
     }
 
-    func testFlush() async {
+    func testFlush() {
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
-        try? await eventPipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
+        try? eventPipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
 
         let fakeHttpClient = FakeHttpClient(configuration: configuration)
         eventPipeline.httpClient = fakeHttpClient as HttpClient

--- a/Tests/AmplitudeTests/Utilities/UrlExtensionTests.swift
+++ b/Tests/AmplitudeTests/Utilities/UrlExtensionTests.swift
@@ -1,0 +1,18 @@
+//
+//  UrlExtensionTests.swift
+//  
+//
+//  Created by Marvin Liu on 12/7/22.
+//
+
+import XCTest
+
+@testable import Amplitude_Swift
+
+final class UrlExtensionTests: XCTestCase {
+    func testAppendFileNameSuffix() {
+        let url = URL(string: "abc/def/hello.txt")
+        let newUrl = url?.appendFileNameSuffix(suffix: "-world")
+        XCTAssertEqual(newUrl?.lastPathComponent, "hello-world.txt")
+    }
+}


### PR DESCRIPTION
### Summary
- fix: change storage to use sync queue
- fix: retry issues

When multiple Task are created, the order of execution doesn't seem to be guaranteed: https://forums.swift.org/t/task-is-order-of-task-execution-deterministic/51553/30, namely FIFO.

After some investigation, I think `@globalActor` might be a potential solution. However, as the documentation is limited, and I don't have a good example to verify it. I change the storage to use dispatch queue (old generation API). Example I tried with `@globalActor`:
```swift
...
    @SomeGlobalActor
    func test_mainActor_taskOrdering() async {
        var counter = 0
        var tasks = [Task<Void, Never>]()
        for iteration in 1...1000 {
            tasks.append(Task {
                print(Thread.current)
                counter += 1
                XCTAssertEqual(counter, iteration) // often fails
            })
        }
        
        for task in tasks {
            _ = await task.value
        }
    }
...

@globalActor
public struct SomeGlobalActor {
  public actor MyActor { }

  public static let shared = MyActor()
}
```

Also test the error cases for handlers, found minor issues and fix here.


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
