### PR TITLE
fix: remove serverUrl as default value for configuration

### DIFF
--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -46,7 +46,7 @@ public class Configuration {
         flushMaxRetries: Int = Constants.Configuration.FLUSH_MAX_RETRIES,
         useBatch: Bool = false,
         serverZone: ServerZone = ServerZone.US,
-        serverUrl: String = "",
+        serverUrl: String? = nil,
         plan: Plan? = nil,
         ingestionMetadata: IngestionMetadata? = nil,
         trackingOptions: TrackingOptions = TrackingOptions(),

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -46,7 +46,7 @@ public class Configuration {
         flushMaxRetries: Int = Constants.Configuration.FLUSH_MAX_RETRIES,
         useBatch: Bool = false,
         serverZone: ServerZone = ServerZone.US,
-        serverUrl: String = Constants.DEFAULT_API_HOST,
+        serverUrl: String = "",
         plan: Plan? = nil,
         ingestionMetadata: IngestionMetadata? = nil,
         trackingOptions: TrackingOptions = TrackingOptions(),


### PR DESCRIPTION
### Summary
I fixed a small issue related to the EU server zone.
The code below doesn't work, because u still use **DEFAULT_API_HOST**
`
let amplitude = Amplitude(
    Configuration(
        apiKey: "YOUR-API-KEY",
        serverZone: ServerZone.EU
    )
)
`

You could double-check **HttpClient.getUrl()**. It always uses **configuration.serverUrl** if it's not empty. So the default **serverUrl** value should be empty to solve this issue.

Currently, I'm using your lib for EU server zone. And made a workaround from my side:
`
let amplitude = Amplitude(
    Configuration(
        apiKey: "YOUR-API-KEY",
        serverZone: ServerZone.EU,
        serverUrl: ""
    )
)
`
