### PR TITLE
feat: idfa plugin example

### DIFF
--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		19C9CC1F2937F5A600C1E660 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C9CC1E2937F5A600C1E660 /* Persistence.swift */; };
 		19C9CC222937F5A600C1E660 /* AmplitudeSwiftUIExample.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 19C9CC202937F5A600C1E660 /* AmplitudeSwiftUIExample.xcdatamodeld */; };
 		19C9CC2D2937F5D000C1E660 /* Amplitude-Swift in Frameworks */ = {isa = PBXBuildFile; productRef = 19C9CC2C2937F5D000C1E660 /* Amplitude-Swift */; };
+		3A4E19BD2941D885002EA8BC /* IDFACollectionPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4E19BC2941D86E002EA8BC /* IDFACollectionPlugin.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		19C9CC212937F5A600C1E660 /* AmplitudeSwiftUIExample.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = AmplitudeSwiftUIExample.xcdatamodel; sourceTree = "<group>"; };
 		19C9CC292937F5B200C1E660 /* Amplitude-Swift */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "Amplitude-Swift"; path = ../..; sourceTree = "<group>"; };
 		19C9CC2A2937F5C900C1E660 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		3A4E19BC2941D86E002EA8BC /* IDFACollectionPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDFACollectionPlugin.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,6 +63,7 @@
 		19C9CC142937F5A400C1E660 /* AmplitudeSwiftUIExample */ = {
 			isa = PBXGroup;
 			children = (
+				3A4E19BB2941D86E002EA8BC /* ExamplePlugins */,
 				19C9CC2A2937F5C900C1E660 /* Info.plist */,
 				19C9CC152937F5A400C1E660 /* AmplitudeSwiftUIExampleApp.swift */,
 				19C9CC172937F5A400C1E660 /* ContentView.swift */,
@@ -93,6 +96,14 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3A4E19BB2941D86E002EA8BC /* ExamplePlugins */ = {
+			isa = PBXGroup;
+			children = (
+				3A4E19BC2941D86E002EA8BC /* IDFACollectionPlugin.swift */,
+			);
+			path = ExamplePlugins;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -172,6 +183,7 @@
 				19C9CC1F2937F5A600C1E660 /* Persistence.swift in Sources */,
 				19C9CC182937F5A400C1E660 /* ContentView.swift in Sources */,
 				19C9CC162937F5A400C1E660 /* AmplitudeSwiftUIExampleApp.swift in Sources */,
+				3A4E19BD2941D885002EA8BC /* IDFACollectionPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
@@ -6,8 +6,8 @@
 //
 
 import Amplitude_Swift
-import SwiftUI
 import AppTrackingTransparency
+import SwiftUI
 
 @main
 struct AmplitudeSwiftUIExampleApp: App {
@@ -23,10 +23,10 @@ struct AmplitudeSwiftUIExampleApp: App {
             ContentView()
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
-                   let status = ATTrackingManager.trackingAuthorizationStatus
-                   if status == .notDetermined {
+                    let status = ATTrackingManager.trackingAuthorizationStatus
+                    if status == .notDetermined {
                         askForPermission()
-                   }
+                    }
                 }
         }
     }
@@ -35,7 +35,12 @@ struct AmplitudeSwiftUIExampleApp: App {
         // Popup modal to request the tracking autorization
         ATTrackingManager.requestTrackingAuthorization { status in
             // send a track event that shows the results of asking the user for permission.
-            Amplitude.testInstance.track(event: BaseEvent(eventType: "Ask For IDFA permission", eventProperties: ["status": statusToString(status)]))
+            Amplitude.testInstance.track(
+                event: BaseEvent(
+                    eventType: "Ask For IDFA permission",
+                    eventProperties: ["status": statusToString(status)]
+                )
+            )
         }
     }
 
@@ -56,7 +61,6 @@ struct AmplitudeSwiftUIExampleApp: App {
         return result
     }
 }
-
 
 extension Amplitude {
     static var testInstance = Amplitude(configuration: Configuration(apiKey: "TEST-API-KEY"))

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
@@ -63,5 +63,9 @@ struct AmplitudeSwiftUIExampleApp: App {
 }
 
 extension Amplitude {
-    static var testInstance = Amplitude(configuration: Configuration(apiKey: "TEST-API-KEY"))
+    static var testInstance = Amplitude(configuration: Configuration(apiKey: "82b148f7211db7f9ccaff8048d0f7192",
+                                                                     logLevel: LogLevelEnum.DEBUG,
+                                                                     trackingOptions: TrackingOptions().disableCarrier().disableTrackDMA(),
+                                                                     flushEventsOnClose: true,
+                                                                     minTimeBetweenSessionsMillis: 100000))
 }

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
@@ -7,18 +7,56 @@
 
 import Amplitude_Swift
 import SwiftUI
+import AppTrackingTransparency
 
 @main
 struct AmplitudeSwiftUIExampleApp: App {
     let persistenceController = PersistenceController.shared
 
+    // Overriding the initializer in the App in order to config amplitude
+    init() {
+        Amplitude.testInstance.add(plugin: IDFACollectionPlugin())
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
+                .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { _ in
+                   let status = ATTrackingManager.trackingAuthorizationStatus
+                   if status == .notDetermined {
+                        askForPermission()
+                   }
+                }
         }
     }
+
+    func askForPermission() {
+        // Popup modal to request the tracking autorization
+        ATTrackingManager.requestTrackingAuthorization { status in
+            // send a track event that shows the results of asking the user for permission.
+            Amplitude.testInstance.track(event: BaseEvent(eventType: "Ask For IDFA permission", eventProperties: ["status": statusToString(status)]))
+        }
+    }
+
+    func statusToString(_ status: ATTrackingManager.AuthorizationStatus) -> String {
+        var result = "unknown"
+        switch status {
+        case .notDetermined:
+            result = "notDetermined"
+        case .restricted:
+            result = "restricted"
+        case .denied:
+            result = "denied"
+        case .authorized:
+            result = "authorized"
+        @unknown default:
+            break
+        }
+        return result
+    }
 }
+
 
 extension Amplitude {
     static var testInstance = Amplitude(configuration: Configuration(apiKey: "TEST-API-KEY"))

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ContentView.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ContentView.swift
@@ -8,11 +8,13 @@
 import Amplitude_Swift
 import CoreData
 import SwiftUI
+import AppTrackingTransparency
 
 let amplitudeColor = Color(red: 0.16, green: 0.46, blue: 0.87)
 
 struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
+
     @State var userId: String = ""
     // TODO: get current deviceId
     @State var deviceId: String = "xxx-xxx-xxx"

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ContentView.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ContentView.swift
@@ -6,9 +6,9 @@
 //
 
 import Amplitude_Swift
+import AppTrackingTransparency
 import CoreData
 import SwiftUI
-import AppTrackingTransparency
 
 let amplitudeColor = Color(red: 0.16, green: 0.46, blue: 0.87)
 
@@ -30,94 +30,94 @@ struct ContentView: View {
     @State var groupUserPropertyValue = ""
 
     var body: some View {
+        VStack {
+            LazyVStack {
+                Text("Amplitude Exmaple")
+                    .bold()
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .background(amplitudeColor)
+                    .foregroundColor(.white)
+            }
             VStack {
-                LazyVStack {
-                    Text("Amplitude Exmaple")
-                        .bold()
-                        .padding()
-                        .frame(maxWidth: .infinity)
-                        .background(amplitudeColor)
-                        .foregroundColor(.white)
-                }
-                VStack {
-                    Form {
-                        Section(header: Text("IDENTITY")) {
-                            HStack {
-                                TextField("UserId", text: $userId)
-                                Button(action: {
-                                    print("Set UserId")
-                                    _ = Amplitude.testInstance.setUserId(userId: userId)
-                                }) {
-                                    Text("Set UserId")
-                                }.buttonStyle(AmplitudeButton())
-                            }
-                            HStack {
-                                TextField("DeviceId", text: $deviceId)
-                                Button(action: {
-                                    _ = Amplitude.testInstance.setDeviceId(deviceId: deviceId)
-                                }) {
-                                    Text("Reset DeviceId")
-                                }.buttonStyle(AmplitudeButton())
-                                
-                            }
-                        }
-                        Section(header: Text("GENERAL EVENT")) {
-                            HStack {
-                                TextField("Event Name", text: $eventType)
-                                Button(action: {
-                                    print("Log event.")
-                                    let event = BaseEvent(eventType: eventType)
-                                    _ = Amplitude.testInstance.track(event: event)
-                                }) {
-                                    Text("Send Event")
-                                }.buttonStyle(AmplitudeButton())
-                                
-                            }
-                        }
-                        Section(header: Text("REVENUE EVENT")) {
-                            TextField("Product Id", text: $productId)
-                            TextField("Price", value: $price, formatter: decimalFormatter())
-                            TextField("Quantity", value: $quantity, formatter: NumberFormatter())
+                Form {
+                    Section(header: Text("IDENTITY")) {
+                        HStack {
+                            TextField("UserId", text: $userId)
                             Button(action: {
-                                // TODO: trigger revenue event
+                                print("Set UserId")
+                                _ = Amplitude.testInstance.setUserId(userId: userId)
                             }) {
-                                Text("Send Revenue Event")
+                                Text("Set UserId")
                             }.buttonStyle(AmplitudeButton())
                         }
-                        Section(header: Text("IDENTIFY")) {
-                            HStack {
-                                TextField("User Property Key", text: $userPropertyKey)
-                                TextField("User Property Value", text: $userPropertyValue)
-                            }
+                        HStack {
+                            TextField("DeviceId", text: $deviceId)
                             Button(action: {
-                                // TODO: trigger identify event
+                                _ = Amplitude.testInstance.setDeviceId(deviceId: deviceId)
                             }) {
-                                Text("Send Identify Event")
+                                Text("Reset DeviceId")
                             }.buttonStyle(AmplitudeButton())
+
                         }
-                        Section(header: Text("GROUP IDENTIFY")) {
-                            HStack {
-                                TextField("Group Type", text: $groupType)
-                                TextField("Group Property", text: $groupProperty)
-                            }
-                            HStack {
-                                TextField("User Property Key", text: $groupUserPropertyKey)
-                                TextField("User Property Value", text: $groupUserPropertyValue)
-                            }
+                    }
+                    Section(header: Text("GENERAL EVENT")) {
+                        HStack {
+                            TextField("Event Name", text: $eventType)
                             Button(action: {
-                                // TODO: trigger group identify event
+                                print("Log event.")
+                                let event = BaseEvent(eventType: eventType)
+                                _ = Amplitude.testInstance.track(event: event)
                             }) {
-                                Text("Send Group Identify Event")
+                                Text("Send Event")
                             }.buttonStyle(AmplitudeButton())
+
                         }
+                    }
+                    Section(header: Text("REVENUE EVENT")) {
+                        TextField("Product Id", text: $productId)
+                        TextField("Price", value: $price, formatter: decimalFormatter())
+                        TextField("Quantity", value: $quantity, formatter: NumberFormatter())
                         Button(action: {
-                            _ = Amplitude.testInstance.flush()
+                            // TODO: trigger revenue event
                         }) {
-                            Text("Flush All Events")
-                                .frame(maxWidth: .infinity)
+                            Text("Send Revenue Event")
                         }.buttonStyle(AmplitudeButton())
                     }
+                    Section(header: Text("IDENTIFY")) {
+                        HStack {
+                            TextField("User Property Key", text: $userPropertyKey)
+                            TextField("User Property Value", text: $userPropertyValue)
+                        }
+                        Button(action: {
+                            // TODO: trigger identify event
+                        }) {
+                            Text("Send Identify Event")
+                        }.buttonStyle(AmplitudeButton())
+                    }
+                    Section(header: Text("GROUP IDENTIFY")) {
+                        HStack {
+                            TextField("Group Type", text: $groupType)
+                            TextField("Group Property", text: $groupProperty)
+                        }
+                        HStack {
+                            TextField("User Property Key", text: $groupUserPropertyKey)
+                            TextField("User Property Value", text: $groupUserPropertyValue)
+                        }
+                        Button(action: {
+                            // TODO: trigger group identify event
+                        }) {
+                            Text("Send Group Identify Event")
+                        }.buttonStyle(AmplitudeButton())
+                    }
+                    Button(action: {
+                        _ = Amplitude.testInstance.flush()
+                    }) {
+                        Text("Flush All Events")
+                            .frame(maxWidth: .infinity)
+                    }.buttonStyle(AmplitudeButton())
                 }
+            }
         }
     }
 }

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
@@ -34,7 +34,8 @@ class IDFACollectionPlugin: Plugin {
         let workingEvent = event
         // The idfa on simulator is always 00000000-0000-0000-0000-000000000000
         event?.idfa = idfa
-
+        // If you want to use idfa for the device_id
+        event?.deviceId = idfa
         return workingEvent
     }
 }

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
@@ -29,15 +29,26 @@ class IDFACollectionPlugin: Plugin {
     
     func execute(event: BaseEvent?) -> BaseEvent? {
         let status = ATTrackingManager.trackingAuthorizationStatus
-        var idfa = ""
+        var idfa = fallbackValue
         if status == .authorized {
             idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
         }
                 
         let workingEvent = event
         // The idfa on simulator is always 00000000-0000-0000-0000-000000000000
-        event?.idfa = "12345678-1234-1234-1234-123456789012"
+        event?.idfa = idfa
 
         return workingEvent
+    }
+}
+
+extension IDFACollectionPlugin {
+    var fallbackValue: String? {
+        get {
+            // fallback to the IDFV value.
+            // this is also sent in event.context.device.id,
+            // feel free to use a value that is more useful to you.
+            return UIDevice.current.identifierForVendor?.uuidString
+        }
     }
 }

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
@@ -1,0 +1,43 @@
+//
+//  IDFACollectionPlugin.swift
+//  
+//
+//  Created by Alyssa.Yu on 12/7/22.
+//
+
+// NOTE: You can see this plugin in use in the AmplitudeSwiftUIExample application.
+//
+// This plugin is NOT SUPPORTED by Segment.  It is here merely as an example,
+// and for your convenience should you find it useful.
+
+import Foundation
+import SwiftUI
+import Amplitude_Swift
+import AdSupport
+import AppTrackingTransparency
+
+/**
+ Plugin to collect IDFA values.  Users will be prompted if authorization status is undetermined.
+ Upon completion of user entry a track event is issued showing the choice user made.
+ 
+ Don't forget to add "NSUserTrackingUsageDescription" with a description to your Info.plist.
+ */
+class IDFACollectionPlugin: Plugin {
+    let type = PluginType.enrichment
+    weak var amplitude: Amplitude? = nil
+    @Atomic private var alreadyAsked = false
+    
+    func execute(event: BaseEvent?) -> BaseEvent? {
+        let status = ATTrackingManager.trackingAuthorizationStatus
+        var idfa = ""
+        if status == .authorized {
+            idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
+        }
+                
+        let workingEvent = event
+        // The idfa on simulator is always 00000000-0000-0000-0000-000000000000
+        event?.idfa = "12345678-1234-1234-1234-123456789012"
+
+        return workingEvent
+    }
+}

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
@@ -7,7 +7,7 @@
 
 // NOTE: You can see this plugin in use in the AmplitudeSwiftUIExample application.
 //
-// This plugin is NOT SUPPORTED by Segment.  It is here merely as an example,
+// This plugin is NOT SUPPORTED by Amplitude.  It is here merely as an example,
 // and for your convenience should you find it useful.
 
 import AdSupport
@@ -23,7 +23,6 @@ import SwiftUI
 class IDFACollectionPlugin: Plugin {
     let type = PluginType.enrichment
     weak var amplitude: Amplitude? = nil
-    @Atomic private var alreadyAsked = false
 
     func execute(event: BaseEvent?) -> BaseEvent? {
         let status = ATTrackingManager.trackingAuthorizationStatus

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/IDFACollectionPlugin.swift
@@ -1,6 +1,6 @@
 //
 //  IDFACollectionPlugin.swift
-//  
+//
 //
 //  Created by Alyssa.Yu on 12/7/22.
 //
@@ -10,30 +10,28 @@
 // This plugin is NOT SUPPORTED by Segment.  It is here merely as an example,
 // and for your convenience should you find it useful.
 
+import AdSupport
+import Amplitude_Swift
+import AppTrackingTransparency
 import Foundation
 import SwiftUI
-import Amplitude_Swift
-import AdSupport
-import AppTrackingTransparency
 
-/**
- Plugin to collect IDFA values.  Users will be prompted if authorization status is undetermined.
- Upon completion of user entry a track event is issued showing the choice user made.
- 
- Don't forget to add "NSUserTrackingUsageDescription" with a description to your Info.plist.
- */
+/// Plugin to collect IDFA values.  Users will be prompted if authorization status is undetermined.
+/// Upon completion of user entry a track event is issued showing the choice user made.
+///
+/// Don't forget to add "NSUserTrackingUsageDescription" with a description to your Info.plist.
 class IDFACollectionPlugin: Plugin {
     let type = PluginType.enrichment
     weak var amplitude: Amplitude? = nil
     @Atomic private var alreadyAsked = false
-    
+
     func execute(event: BaseEvent?) -> BaseEvent? {
         let status = ATTrackingManager.trackingAuthorizationStatus
         var idfa = fallbackValue
         if status == .authorized {
             idfa = ASIdentifierManager.shared().advertisingIdentifier.uuidString
         }
-                
+
         let workingEvent = event
         // The idfa on simulator is always 00000000-0000-0000-0000-000000000000
         event?.idfa = idfa
@@ -44,11 +42,9 @@ class IDFACollectionPlugin: Plugin {
 
 extension IDFACollectionPlugin {
     var fallbackValue: String? {
-        get {
-            // fallback to the IDFV value.
-            // this is also sent in event.context.device.id,
-            // feel free to use a value that is more useful to you.
-            return UIDevice.current.identifierForVendor?.uuidString
-        }
+        // fallback to the IDFV value.
+        // this is also sent in event.context.device.id,
+        // feel free to use a value that is more useful to you.
+        return UIDevice.current.identifierForVendor?.uuidString
     }
 }

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/Info.plist
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/Info.plist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Using IDFA as a DeviceID</string>
+</dict>
 </plist>

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -5,6 +5,15 @@ public class Amplitude {
     var instanceName: String
     var _inForeground = false
     internal var _sessionId: Int64 = -1
+    /**
+     Sets a block to be called when location (latitude, longitude) information can be passed into an event.
+
+     let locationInfo = LocationInfo(lat: 37.7, lng: 122.4)
+     Amplitude.testInstance.locationInfoBlock = {
+         return locationInfo
+     }
+     */
+    public var locationInfoBlock : LocationInfoBlock? = nil
 
     lazy var storage: any Storage = {
         return self.configuration.storageProvider

--- a/Sources/Amplitude/Events/EventOptions.swift
+++ b/Sources/Amplitude/Events/EventOptions.swift
@@ -8,43 +8,43 @@
 import Foundation
 
 public class EventOptions {
-    var userId: String?
-    var deviceId: String?
-    var timestamp: Int64?
-    var eventId: Int64?
-    var sessionId: Int64? = -1
-    var insertId: String?
-    var locationLat: Double?
-    var locationLng: Double?
-    var appVersion: String?
-    var versionName: String?
-    var platform: String?
-    var osName: String?
-    var osVersion: String?
-    var deviceBrand: String?
-    var deviceManufacturer: String?
-    var deviceModel: String?
-    var carrier: String?
-    var country: String?
-    var region: String?
-    var city: String?
-    var dma: String?
-    var idfa: String?
-    var idfv: String?
-    var adid: String?
-    var language: String?
-    var library: String?
-    var ip: String?
-    var plan: Plan?
-    var ingestionMetadata: IngestionMetadata?
-    var revenue: Double?
-    var price: Double?
-    var quantity: Int?
-    var productId: String?
-    var revenueType: String?
-    var extra: [String: Any]?
-    var callback: EventCallback?
-    var partnerId: String?
+    public var userId: String?
+    public var deviceId: String?
+    public var timestamp: Int64?
+    public var eventId: Int64?
+    public var sessionId: Int64? = -1
+    public var insertId: String?
+    public var locationLat: Double?
+    public var locationLng: Double?
+    public var appVersion: String?
+    public var versionName: String?
+    public var platform: String?
+    public var osName: String?
+    public var osVersion: String?
+    public var deviceBrand: String?
+    public var deviceManufacturer: String?
+    public var deviceModel: String?
+    public var carrier: String?
+    public var country: String?
+    public var region: String?
+    public var city: String?
+    public var dma: String?
+    public var idfa: String?
+    public var idfv: String?
+    public var adid: String?
+    public var language: String?
+    public var library: String?
+    public var ip: String?
+    public var plan: Plan?
+    public var ingestionMetadata: IngestionMetadata?
+    public var revenue: Double?
+    public var price: Double?
+    public var quantity: Int?
+    public var productId: String?
+    public var revenueType: String?
+    public var extra: [String: Any]?
+    public var callback: EventCallback?
+    public var partnerId: String?
     internal var attempts: Int
 
     init(

--- a/Sources/Amplitude/Plugins/ContextPlugin.swift
+++ b/Sources/Amplitude/Plugins/ContextPlugin.swift
@@ -50,7 +50,7 @@ class ContextPlugin: Plugin {
         let device = self.device
         staticContext["device_manufacturer"] = device.manufacturer
         staticContext["device_model"] = device.model
-        staticContext["vendorID"] = device.identifierForVendor
+        staticContext["idfv"] = device.identifierForVendor
         staticContext["os_name"] = device.os_name
         staticContext["os_version"] = device.os_version
         staticContext["platform"] = device.platform
@@ -135,12 +135,15 @@ class ContextPlugin: Plugin {
         if trackingOptions?.shouldTrackCountry() ?? false && event.ip != "$remote" {
             event.country = context["country"] as? String
         }
+        if trackingOptions?.shouldTrackIDFV() ?? false {
+            event.idfv = context["idfv"] as? String
+        }
         // TODO: get lat and lng from locationInfoBlock
-        /*if (trackingOptions?.shouldTrackLatLng() ?? false) && (self.amplitude.locationInfoBlock != nil)  {
-            let location = self.amplitude.locationInfoBlock();
-            event.locationLat = location.lat
-            event.locationLng = location.lng
-        }*/
+        if (trackingOptions?.shouldTrackLatLng() ?? false) && (self.amplitude?.locationInfoBlock != nil)  {
+            let location = self.amplitude?.locationInfoBlock!()
+            event.locationLat = location?.lat
+            event.locationLng = location?.lng
+        }
         if trackingOptions?.shouldTrackLanguage() ?? false {
             event.language = context["language"] as? String
         }

--- a/Sources/Amplitude/TrackingOptions.swift
+++ b/Sources/Amplitude/TrackingOptions.swift
@@ -21,146 +21,146 @@ public class TrackingOptions {
 
     var disabledFields: Set<String> = []
 
-    func shouldTrackVersionName() -> Bool {
+    public func shouldTrackVersionName() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_VERSION_NAME)
     }
 
-    func disableTrackVersionName() -> TrackingOptions {
+    public func disableTrackVersionName() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_VERSION_NAME)
         return self
     }
 
-    func shouldTrackOsName() -> Bool {
+    public func shouldTrackOsName() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_OS_NAME)
     }
 
-    func disableTrackOsName() -> TrackingOptions {
+    public func disableTrackOsName() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_OS_NAME)
         return self
     }
 
-    func shouldTrackOsVersion() -> Bool {
+    public func shouldTrackOsVersion() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_OS_VERSION)
     }
 
-    func disableTrackOsVersion() -> TrackingOptions {
+    public func disableTrackOsVersion() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_OS_VERSION)
         return self
     }
 
-    func shouldTrackDeviceManufacturer() -> Bool {
+    public func shouldTrackDeviceManufacturer() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_DEVICE_MANUFACTURER)
     }
 
-    func disableTrackDeviceManufacturer() -> TrackingOptions {
+    public func disableTrackDeviceManufacturer() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_DEVICE_MANUFACTURER)
         return self
     }
 
-    func shouldTrackDeviceModel() -> Bool {
+    public func shouldTrackDeviceModel() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_DEVICE_MODEL)
     }
 
-    func disableTrackDeviceModel() -> TrackingOptions {
+    public func disableTrackDeviceModel() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_DEVICE_MODEL)
         return self
     }
 
-    func shouldTrackCarrier() -> Bool {
+    public func shouldTrackCarrier() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_CARRIER)
     }
 
-    func disableCarrier() -> TrackingOptions {
+    public func disableCarrier() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_CARRIER)
         return self
     }
 
-    func shouldTrackIpAddress() -> Bool {
+    public func shouldTrackIpAddress() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_IP_ADDRESS)
     }
 
-    func disableTrackIpAddress() -> TrackingOptions {
+    public func disableTrackIpAddress() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_IP_ADDRESS)
         return self
     }
 
-    func shouldTrackCountry() -> Bool {
+    public func shouldTrackCountry() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_COUNTRY)
     }
 
