### PR TITLE
build: temp remove cocoapods watchos

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/Amplitude-Swift.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/Amplitude-Swift.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1410"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Amplitude-Swift"
+               BuildableName = "Amplitude-Swift"
+               BlueprintName = "Amplitude-Swift"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Amplitude-SwiftTests"
+               BuildableName = "Amplitude-SwiftTests"
+               BlueprintName = "Amplitude-SwiftTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Amplitude-SwiftTests"
+               BuildableName = "Amplitude-SwiftTests"
+               BlueprintName = "Amplitude-SwiftTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "Amplitude-Swift"
+            BuildableName = "Amplitude-Swift"
+            BlueprintName = "Amplitude-Swift"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -20,8 +20,10 @@ Pod::Spec.new do |s|
   s.osx.deployment_target  = '10.15'
   s.osx.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
 
-  s.watchos.deployment_target  = '7.0'
-  s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
+  # temporary disable watchos support due to: https://github.com/CocoaPods/CocoaPods/issues/11558
+  # unpaired watchos will cause failure, the fix of the above issue is merged but not released
+  # s.watchos.deployment_target  = '7.0'
+  # s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end


### PR DESCRIPTION
### Summary
- build: temp remove cocoapods watchos

1. Temporary disable watchos support due to: https://github.com/CocoaPods/CocoaPods/issues/11558. Unpaired watchos will cause failure, the fix of the above issue is merged but not released. I manually did https://github.com/CocoaPods/CocoaPods/issues/11558#issuecomment-1284573492 to fix my local `lint`. After the fix in Cocoapods is released, we can enable this back.
2. Add ".swiftpm/xcode/xcshareddata/xcschemes/Amplitude-Swift.xcscheme", the scheme is required by Carthage, but even after adding this and using a remote branch, I cannot make Carthage work. Probably related to: https://github.com/Carthage/Carthage/issues/2867. As this is also showing up in Xcode frequently, I just add it to git and commit it.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
