### PR TITLE
fix: expose plan and ingestion metadata

### DIFF
--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -8,15 +8,38 @@
 import Foundation
 
 public struct Plan: Codable {
-    var branch: String?
-    var source: String?
-    var version: String?
-    var versionId: String?
+    public var branch: String?
+    public var source: String?
+    public var version: String?
+    public var versionId: String?
+
+    public init(branch: String? = nil, source: String? = nil, version: String? = nil, versionId: String? = nil) {
+        self.branch = branch
+        self.source = source
+        self.version = version
+        self.versionId = versionId
+    }
 }
 
 public struct IngestionMetadata: Codable {
-    var sourceName: String?
-    var sourceVersion: String?
+    public var sourceName: String?
+    public var sourceVersion: String?
+
+    enum CodingKeys: String, CodingKey {
+        case sourceName = "source_name"
+        case sourceVersion = "source_version"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        sourceName = try values.decodeIfPresent(String.self, forKey: .sourceName)
+        sourceVersion = try values.decodeIfPresent(String.self, forKey: .sourceVersion)
+    }
+
+    public init(sourceName: String? = nil, sourceVersion: String? = nil) {
+        self.sourceName = sourceName
+        self.sourceVersion = sourceVersion
+    }
 }
 
 public typealias EventCallback = (BaseEvent, Int, String) -> Void

--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -13,6 +13,16 @@ import XCTest
 final class BaseEventTests: XCTestCase {
     func testToString() {
         let baseEvent = BaseEvent(
+            plan: Plan(
+                branch: "test-branch",
+                source: "test-source",
+                version: "test-version",
+                versionId: "test-version-id"
+            ),
+            ingestionMetadata: IngestionMetadata(
+                sourceName: "test-source-name",
+                sourceVersion: "test-source-version"
+            ),
             eventType: "test",
             eventProperties: [
                 "integer": 1,
@@ -39,6 +49,30 @@ final class BaseEventTests: XCTestCase {
         XCTAssertEqual(
             baseEventDict!["event_properties"]!["array" as NSString] as! Array,
             [1, 2, 3]
+        )
+        XCTAssertEqual(
+            baseEventDict!["plan"]!["branch" as NSString] as! String,
+            "test-branch"
+        )
+        XCTAssertEqual(
+            baseEventDict!["plan"]!["source" as NSString] as! String,
+            "test-source"
+        )
+        XCTAssertEqual(
+            baseEventDict!["plan"]!["version" as NSString] as! String,
+            "test-version"
+        )
+        XCTAssertEqual(
+            baseEventDict!["plan"]!["versionId" as NSString] as! String,
+            "test-version-id"
+        )
+        XCTAssertEqual(
+            baseEventDict!["ingestion_metadata"]!["source_name" as NSString] as! String,
+            "test-source-name"
+        )
+        XCTAssertEqual(
+            baseEventDict!["ingestion_metadata"]!["source_version" as NSString] as! String,
+            "test-source-version"
         )
     }
 
@@ -89,6 +123,16 @@ final class BaseEventTests: XCTestCase {
                     "integer": 1,
                     "string": "stringValue",
                     "array": [1, 2, 3]
+                },
+                "plan": {
+                    "branch": "test-branch",
+                    "source": "test-source",
+                    "version": "test-version",
+                    "versionId": "test-version-id",
+                },
+                "ingestion_metadata": {
+                    "source_name": "test-source-name",
+                    "source_version": "test-source-version"
                 }
             }
             """
@@ -109,6 +153,30 @@ final class BaseEventTests: XCTestCase {
         XCTAssertEqual(
             event?.eventProperties!["array"] as! [Double],
             [1, 2, 3]
+        )
+        XCTAssertEqual(
+            event?.plan?.branch,
+            "test-branch"
+        )
+        XCTAssertEqual(
+            event?.plan?.source,
+            "test-source"
+        )
+        XCTAssertEqual(
+            event?.plan?.version,
+            "test-version"
+        )
+        XCTAssertEqual(
+            event?.plan?.versionId,
+            "test-version-id"
+        )
+        XCTAssertEqual(
+            event?.ingestionMetadata?.sourceName,
+            "test-source-name"
+        )
+        XCTAssertEqual(
+            event?.ingestionMetadata?.sourceVersion,
+            "test-source-version"
         )
     }
 


### PR DESCRIPTION
### Summary
- fix: expose plan and ingestion metadata

Related to https://github.com/amplitude/Amplitude-Swift/issues/39

Tested with example app:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/8689754/220442124-753e5469-fd09-478b-8e5f-2ad6d4fd2753.png">
<img width="340" alt="image" src="https://user-images.githubusercontent.com/8689754/220442244-f74e74df-08fa-4cc7-906d-25d2e9639736.png">

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
