### PR TITLE
fix: make 'mergeEventOptions' public

### DIFF
--- a/Sources/Amplitude/Events/BaseEvent.swift
+++ b/Sources/Amplitude/Events/BaseEvent.swift
@@ -147,7 +147,7 @@ public class BaseEvent: EventOptions, Codable {
         )
     }
 
-    func mergeEventOptions(eventOptions: EventOptions) {
+    public func mergeEventOptions(eventOptions: EventOptions) {
         userId = eventOptions.userId ?? userId
         deviceId = eventOptions.deviceId ?? deviceId
         timestamp = eventOptions.timestamp ?? timestamp


### PR DESCRIPTION
### Summary

Make `mergeEventOptions` public to use in Ampli codegen.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
