### PR TITLE
fix: setGroup() should set event.userProperties

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -176,8 +176,10 @@ public class Amplitude {
         groupName: String,
         options: EventOptions? = nil
     ) -> Amplitude {
+        let identify = Identify().set(property: groupType, value: groupName)
         let event = IdentifyEvent()
         event.groups = [groupType: groupName]
+        event.userProperties = identify.properties
         track(event: event, options: options)
         return self
     }
@@ -188,8 +190,10 @@ public class Amplitude {
         groupName: [String],
         options: EventOptions? = nil
     ) -> Amplitude {
+        let identify = Identify().set(property: groupType, value: groupName)
         let event = IdentifyEvent()
         event.groups = [groupType: groupName]
+        event.userProperties = identify.properties
         track(event: event, options: options)
         return self
     }

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -188,7 +188,8 @@ final class AmplitudeTests: XCTestCase {
 
         let e2 = events[1]
         XCTAssertEqual(e2.eventType, "$identify")
-        XCTAssertNil(e2.userProperties)
+        XCTAssertNotNil(e2.userProperties)
+        XCTAssertTrue(getDictionary(e2.userProperties!).isEqual(to: ["$set": ["group-type": "group-name"]]))
         XCTAssertNotNil(e2.groups)
         XCTAssertTrue(getDictionary(e2.groups!).isEqual(to: ["group-type": "group-name"]))
 


### PR DESCRIPTION
### Summary

`seGroup()` should set `event.userProperties` similar to:
https://github.com/amplitude/Amplitude-iOS/blob/main/Sources/Amplitude/Amplitude.m#L1480
https://github.com/amplitude/Amplitude-Kotlin/blob/main/core/src/main/java/com/amplitude/core/Amplitude.kt#L311

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
