### PR TITLE
fix: updated identify merging logic to ignore nil values

### DIFF
--- a/Sources/Amplitude/Utilities/IdentifyInterceptor.swift
+++ b/Sources/Amplitude/Utilities/IdentifyInterceptor.swift
@@ -211,7 +211,7 @@ public class IdentifyInterceptor {
 
     func mergeUserProperties(destination: [String: Any?]?, source: [String: Any?]?) -> [String: Any?] {
         var result = destination ?? [:]
-        result = result.merging(source ?? [:]) { _, new in new }
+        result = result.merging(source ?? [:]) { old, new in (new == nil || new is NSNull) ? old : new }
 
         return result
     }

--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -216,3 +216,4 @@ final class BaseEventTests: XCTestCase {
         )
     }
 }
+// swiftlint:enable force_cast

--- a/Tests/AmplitudeTests/Events/IdentifyTests.swift
+++ b/Tests/AmplitudeTests/Events/IdentifyTests.swift
@@ -85,3 +85,4 @@ final class IdentifyTests: XCTestCase {
         )
     }
 }
+// swiftlint:enable force_cast

--- a/Tests/AmplitudeTests/Events/RevenueTests.swift
+++ b/Tests/AmplitudeTests/Events/RevenueTests.swift
@@ -126,3 +126,4 @@ final class RevenueTests: XCTestCase {
         )
     }
 }
+// swiftlint:enable force_cast


### PR DESCRIPTION
### Summary

Updated identify merging logic to ignore nil values.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
