### PR TITLE
fix: fix platform value

### DIFF
--- a/Sources/Amplitude/Plugins/Vendors/AppUtil.swift
+++ b/Sources/Amplitude/Plugins/Vendors/AppUtil.swift
@@ -28,7 +28,7 @@ import Foundation
         }
 
         override var os_name: String {
-            return device.systemName
+            return device.systemName.lowercased()
         }
 
         override var os_version: String {
@@ -36,6 +36,16 @@ import Foundation
         }
 
         override var platform: String {
+            #if os(tvOS)
+                return "tvOS"
+            #elseif targetEnvironment(macCatalyst)
+                return "macOS"
+            #else
+                return "iOS"
+            #endif
+        }
+
+        private func getPlatformString() -> String {
             var name: [Int32] = [CTL_HW, HW_MACHINE]
             var size: Int = 2
             sysctl(&name, 2, nil, &size, nil, 0)
@@ -46,7 +56,7 @@ import Foundation
         }
 
         private func deviceModel() -> String {
-            let platform = self.platform
+            let platform = getPlatformString()
             return getDeviceModel(platform: platform)
         }
 
@@ -79,7 +89,7 @@ import Foundation
         }
 
         override var os_name: String {
-            return "macOS"
+            return "macos"
         }
 
         override var os_version: String {
@@ -96,6 +106,10 @@ import Foundation
         }
 
         override var platform: String {
+            return "macOS"
+        }
+
+        private func getPlatformString() -> String {
             var systemInfo = utsname()
             uname(&systemInfo)
             let machineMirror = Mirror(reflecting: systemInfo.machine)
@@ -107,7 +121,7 @@ import Foundation
         }
 
         private func deviceModel() -> String {
-            let platform = self.platform
+            let platform = getPlatformString()
             return getDeviceModel(platform: platform)
         }
 
@@ -174,7 +188,7 @@ import Foundation
         }
 
         override var os_name: String {
-            return device.systemName
+            return "watchos"
         }
 
         override var os_version: String {
@@ -182,6 +196,10 @@ import Foundation
         }
 
         override var platform: String {
+            return "watchOS"
+        }
+
+        private func getPlatformString() -> String {
             var name: [Int32] = [CTL_HW, HW_MACHINE]
             var size: Int = 2
             sysctl(&name, 2, nil, &size, nil, 0)
@@ -192,7 +210,7 @@ import Foundation
         }
 
         private func deviceModel() -> String {
-            let platform = self.platform
+            let platform = getPlatformString()
             return getDeviceModel(platform: platform)
         }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary
The platform should show `iOS`, `tvOS`, etc. But now it's showing `iPhone 9,1`.
This pr fixed this issue and also fix the os_name to be consistent with the previous value.

<!-- What does the PR do? -->

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
