### PR TITLE
chore: do not use CTTelephonyNetworkInfo in simulator to hide annoying debug log messages with com.apple.commcenter.coretelephony.xpc mention

### DIFF
--- a/Sources/Amplitude/Plugins/ContextPlugin.swift
+++ b/Sources/Amplitude/Plugins/ContextPlugin.swift
@@ -67,7 +67,7 @@ class ContextPlugin: Plugin {
         }
 
         var carrier = "Unknown"
-        #if os(iOS)
+        #if os(iOS) && !targetEnvironment(simulator)
         let networkInfo = CTTelephonyNetworkInfo()
         if let providers = networkInfo.serviceSubscriberCellularProviders {
             for (_, provider) in providers where provider.mobileNetworkCode != nil {


### PR DESCRIPTION
See Jira comments.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
