### PR TITLE
fix: normalize package names for all package managers

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -783,7 +783,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
-				TARGET_NAME = "Amplitude-Swift";
+				TARGET_NAME = "AmplitudeSwift";
 				TVOS_DEPLOYMENT_TARGET = 13.0;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};
@@ -817,7 +817,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,4";
-				TARGET_NAME = "Amplitude-Swift";
+				TARGET_NAME = "AmplitudeSwift";
 				TVOS_DEPLOYMENT_TARGET = 13.0;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
 			};

--- a/Amplitude-Swift.xcodeproj/xcshareddata/xcschemes/Amplitude-Swift-Package.xcscheme
+++ b/Amplitude-Swift.xcodeproj/xcshareddata/xcschemes/Amplitude-Swift-Package.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "amplitude-swift::Amplitude-Swift"
-               BuildableName = "Amplitude_Swift.framework"
+               BuildableName = "AmplitudeSwift.framework"
                BlueprintName = "Amplitude-Swift"
                ReferencedContainer = "container:Amplitude-Swift.xcodeproj">
             </BuildableReference>

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "Amplitude-Swift",
-            targets: ["Amplitude-Swift"]
+            name: "AmplitudeSwift",
+            targets: ["AmplitudeSwift"]
         )
     ],
     dependencies: [
@@ -26,14 +26,14 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "Amplitude-Swift",
+            name: "AmplitudeSwift",
             dependencies: [],
             path: "Sources/Amplitude",
             exclude: ["../../Examples/", "../../Tests/"]
         ),
         .testTarget(
             name: "Amplitude-SwiftTests",
-            dependencies: ["Amplitude-Swift"],
+            dependencies: ["AmplitudeSwift"],
             path: "Tests/AmplitudeTests"
         ),
     ]

--- a/Tests/AmplitudeTests/AmplitudeSessionTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeSessionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class AmplitudeSessionTests: XCTestCase {
     private var configuration: Configuration!

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class AmplitudeTests: XCTestCase {
     private var configuration: Configuration!

--- a/Tests/AmplitudeTests/ConfigurationTests.swift
+++ b/Tests/AmplitudeTests/ConfigurationTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class ConfigurationTests: XCTestCase {
     let apiKey = "testApiKey"

--- a/Tests/AmplitudeTests/ConsoleLoggerTests.swift
+++ b/Tests/AmplitudeTests/ConsoleLoggerTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class ConsoleLoggerTests: XCTestCase {
     func testConsoleLoggerInit() {

--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 // swiftlint:disable force_cast
 final class BaseEventTests: XCTestCase {

--- a/Tests/AmplitudeTests/Events/GroupIdentifyEventTests.swift
+++ b/Tests/AmplitudeTests/Events/GroupIdentifyEventTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class GroupIdentifyEventTests: XCTestCase {
     func testInit() {

--- a/Tests/AmplitudeTests/Events/IdentifyEventTests.swift
+++ b/Tests/AmplitudeTests/Events/IdentifyEventTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class IdentifyEventTests: XCTestCase {
     func testInit() {

--- a/Tests/AmplitudeTests/Events/IdentifyTests.swift
+++ b/Tests/AmplitudeTests/Events/IdentifyTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 // swiftlint:disable force_cast
 final class IdentifyTests: XCTestCase {

--- a/Tests/AmplitudeTests/Events/RevenueEventTests.swift
+++ b/Tests/AmplitudeTests/Events/RevenueEventTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class RevenueEventTests: XCTestCase {
     func testInit() {

--- a/Tests/AmplitudeTests/Events/RevenueTests.swift
+++ b/Tests/AmplitudeTests/Events/RevenueTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 // swiftlint:disable force_cast
 final class RevenueTests: XCTestCase {

--- a/Tests/AmplitudeTests/Migration/LegacyDatabaseStorageTests.swift
+++ b/Tests/AmplitudeTests/Migration/LegacyDatabaseStorageTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class LegacyDatabaseStorageTests: XCTestCase {
     var storage: LegacyDatabaseStorage?

--- a/Tests/AmplitudeTests/Migration/RemnantDataMigrationTests.swift
+++ b/Tests/AmplitudeTests/Migration/RemnantDataMigrationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class RemnantDataMigrationTests: XCTestCase {
     var storage: LegacyDatabaseStorage?

--- a/Tests/AmplitudeTests/Migration/StoragePrefixMigrationTests.swift
+++ b/Tests/AmplitudeTests/Migration/StoragePrefixMigrationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class StoragePrefixMigrationTests: XCTestCase {
     func testUserDefaults() throws {

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class PersistentStorageTests: XCTestCase {
     func testIsBasicType() {

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 class TestEnrichmentPlugin: Plugin {
     let type: PluginType

--- a/Tests/AmplitudeTests/TimelineTests.swift
+++ b/Tests/AmplitudeTests/TimelineTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class TimelineTests: XCTestCase {
     private var timeline: Timeline!

--- a/Tests/AmplitudeTests/TypesTests.swift
+++ b/Tests/AmplitudeTests/TypesTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class TypesTests: XCTestCase {
     func testResponseHandler_collectIndices() {

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class EventPipelineTests: XCTestCase {
     private static let FLUSH_INTERVAL_SECONDS = 1.0

--- a/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
+++ b/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class HttpClientTests: XCTestCase {
     private var configuration: Configuration!

--- a/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
+++ b/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class IdentifyInterceptorTests: XCTestCase {
     private static let IDENTIFY_UPLOAD_INTERVAL_SECONDS = 1.5

--- a/Tests/AmplitudeTests/Utilities/PersistentStorageResponseHandlerTests.swift
+++ b/Tests/AmplitudeTests/Utilities/PersistentStorageResponseHandlerTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class PersistentStorageResponseHandlerTests: XCTestCase {
     private var configuration: Configuration!

--- a/Tests/AmplitudeTests/Utilities/QueueTimeTests.swift
+++ b/Tests/AmplitudeTests/Utilities/QueueTimeTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class QueueTimerTests: XCTestCase {
     func testRepeat() {

--- a/Tests/AmplitudeTests/Utilities/UrlExtensionTests.swift
+++ b/Tests/AmplitudeTests/Utilities/UrlExtensionTests.swift
@@ -7,7 +7,7 @@
 
 import XCTest
 
-@testable import Amplitude_Swift
+@testable import AmplitudeSwift
 
 final class UrlExtensionTests: XCTestCase {
     func testAppendFileNameSuffix() {


### PR DESCRIPTION
### Summary

Normalize package names for all package managers CocoaPods, Swift Package Manager (SPM), Carthage - now `import AmplitudeSwift` should be used instead of `import Amplitude_Swift`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:   SPM and Carthage users need to update imports.
