### PR TITLE
feat: add podspec and release flow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
         run: |
           sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Lint
-        run: swiftlint
+        run: swiftlint --strict # force to fix warnings too

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Set Xcode 14
         run: |
-          sudo xcode-select -switch /Applications/Xcode_12.4.app
+          sudo xcode-select -switch /Applications/Xcode_14.1.app
       - name: Carthage Bootstrap
         run: carthage bootstrap --use-xcframeworks
       - name: iOS Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Do a dry run to preview instead of a real release"
+        required: true
+        default: "true"
+
+jobs:
+  authorize:
+    name: Authorize
+    runs-on: macos-latest
+    steps:
+      - name: ${{ github.actor }} permission check to do a release
+        uses: octokit/request-action@v2.0.0
+        with:
+          route: GET /repos/:repository/collaborators/${{ github.actor }}
+          repository: ${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Release
+    runs-on: macos-latest
+    needs: [authorize]
+    env:
+      SWIFT_DOC_VERSION: '1.0.0-rc.1'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set Xcode 14
+        run: |
+          sudo xcode-select -switch /Applications/Xcode_12.4.app
+      - name: Carthage Bootstrap
+        run: carthage bootstrap --use-xcframeworks
+      - name: iOS Tests
+        run: |
+          xcodebuild test \
+            -scheme Amplitude-Swift \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 14'
+      - name: macOS Tests
+        run: |
+          xcodebuild test \
+            -scheme Amplitude-Swift \
+            -sdk macosx \
+            -destination 'platform=macosx'
+      - name: tvOS Tests
+        run: |
+          xcodebuild \
+            -scheme Amplitude-Swift \
+            -sdk appletvsimulator \
+            -destination 'platform=tvOS Simulator,name=Apple TV' \
+            test
+      - name: watchOS Tests
+        run: |
+          xcodebuild \
+            -scheme Amplitude-Swift \
+            -sdk watchsimulator \
+            -destination 'platform=watchOS Simulator,name=Apple Watch Series 8 (41mm)' \
+            test
+      - name: Validate Podfile
+        run: pod lib lint --allow-warnings
+      - name: Cache Swift Doc
+        id: cache-swift-doc
+        uses: actions/cache@v2
+        with:
+          path: /usr/local/bin/swift-doc
+          key: ${{ runner.os }}-swift-doc-${{ env.SWIFT_DOC_VERSION }}
+
+      # Swift Doc requires graphviz as a dependency.
+      # TODO Look into either caching graphviz or using a separate linux job
+      #      in order to use the pre-built SwiftDoc github action.
+      - name: Install Graphviz
+        run: brew install graphviz
+
+      - name: Install Swift Doc
+        if: steps.cache-swift-doc.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/SwiftDocOrg/swift-doc
+          cd swift-doc
+          git checkout ${{ env.SWIFT_DOC_VERSION }}
+          make install
+          cd ..
+          rm -rf swift-doc
+
+      - name: Generate Swift Doc
+        run: swift doc generate Sources/Amplitude/ --module-name Amplitude --output docs --format html --base-url /${{ github.event.repository.name }}
+
+      - name: Semantic Release --dry-run
+        if: ${{ github.event.inputs.dryRun == 'true'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          GIT_AUTHOR_NAME: amplitude-sdk-bot
+          GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+          GIT_COMMITTER_NAME: amplitude-sdk-bot
+          GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+        run: |
+          npx \
+          -p lodash \
+          -p semantic-release@17 \
+          -p @semantic-release/changelog@5 \
+          -p @semantic-release/git@9 \
+          -p @google/semantic-release-replace-plugin@1 \
+          -p @semantic-release/exec@5 \
+          semantic-release --dry-run
+
+      - name: Semantic Release
+        if: ${{ github.event.inputs.dryRun == 'false'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+          GIT_AUTHOR_NAME: amplitude-sdk-bot
+          GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+          GIT_COMMITTER_NAME: amplitude-sdk-bot
+          GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+        run: |
+          npx \
+          -p lodash \
+          -p semantic-release@17 \
+          -p @semantic-release/changelog@5 \
+          -p @semantic-release/git@9 \
+          -p @google/semantic-release-replace-plugin@1 \
+          -p @semantic-release/exec@5 \
+          semantic-release

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,10 +6,10 @@ disabled_rules:
   - trailing_comma
   - opening_brace
   - todo
+  - cyclomatic_complexity
 identifier_name:
   allowed_symbols: "_"
   min_length: 1
-cyclomatic_complexity: 25
 nesting:
   type_level:
     warning: 3

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -1,0 +1,31 @@
+amplitude_version = "0.0.0" # Version is managed automatically by semantic-release, please don't change it manually
+
+Pod::Spec.new do |s|
+  s.name                   = "AmplitudeSwift"
+  s.version                = amplitude_version
+  s.summary                = "Amplitude Analytics SDK"
+  s.homepage               = "https://amplitude.com"
+  s.license                = { :type => "MIT" }
+  s.author                 = { "Amplitude" => "dev@amplitude.com" }
+  s.source                 = { :git => "https://github.com/amplitude/Amplitude-Swift.git", :tag => "v#{s.version}" }
+
+  s.swift_version = '5.7'
+
+  s.ios.deployment_target  = '13.0'
+  s.ios.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
+  s.ios.resources          = 'Sources/Resources/*.{der}'
+
+  s.tvos.deployment_target = '13.0'
+  s.tvos.source_files      = 'Sources/Amplitude/**/*.{h,swift}'
+  s.tvos.resources         = 'Sources/Resources/*.{der}'
+
+  s.osx.deployment_target  = '10.15'
+  s.osx.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
+  s.osx.resources          = 'Sources/Resources/*.{der}'
+
+  s.watchos.deployment_target  = '7.0'
+  s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
+  s.watchos.resources          = 'Sources/Resources/*.{der}'
+
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+end

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -13,19 +13,15 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target  = '13.0'
   s.ios.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
-  s.ios.resources          = 'Sources/Resources/*.{der}'
 
   s.tvos.deployment_target = '13.0'
   s.tvos.source_files      = 'Sources/Amplitude/**/*.{h,swift}'
-  s.tvos.resources         = 'Sources/Resources/*.{der}'
 
   s.osx.deployment_target  = '10.15'
   s.osx.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
-  s.osx.resources          = 'Sources/Resources/*.{der}'
 
   s.watchos.deployment_target  = '7.0'
   s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
-  s.watchos.resources          = 'Sources/Resources/*.{der}'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Amplitude-Swift
 
-This is Amplitude's latest version of the Swift SDK.
+This is Amplitude's latest version of the iOS SDK.
 
 ## Need Help?
 If you have any issues using our SDK, feel free to [create a GitHub issue](https://github.com/amplitude/Amplitude-Swift/issues/new) or submit a request on [Amplitude Help](https://help.amplitude.com/hc/en-us/requests/new).

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -17,7 +17,7 @@ public class Amplitude {
          return locationInfo
      }
      */
-    public var locationInfoBlock : LocationInfoBlock? = nil
+    public var locationInfoBlock: LocationInfoBlock?
 
     lazy var storage: any Storage = {
         return self.configuration.storageProvider

--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -32,7 +32,6 @@ public struct LocationInfo {
 
 public typealias LocationInfoBlock = () -> LocationInfo
 
-
 // Swift 5.7 supports any existential type.
 // The type of EventBlock has to be determined pre-runtime.
 // It cannot be dynamically associated with this protocol.


### PR DESCRIPTION
### Summary

- feat: add podspec and release flow

CocoaPods is working locally:
```
# Podfile
platform :ios, '16.0'
target 'cocoapod-test-app' do
  pod 'AmplitudeSwift', :path => '/Users/marvin/src/amp/Amplitude-Swift'
end
```
<img width="991" alt="image" src="https://user-images.githubusercontent.com/8689754/207201529-3fad9c20-2f50-495b-9beb-9d89206c35e3.png">
<img width="1427" alt="image" src="https://user-images.githubusercontent.com/8689754/207201602-802124b2-d4f1-4bb9-9a55-e720ffc8ef5c.png">

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