-    func disableTrackCountry() -> TrackingOptions {
+    public func disableTrackCountry() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_COUNTRY)
         return self
     }
 
-    func shouldTrackCity() -> Bool {
+    public func shouldTrackCity() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_CITY)
     }
 
-    func disableTrackCity() -> TrackingOptions {
+    public func disableTrackCity() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_CITY)
         return self
     }
 
-    func shouldTrackDMA() -> Bool {
+    public func shouldTrackDMA() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_DMA)
     }
 
-    func disableTrackDMA() -> TrackingOptions {
+    public func disableTrackDMA() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_DMA)
         return self
     }
 
-    func shouldTrackIDFA() -> Bool {
+    public func shouldTrackIDFA() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_IDFA)
     }
 
-    func disableTrackIDFA() -> TrackingOptions {
+    public func disableTrackIDFA() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_IDFA)
         return self
     }
 
-    func shouldTrackIDFV() -> Bool {
+    public func shouldTrackIDFV() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_IDFV)
     }
 
-    func disableTrackIDFV() -> TrackingOptions {
+    public func disableTrackIDFV() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_IDFV)
         return self
     }
 
-    func shouldTrackLanguage() -> Bool {
+    public func shouldTrackLanguage() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_LANGUAGE)
     }
 
-    func disableTrackLanguage() -> TrackingOptions {
+    public func disableTrackLanguage() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_LANGUAGE)
         return self
     }
 
