### PR TITLE
fix: move mergeEventOptions() function to EventOptions class

### DIFF
--- a/Sources/Amplitude/Events/BaseEvent.swift
+++ b/Sources/Amplitude/Events/BaseEvent.swift
@@ -147,46 +147,6 @@ public class BaseEvent: EventOptions, Codable {
         )
     }
 
-    public func mergeEventOptions(eventOptions: EventOptions) {
-        userId = eventOptions.userId ?? userId
-        deviceId = eventOptions.deviceId ?? deviceId
-        timestamp = eventOptions.timestamp ?? timestamp
-        eventId = eventOptions.eventId ?? eventId
-        sessionId = eventOptions.sessionId ?? sessionId
-        insertId = eventOptions.insertId ?? insertId
-        locationLat = eventOptions.locationLat ?? locationLat
-        locationLng = eventOptions.locationLng ?? locationLng
-        appVersion = eventOptions.appVersion ?? appVersion
-        versionName = eventOptions.versionName ?? versionName
-        platform = eventOptions.platform ?? platform
-        osName = eventOptions.osName ?? osName
-        osVersion = eventOptions.osVersion ?? osVersion
-        deviceBrand = eventOptions.deviceBrand ?? deviceBrand
-        deviceManufacturer = eventOptions.deviceManufacturer ?? deviceManufacturer
-        deviceModel = eventOptions.deviceModel ?? deviceModel
-        carrier = eventOptions.carrier ?? carrier
-        country = eventOptions.country ?? country
-        region = eventOptions.region ?? region
-        city = eventOptions.city ?? city
-        dma = eventOptions.dma ?? dma
-        idfa = eventOptions.idfa ?? idfa
-        idfv = eventOptions.idfv ?? idfv
-        adid = eventOptions.adid ?? adid
-        language = eventOptions.language ?? language
-        library = eventOptions.library ?? library
-        ip = eventOptions.ip ?? ip
-        plan = eventOptions.plan ?? plan
-        ingestionMetadata = eventOptions.ingestionMetadata ?? ingestionMetadata
-        revenue = eventOptions.revenue ?? revenue
-        price = eventOptions.price ?? price
-        quantity = eventOptions.quantity ?? quantity
-        productId = eventOptions.productId ?? productId
-        revenueType = eventOptions.revenueType ?? revenueType
-        extra = eventOptions.extra ?? extra
-        callback = eventOptions.callback ?? callback
-        partnerId = eventOptions.partnerId ?? partnerId
-    }
-
     func isValid() -> Bool {
         return userId != nil || deviceId != nil
     }

--- a/Sources/Amplitude/Events/EventOptions.swift
+++ b/Sources/Amplitude/Events/EventOptions.swift
@@ -126,4 +126,44 @@ public class EventOptions {
         self.partnerId = partnerId
         self.attempts = attempts
     }
+
+    public func mergeEventOptions(eventOptions: EventOptions) {
+        userId = eventOptions.userId ?? userId
+        deviceId = eventOptions.deviceId ?? deviceId
+        timestamp = eventOptions.timestamp ?? timestamp
+        eventId = eventOptions.eventId ?? eventId
+        sessionId = eventOptions.sessionId ?? sessionId
+        insertId = eventOptions.insertId ?? insertId
+        locationLat = eventOptions.locationLat ?? locationLat
+        locationLng = eventOptions.locationLng ?? locationLng
+        appVersion = eventOptions.appVersion ?? appVersion
+        versionName = eventOptions.versionName ?? versionName
+        platform = eventOptions.platform ?? platform
+        osName = eventOptions.osName ?? osName
+        osVersion = eventOptions.osVersion ?? osVersion
+        deviceBrand = eventOptions.deviceBrand ?? deviceBrand
+        deviceManufacturer = eventOptions.deviceManufacturer ?? deviceManufacturer
+        deviceModel = eventOptions.deviceModel ?? deviceModel
+        carrier = eventOptions.carrier ?? carrier
+        country = eventOptions.country ?? country
+        region = eventOptions.region ?? region
+        city = eventOptions.city ?? city
+        dma = eventOptions.dma ?? dma
+        idfa = eventOptions.idfa ?? idfa
+        idfv = eventOptions.idfv ?? idfv
+        adid = eventOptions.adid ?? adid
+        language = eventOptions.language ?? language
+        library = eventOptions.library ?? library
+        ip = eventOptions.ip ?? ip
+        plan = eventOptions.plan ?? plan
+        ingestionMetadata = eventOptions.ingestionMetadata ?? ingestionMetadata
+        revenue = eventOptions.revenue ?? revenue
+        price = eventOptions.price ?? price
+        quantity = eventOptions.quantity ?? quantity
+        productId = eventOptions.productId ?? productId
+        revenueType = eventOptions.revenueType ?? revenueType
+        extra = eventOptions.extra ?? extra
+        callback = eventOptions.callback ?? callback
+        partnerId = eventOptions.partnerId ?? partnerId
+    }
 }

--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -216,7 +216,7 @@ final class BaseEventTests: XCTestCase {
         )
     }
 
-    func testMergeEventOptions() {
+    func testMergeEventOptionsToEvent() {
         let event = BaseEvent(
             userId: "userId-event",
             deviceId: "deviceId-event",
@@ -240,6 +240,30 @@ final class BaseEventTests: XCTestCase {
         XCTAssertEqual(event.country, "country-options")
         XCTAssertEqual(event.city, "city-options")
         XCTAssertEqual(event.eventType, "eventType-event")
+    }
+
+    func testMergeEventOptionsToOptions() {
+        let options = EventOptions(
+            userId: "userId",
+            deviceId: "deviceId",
+            sessionId: 111,
+            city: "city"
+        )
+
+        let sourceOptions = EventOptions(
+            userId: "userId-options",
+            sessionId: -1,
+            country: "country-options",
+            city: "city-options"
+        )
+
+        options.mergeEventOptions(eventOptions: sourceOptions)
+
+        XCTAssertEqual(options.userId, "userId-options")
+        XCTAssertEqual(options.deviceId, "deviceId")
+        XCTAssertEqual(options.sessionId, -1)
+        XCTAssertEqual(options.country, "country-options")
+        XCTAssertEqual(options.city, "city-options")
     }
 }
 // swiftlint:enable force_cast


### PR DESCRIPTION
### Summary

Moves `mergeEventOptions()` function to `EventOptions` class.
https://github.com/amplitude/javascript/pull/31001#discussion_r1290810390

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
