### PR TITLE
build: remove carthage and doc generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,6 @@ jobs:
       - name: Set Xcode 14
         run: |
           sudo xcode-select -switch /Applications/Xcode_14.1.app
-      - name: Carthage Bootstrap
-        run: carthage bootstrap --use-xcframeworks
       - name: iOS Tests
         run: |
           xcodebuild test \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
     name: Release
     runs-on: macos-latest
     needs: [authorize]
-    env:
-      SWIFT_DOC_VERSION: '1.0.0-rc.1'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -59,33 +57,9 @@ jobs:
             -sdk watchsimulator \
             -destination 'platform=watchOS Simulator,name=Apple Watch Series 8 (41mm)' \
             test
+
       - name: Validate Podfile
         run: pod lib lint --allow-warnings
-      - name: Cache Swift Doc
-        id: cache-swift-doc
-        uses: actions/cache@v2
-        with:
-          path: /usr/local/bin/swift-doc
-          key: ${{ runner.os }}-swift-doc-${{ env.SWIFT_DOC_VERSION }}
-
-      # Swift Doc requires graphviz as a dependency.
-      # TODO Look into either caching graphviz or using a separate linux job
-      #      in order to use the pre-built SwiftDoc github action.
-      - name: Install Graphviz
-        run: brew install graphviz
-
-      - name: Install Swift Doc
-        if: steps.cache-swift-doc.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/SwiftDocOrg/swift-doc
-          cd swift-doc
-          git checkout ${{ env.SWIFT_DOC_VERSION }}
-          make install
-          cd ..
-          rm -rf swift-doc
-
-      - name: Generate Swift Doc
-        run: swift doc generate Sources/Amplitude/ --module-name Amplitude --output docs --format html --base-url /${{ github.event.repository.name }}
 
       - name: Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}


### PR DESCRIPTION
### Summary
- build: remove carthage and doc generation

We don't need to install dependency, so no need to have `Cartfile`, putting an empty `Cartfile` will get rid of the error though.

https://github.com/SwiftDocOrg/swift-doc is archived, I get rid of the doc generation now, it is not within current scope.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
