### PR TITLE
feat: update destination plugin to class

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -29,7 +29,7 @@ public class Amplitude {
         return timeline
     }()
 
-    lazy var logger: (any Logger)? = {
+    public lazy var logger: (any Logger)? = {
         return self.configuration.loggerProvider
     }()
 

--- a/Sources/Amplitude/Plugins/AmplitudeDestinationPlugin.swift
+++ b/Sources/Amplitude/Plugins/AmplitudeDestinationPlugin.swift
@@ -6,9 +6,6 @@
 //
 
 public class AmplitudeDestinationPlugin: DestinationPlugin {
-    public let timeline = Timeline()
-    public var amplitude: Amplitude?
-    public let type: PluginType = .destination
     private var pipeline: EventPipeline?
 
     internal func enqueue(event: BaseEvent?) {
@@ -21,31 +18,31 @@ public class AmplitudeDestinationPlugin: DestinationPlugin {
         }
     }
 
-    public func track(event: BaseEvent) -> BaseEvent? {
+    public override func track(event: BaseEvent) -> BaseEvent? {
         enqueue(event: event)
         return event
     }
 
-    public func identify(event: IdentifyEvent) -> IdentifyEvent? {
+    public override func identify(event: IdentifyEvent) -> IdentifyEvent? {
         enqueue(event: event)
         return event
     }
 
-    public func groupIdentify(event: GroupIdentifyEvent) -> GroupIdentifyEvent? {
+    public override func groupIdentify(event: GroupIdentifyEvent) -> GroupIdentifyEvent? {
         enqueue(event: event)
         return event
     }
 
-    public func revenue(event: RevenueEvent) -> RevenueEvent? {
+    public override func revenue(event: RevenueEvent) -> RevenueEvent? {
         enqueue(event: event)
         return event
     }
 
-    public func flush() {
+    public override func flush() {
         pipeline?.flush()
     }
 
-    public func setup(amplitude: Amplitude) {
+    public override func setup(amplitude: Amplitude) {
         self.amplitude = amplitude
         pipeline = EventPipeline(amplitude: amplitude)
         pipeline?.start()
@@ -53,7 +50,7 @@ public class AmplitudeDestinationPlugin: DestinationPlugin {
         add(plugin: IdentityEventSender())
     }
 
-    public func execute(event: BaseEvent?) -> BaseEvent? {
+    public override func execute(event: BaseEvent?) -> BaseEvent? {
         return event
     }
 }

--- a/Sources/Amplitude/Plugins/DestinationPlugin.swift
+++ b/Sources/Amplitude/Plugins/DestinationPlugin.swift
@@ -5,12 +5,43 @@
 //  Created by Hao Yu on 11/15/22.
 //
 
-public protocol DestinationPlugin: EventPlugin {
-    var timeline: Timeline { get }
+open class DestinationPlugin: EventPlugin {
+    public let type: PluginType = .destination
+    public var amplitude: Amplitude?
+    private var timeline = Timeline()
+
+    public init() {
+    }
+
+    open func track(event: BaseEvent) -> BaseEvent? {
+        return event
+    }
+
+    open func identify(event: IdentifyEvent) -> IdentifyEvent? {
+        return event
+    }
+
+    open func groupIdentify(event: GroupIdentifyEvent) -> GroupIdentifyEvent? {
+        return event
+    }
+
+    open func revenue(event: RevenueEvent) -> RevenueEvent? {
+        return event
+    }
+
+    open func flush() {
+    }
+
+    open func execute(event: BaseEvent?) -> BaseEvent? {
+        return event
+    }
+
+    open func setup(amplitude: Amplitude) {
+        self.amplitude = amplitude
+    }
 }
 
 extension DestinationPlugin {
-
     var enabled: Bool {
         return true
     }


### PR DESCRIPTION
### Summary
Current `DestinationPlugin` is a protocol, but it cannot hold the `timeline` property, so if user writes a new `DestinationPlugin`, needs to define a timeline as well, which shouldn't be needed.

To make it work, change `DestinationPlugin` to a class, and due to Swift's PWT (https://stackoverflow.com/a/44706021), we provide a common implementation for `setup` and `execute`, which can be override to call.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
