### PR TITLE
fix: open 'DestinationPlugin.execute()' method

### DIFF
--- a/Sources/Amplitude/Plugins/DestinationPlugin.swift
+++ b/Sources/Amplitude/Plugins/DestinationPlugin.swift
@@ -28,7 +28,7 @@ open class DestinationPlugin: BasePlugin, EventPlugin {
     open func flush() {
     }
 
-    public override func execute(event: BaseEvent) -> BaseEvent? {
+    open override func execute(event: BaseEvent) -> BaseEvent? {
         // Skip this destination if it is disabled via settings
         if !enabled {
             return nil


### PR DESCRIPTION
### Summary

Opens `DestinationPlugin.execute()` method to allow overriding in external modules.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
