### PR TITLE
chore: update semantic-pr to supported version 22.04

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   pr-title-check:
     name: Check PR for semantic title
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: PR title is valid
         if: >

--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -216,3 +216,4 @@ final class BaseEventTests: XCTestCase {
         )
     }
 }
+// swiftlint:enable force_cast

--- a/Tests/AmplitudeTests/Events/IdentifyTests.swift
+++ b/Tests/AmplitudeTests/Events/IdentifyTests.swift
@@ -85,3 +85,4 @@ final class IdentifyTests: XCTestCase {
         )
     }
 }
+// swiftlint:enable force_cast

--- a/Tests/AmplitudeTests/Events/RevenueTests.swift
+++ b/Tests/AmplitudeTests/Events/RevenueTests.swift
@@ -126,3 +126,4 @@ final class RevenueTests: XCTestCase {
         )
     }
 }
+// swiftlint:enable force_cast


### PR DESCRIPTION
### Summary
* Ubuntu 18 is no longer supported in workflows, updated to 22.04 to fix Semantic PR check

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
