### PR TITLE
feat: add iOS background request keep-alive

### DIFF
--- a/Sources/Amplitude/Plugins/Vendors/AppUtil.swift
+++ b/Sources/Amplitude/Plugins/Vendors/AppUtil.swift
@@ -63,6 +63,13 @@ import Foundation
         override var requiredPlugin: Plugin {
             return IOSLifecycleMonitor()
         }
+      
+        override func beginBackgroundRequest() -> BackgroundRequestCompletionCallback? {
+          let id = UIApplication.shared.beginBackgroundTask(withName: "amplitude")
+          return { result in
+            UIApplication.shared.endBackgroundTask(id)
+          }
+        }
     }
 #endif
 

--- a/Sources/Amplitude/Plugins/Vendors/VendorSystem.swift
+++ b/Sources/Amplitude/Plugins/Vendors/VendorSystem.swift
@@ -5,6 +5,8 @@
 //  Created by Hao Yu on 11/11/22.
 //
 
+internal typealias BackgroundRequestCompletionCallback = (Result<Int, Error>) -> Void
+
 internal class VendorSystem {
     var manufacturer: String {
         return "unknown"
@@ -43,6 +45,10 @@ internal class VendorSystem {
     }()
 
     var requiredPlugin: Plugin? {
+        return nil
+    }
+  
+    func beginBackgroundRequest() -> BackgroundRequestCompletionCallback? {
         return nil
     }
 }


### PR DESCRIPTION
### Summary

When an iOS app is backgrounded, any network requests which aren't specifically marked as background tasks will fail to complete. With the current implementation, this means that up to 30 seconds of events will be delayed until the next time the app is opened, or lost completely.

iOS does include an affordance to extend the time after an app loses foreground focus in which it can perform additional tasks, but these tasks need to be marked explicitly with calls to `UIApplication.beginBackgroundTask` and `UIApplication.endBackgroundTask`.

Unfortunately, this can't be achieved with an event callback alone as a background task should ideally be limited to around 5s, with a maximum deadline of 30s. This deadline is frequently exceeded with an event callback as the duration between when an event is tracked and when it is finally flushed through the queue frequently exceeds 30s and results in warnings from the system.

The PR works around this issue by calling the system's `UIApplication.beginBackgroundTask` and `UIApplication.endBackgroundTask` methods as part of the EventPipeline mechanism, indicating to the system that it should keep the app alive until the point that all pending network requests have completed. It also includes some changes to the setup of `URLSession` to increase the chances of a successful network request being made, and to avoid background tasks running over deadline.

An alternative way to achieve this might be to include an additional callback in the options that gets fired just prior to dispatch, but on balance this seems a more pragmatic approach that doesn't require the addition of any public API.

### Checklist
* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
