### PR TITLE
fix: mark uploads as background tasks to let them continue if the app enters the background

### DIFF
--- a/Sources/Amplitude/Plugins/Vendors/AppUtil.swift
+++ b/Sources/Amplitude/Plugins/Vendors/AppUtil.swift
@@ -63,6 +63,16 @@ import Foundation
         override var requiredPlugin: Plugin {
             return IOSLifecycleMonitor()
         }
+
+        override func beginBackgroundTask() -> BackgroundTaskCompletionCallback? {
+            var id: UIBackgroundTaskIdentifier = .invalid
+            let callback = { () in
+                UIApplication.shared.endBackgroundTask(id)
+                id = .invalid
+            }
+            id = UIApplication.shared.beginBackgroundTask(withName: "amplitude", expirationHandler: callback)
+            return callback
+        }
     }
 #endif
 

--- a/Sources/Amplitude/Plugins/Vendors/VendorSystem.swift
+++ b/Sources/Amplitude/Plugins/Vendors/VendorSystem.swift
@@ -5,6 +5,8 @@
 //  Created by Hao Yu on 11/11/22.
 //
 
+internal typealias BackgroundTaskCompletionCallback = () -> Void
+
 internal class VendorSystem {
     var manufacturer: String {
         return "unknown"
@@ -43,6 +45,10 @@ internal class VendorSystem {
     }()
 
     var requiredPlugin: Plugin? {
+        return nil
+    }
+
+    func beginBackgroundTask() -> BackgroundTaskCompletionCallback? {
         return nil
     }
 }

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -14,9 +14,10 @@ class HttpClient {
     init(configuration: Configuration) {
         self.configuration = configuration
 
-        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        let sessionConfiguration = URLSessionConfiguration.default
         sessionConfiguration.httpMaximumConnectionsPerHost = 2
-        self.session = URLSession(configuration: sessionConfiguration)
+        sessionConfiguration.urlCache = nil
+        self.session = URLSession(configuration: sessionConfiguration, delegate: nil, delegateQueue: nil)
     }
 
     func upload(events: String, completion: @escaping (_ result: Result<Int, Error>) -> Void) -> URLSessionDataTask? {

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -13,9 +13,10 @@ class HttpClient {
 
     init(configuration: Configuration) {
         self.configuration = configuration
-        // shared instance has limitations but think we are not affected
-        // https://developer.apple.com/documentation/foundation/urlsession/1409000-shared
-        self.session = URLSession.shared
+
+        let sessionConfiguration = URLSessionConfiguration.ephemeral
+        sessionConfiguration.httpMaximumConnectionsPerHost = 2
+        self.session = URLSession(configuration: sessionConfiguration)
     }
 
     func upload(events: String, completion: @escaping (_ result: Result<Int, Error>) -> Void) -> URLSessionDataTask? {

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class HttpClient {
     let configuration: Configuration
-    internal var session: URLSession
+    internal let session: URLSession
 
     init(configuration: Configuration) {
         self.configuration = configuration
@@ -20,6 +20,7 @@ class HttpClient {
 
     func upload(events: String, completion: @escaping (_ result: Result<Int, Error>) -> Void) -> URLSessionDataTask? {
         var sessionTask: URLSessionDataTask?
+        let backgroundTaskCompletion = VendorSystem.current.beginBackgroundTask()
         do {
             let request = try getRequest()
             let requestData = getRequestData(events: events)
@@ -35,10 +36,12 @@ class HttpClient {
                         completion(.failure(Exception.httpError(code: httpResponse.statusCode, data: data)))
                     }
                 }
+                backgroundTaskCompletion?()
             }
             sessionTask!.resume()
         } catch {
             completion(.failure(Exception.httpError(code: 500, data: nil)))
+            backgroundTaskCompletion?()
         }
         return sessionTask
     }


### PR DESCRIPTION
### Summary

Based on example https://github.com/amplitude/Amplitude-Swift/pull/68.
Test environment: Simulator, fake server.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