-    func shouldTrackRegion() -> Bool {
+    public func shouldTrackRegion() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_REGION)
     }
 
-    func disableTrackRegion() -> TrackingOptions {
+    public func disableTrackRegion() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_REGION)
         return self
     }
 
-    func shouldTrackPlatform() -> Bool {
+    public func shouldTrackPlatform() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_PLATFORM)
     }
 
-    func disableTrackPlatform() -> TrackingOptions {
+    public func disableTrackPlatform() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_PLATFORM)
         return self
     }
 
-    func shouldTrackLatLng() -> Bool {
+    public func shouldTrackLatLng() -> Bool {
         return shouldTrackField(field: Constants.AMP_TRACKING_OPTION_LAT_LNG)
     }
 
-    func disableTrackLatLng() -> TrackingOptions {
+    public func disableTrackLatLng() -> TrackingOptions {
         disabledFields.insert(Constants.AMP_TRACKING_OPTION_LAT_LNG)
         return self
     }

--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -21,6 +21,18 @@ public struct IngestionMetadata: Codable {
 
 public typealias EventCallback = (BaseEvent, Int, String) -> Void
 
+public struct LocationInfo {
+    public var lat: Double
+    public var lng: Double
+    public init(lat: Double, lng: Double) {
+        self.lat = lat
+        self.lng = lng
+    }
+}
+
+public typealias LocationInfoBlock = () -> LocationInfo
+
+
 // Swift 5.7 supports any existential type.
 // The type of EventBlock has to be determined pre-runtime.
 // It cannot be dynamically associated with this protocol.

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -19,6 +19,12 @@ final class AmplitudeTests: XCTestCase {
 
     func testContext() {
         let amplitude = Amplitude(configuration: configuration)
+
+        let locationInfo = LocationInfo(lat: 123, lng: 123)
+        amplitude.locationInfoBlock = {
+            return locationInfo
+        }
+
         let outputReader = OutputReaderPlugin()
         amplitude.add(plugin: outputReader)
         amplitude.track(event: BaseEvent(eventType: "testEvent"))
@@ -28,9 +34,12 @@ final class AmplitudeTests: XCTestCase {
         XCTAssertEqual(lastEvent?.deviceManufacturer, "Apple")
         XCTAssertEqual(lastEvent?.deviceModel!.isEmpty, false)
         XCTAssertEqual(lastEvent?.ip, "$remote")
+        XCTAssertEqual(lastEvent?.idfv!.isEmpty, false)
         XCTAssertNil(lastEvent?.country)
         XCTAssertEqual(lastEvent?.platform!.isEmpty, false)
         XCTAssertEqual(lastEvent?.language!.isEmpty, false)
+        XCTAssertNotNil(lastEvent?.locationLat)
+        XCTAssertNotNil(lastEvent?.locationLng)
     }
 
     func testNewSessionStartEvent() {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
No.1 IDFA example
The value of idfa when using simulator is `00000000-0000-0000-0000-000000000000`.
1. in our backend, the idfa value will be always null. For privacy reasons, Amplitude processes the attribution information, but strips the values before saving the event in the system. We saved some hashed values into attribution_id instead.
2. idfa = `00000000-0000-0000-0000-000000000000` marked as invalid, so we need to manually replace this value with a valid one in order to test.
During the test, I test using breakpoint to check we do replace the event.idfa with the right value. The event stream also includes the attribution_id. 
<img width="1201" alt="Screen Shot 2022-12-09 at 12 52 42 PM" src="https://user-images.githubusercontent.com/13028329/206794205-930334db-21fa-474c-b55e-89dbc4cc513f.png">

<img width="1074" alt="Screen Shot 2022-12-09 at 12 43 08 PM" src="https://user-images.githubusercontent.com/13028329/206794106-f6426fa9-89f7-4430-af71-4bad55559fec.png">

No.2 idfv tracking option fix

No.3 locationInfoBlock tracking option implementation
 
<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
