### PR TITLE
build: fix macos version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   authorize:
     name: Authorize
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: ${{ github.actor }} permission check to do a release
         uses: octokit/request-action@v2.0.0
@@ -23,7 +23,7 @@ jobs:
 
   release:
     name: Release
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: [authorize]
     env:
       SWIFT_DOC_VERSION: '1.0.0-rc.1'


### PR DESCRIPTION
### Summary
- build: fix macos version in release workflow

`macos-latest` is macOS Big Sur 11: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
