### PR TITLE
feat: support integration with experiment ios

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -21,8 +21,10 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		8EDEC1073A308B12B5CCD975 /* AnalyticsConnectorPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDECD39BAA97DD4320C0AA5 /* AnalyticsConnectorPlugin.swift */; };
 		8EDEC14255F82E24CEE00B36 /* AmplitudeSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC0630C3B587334275D9B /* AmplitudeSessionTests.swift */; };
 		8EDEC2E0CC80DF79F5463ACC /* RemnantDataMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC6A9899998F823C278F7 /* RemnantDataMigrationTests.swift */; };
+		8EDEC3283B812D5D34DADF7B /* AnalyticsConnectorIdentityPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC48916EFEF6D5B3EEF9A /* AnalyticsConnectorIdentityPlugin.swift */; };
 		8EDEC4EE0DE1C89889F451B5 /* QueueTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC4F83BFAA664749FAEF0 /* QueueTimeTests.swift */; };
 		8EDEC8F8DD2CDCD6568512F8 /* RemnantDataMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC19F9FBC98A0D4E5A513 /* RemnantDataMigration.swift */; };
 		8EDEC972AEB33E4528F7FEEB /* StoragePrefixMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC9B98272069D70D08EA4 /* StoragePrefixMigrationTests.swift */; };
@@ -31,6 +33,7 @@
 		8EDECFCCF4219767F26210D6 /* Sessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC2B8B38E04CDB51F0E83 /* Sessions.swift */; };
 		BA0359CA2A51585D007C383B /* legacy_v3.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = BA0359C92A51585D007C383B /* legacy_v3.sqlite */; };
 		BA0639F62A4DD491000F1CEE /* LegacyDatabaseStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0639F52A4DD491000F1CEE /* LegacyDatabaseStorage.swift */; };
+		BA34B23C2AA0723A00F88097 /* AnalyticsConnector in Frameworks */ = {isa = PBXBuildFile; productRef = BA34B23B2AA0723A00F88097 /* AnalyticsConnector */; };
 		BA994B9A2A4F48DE00D0913F /* LegacyDatabaseStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA994B992A4F48DE00D0913F /* LegacyDatabaseStorageTests.swift */; };
 		BA994B9D2A4F4FCB00D0913F /* legacy_v4.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = BA994B9B2A4F4B7500D0913F /* legacy_v4.sqlite */; };
 		BA9BEA4B299FB43B00BC0F7C /* IdentifyInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9BEA4A299FB43B00BC0F7C /* IdentifyInterceptor.swift */; };
@@ -114,10 +117,12 @@
 		8EDEC19F9FBC98A0D4E5A513 /* RemnantDataMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemnantDataMigration.swift; sourceTree = "<group>"; };
 		8EDEC2B8B38E04CDB51F0E83 /* Sessions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sessions.swift; sourceTree = "<group>"; };
 		8EDEC448C42C8C0A464FAA15 /* BasePlugins.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BasePlugins.swift; sourceTree = "<group>"; };
+		8EDEC48916EFEF6D5B3EEF9A /* AnalyticsConnectorIdentityPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsConnectorIdentityPlugin.swift; sourceTree = "<group>"; };
 		8EDEC4F83BFAA664749FAEF0 /* QueueTimeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QueueTimeTests.swift; sourceTree = "<group>"; };
 		8EDEC6A9899998F823C278F7 /* RemnantDataMigrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemnantDataMigrationTests.swift; sourceTree = "<group>"; };
 		8EDEC9B98272069D70D08EA4 /* StoragePrefixMigrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoragePrefixMigrationTests.swift; sourceTree = "<group>"; };
 		8EDECC2335BCF4C2EC3A6206 /* StoragePrefixMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoragePrefixMigration.swift; sourceTree = "<group>"; };
+		8EDECD39BAA97DD4320C0AA5 /* AnalyticsConnectorPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsConnectorPlugin.swift; sourceTree = "<group>"; };
 		BA0359C92A51585D007C383B /* legacy_v3.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = legacy_v3.sqlite; sourceTree = "<group>"; };
 		BA0639F52A4DD491000F1CEE /* LegacyDatabaseStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyDatabaseStorage.swift; sourceTree = "<group>"; };
 		BA994B992A4F48DE00D0913F /* LegacyDatabaseStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyDatabaseStorageTests.swift; sourceTree = "<group>"; };
@@ -183,7 +188,7 @@
 		OBJ_81 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		OBJ_82 /* AmplitudeSwift.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = AmplitudeSwift.podspec; sourceTree = "<group>"; };
 		OBJ_9 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
-		"amplitude-swift::Amplitude-Swift::Product" /* Amplitude_Swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Amplitude_Swift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"amplitude-swift::Amplitude-Swift::Product" /* Amplitude_Swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = Amplitude_Swift.framework; path = AmplitudeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"amplitude-swift::Amplitude-SwiftTests::Product" /* Amplitude_SwiftTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; name = Amplitude_SwiftTests.xctest; path = "Amplitude-SwiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -192,6 +197,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				BA34B23C2AA0723A00F88097 /* AnalyticsConnector in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,6 +260,8 @@
 				OBJ_32 /* iOS */,
 				OBJ_34 /* watchOS */,
 				8EDEC448C42C8C0A464FAA15 /* BasePlugins.swift */,
+				8EDECD39BAA97DD4320C0AA5 /* AnalyticsConnectorPlugin.swift */,
+				8EDEC48916EFEF6D5B3EEF9A /* AnalyticsConnectorIdentityPlugin.swift */,
 			);
 			path = Plugins;
 			sourceTree = "<group>";
@@ -316,7 +324,7 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -329,7 +337,6 @@
 				OBJ_81 /* CONTRIBUTING.md */,
 				OBJ_82 /* AmplitudeSwift.podspec */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_53 /* Tests */ = {
@@ -441,6 +448,9 @@
 			dependencies = (
 			);
 			name = "Amplitude-Swift";
+			packageProductDependencies = (
+				BA34B23B2AA0723A00F88097 /* AnalyticsConnector */,
+			);
 			productName = Amplitude_Swift;
 			productReference = "amplitude-swift::Amplitude-Swift::Product" /* Amplitude_Swift.framework */;
 			productType = "com.apple.product-type.framework";
@@ -493,7 +503,10 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
+			packageReferences = (
+				BA34B23A2AA0723900F88097 /* XCRemoteSwiftPackageReference "analytics-connector-ios" */,
+			);
 			productRefGroup = OBJ_75 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -603,6 +616,8 @@
 				8EDECD602E181B3E2E85D4DF /* StoragePrefixMigration.swift in Sources */,
 				8EDEC8F8DD2CDCD6568512F8 /* RemnantDataMigration.swift in Sources */,
 				8EDEC977C03AA2676724F436 /* BasePlugins.swift in Sources */,
+				8EDEC1073A308B12B5CCD975 /* AnalyticsConnectorPlugin.swift in Sources */,
+				8EDEC3283B812D5D34DADF7B /* AnalyticsConnectorIdentityPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -666,7 +681,11 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -693,7 +712,11 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@loader_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -754,7 +777,8 @@
 				SUPPORTED_PLATFORMS = "$(AVAILABLE_PLATFORMS)";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) SWIFT_PACKAGE";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
@@ -772,7 +796,10 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -806,7 +833,10 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -876,6 +906,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BA34B23A2AA0723900F88097 /* XCRemoteSwiftPackageReference "analytics-connector-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/amplitude/analytics-connector-ios.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BA34B23B2AA0723A00F88097 /* AnalyticsConnector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BA34B23A2AA0723900F88097 /* XCRemoteSwiftPackageReference "analytics-connector-ios" */;
+			productName = AnalyticsConnector;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = OBJ_1 /* Project object */;
 }

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -25,5 +25,7 @@ Pod::Spec.new do |s|
   # s.watchos.deployment_target  = '7.0'
   # s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
 
+  s.dependency 'AnalyticsConnector', '~> 1.0.1'
+
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample.xcodeproj/project.pbxproj
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		58324F9A294BFB4000C71E2E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 58324F99294BFB4000C71E2E /* Preview Assets.xcassets */; };
 		58324F9F294BFB4000C71E2E /* iOSAppClip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = 58324F90294BFB4000C71E2E /* iOSAppClip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		58324FA5294BFF3700C71E2E /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 58324FA4294BFF3700C71E2E /* AmplitudeSwift */; };
+		BA34B23F2AA100F900F88097 /* Experiment in Frameworks */ = {isa = PBXBuildFile; productRef = BA34B23E2AA100F900F88097 /* Experiment */; };
 		BA541E9B2A8B587E0088D841 /* LocationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA541E9A2A8B587E0088D841 /* LocationPlugin.swift */; };
 /* End PBXBuildFile section */
 
@@ -113,6 +114,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				19C9CC2D2937F5D000C1E660 /* AmplitudeSwift in Frameworks */,
+				BA34B23F2AA100F900F88097 /* Experiment in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -264,6 +266,7 @@
 			name = AmplitudeSwiftUIExample;
 			packageProductDependencies = (
 				19C9CC2C2937F5D000C1E660 /* AmplitudeSwift */,
+				BA34B23E2AA100F900F88097 /* Experiment */,
 			);
 			productName = AmplitudeSwiftUIExample;
 			productReference = 19C9CC122937F5A400C1E660 /* AmplitudeSwiftUIExample.app */;
@@ -336,6 +339,9 @@
 				Base,
 			);
 			mainGroup = 19C9CC092937F5A400C1E660;
+			packageReferences = (
+				BA34B23D2AA100F900F88097 /* XCRemoteSwiftPackageReference "experiment-ios-client" */,
+			);
 			productRefGroup = 19C9CC132937F5A400C1E660 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -765,6 +771,17 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		BA34B23D2AA100F900F88097 /* XCRemoteSwiftPackageReference "experiment-ios-client" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/amplitude/experiment-ios-client";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.11.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		19C9CC2C2937F5D000C1E660 /* AmplitudeSwift */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -773,6 +790,11 @@
 		58324FA4294BFF3700C71E2E /* AmplitudeSwift */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AmplitudeSwift;
+		};
+		BA34B23E2AA100F900F88097 /* Experiment */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BA34B23D2AA100F900F88097 /* XCRemoteSwiftPackageReference "experiment-ios-client" */;
+			productName = Experiment;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
@@ -7,6 +7,7 @@
 
 import AmplitudeSwift
 import AppTrackingTransparency
+import Experiment
 import SwiftUI
 
 @main
@@ -19,6 +20,8 @@ struct AmplitudeSwiftUIExampleApp: App {
         Amplitude.testInstance.add(plugin: LocationPlugin())
         // add the trouble shooting plugin for debugging
         Amplitude.testInstance.add(plugin: TroubleShootingPlugin())
+
+        Amplitude.experimentClient.fetch(user: nil, completion: nil)
     }
 
     var body: some Scene {
@@ -77,5 +80,12 @@ extension Amplitude {
             flushEventsOnClose: true,
             minTimeBetweenSessionsMillis: 15000
         )
+    )
+
+    static var experimentClient = Experiment.initializeWithAmplitudeAnalytics(
+        apiKey: "TEST-EXPERIMENT-KEY",
+        config: ExperimentConfigBuilder()
+            .instanceName(testInstance.configuration.instanceName)
+            .build()
     )
 }

--- a/Package.swift
+++ b/Package.swift
@@ -19,15 +19,16 @@ let package = Package(
         )
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.0.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "AmplitudeSwift",
-            dependencies: [],
+            dependencies: [
+                .product(name: "AnalyticsConnector", package: "analytics-connector-ios")
+            ],
             path: "Sources/Amplitude",
             exclude: ["../../Examples/", "../../Tests/"]
         ),

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -40,6 +40,7 @@ public class Amplitude {
         self.contextPlugin = contextPlugin
 
         migrateApiKeyStorages()
+        migrateDefaultInstanceStorages()
 
         if configuration.migrateLegacyData {
             RemnantDataMigration(self).execute()
@@ -325,6 +326,23 @@ public class Amplitude {
         if let persistentIdentifyStorage = configuration.identifyStorageProvider as? PersistentStorage {
             let apiKeyIdentifyStorage = PersistentStorage(storagePrefix: "\(PersistentStorage.DEFAULT_STORAGE_PREFIX)-identify-\(configuration.apiKey)")
             StoragePrefixMigration(source: apiKeyIdentifyStorage, destination: persistentIdentifyStorage, logger: logger).execute()
+        }
+    }
+
+    private func migrateDefaultInstanceStorages() {
+        if configuration.instanceName != Constants.Configuration.DEFAULT_INSTANCE {
+            return
+        }
+
+        let legacyDefaultInstanceName = "default_instance"
+        if let persistentStorage = configuration.storageProvider as? PersistentStorage {
+            let legacyStorage = PersistentStorage(storagePrefix: "storage-\(legacyDefaultInstanceName)")
+            StoragePrefixMigration(source: legacyStorage, destination: persistentStorage, logger: logger).execute()
+        }
+
+        if let persistentIdentifyStorage = configuration.identifyStorageProvider as? PersistentStorage {
+            let legacyIdentifyStorage = PersistentStorage(storagePrefix: "identify-\(legacyDefaultInstanceName)")
+            StoragePrefixMigration(source: legacyIdentifyStorage, destination: persistentIdentifyStorage, logger: logger).execute()
         }
     }
 }

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -57,6 +57,8 @@ public class Amplitude {
             _ = add(plugin: requiredPlugin)
         }
         _ = add(plugin: contextPlugin)
+        _ = add(plugin: AnalyticsConnectorPlugin())
+        _ = add(plugin: AnalyticsConnectorIdentityPlugin())
         _ = add(plugin: AmplitudeDestinationPlugin())
     }
 
@@ -221,13 +223,21 @@ public class Amplitude {
     @discardableResult
     public func add(plugin: Plugin) -> Amplitude {
         plugin.setup(amplitude: self)
-        timeline.add(plugin: plugin)
+        if let _plugin = plugin as? ObservePlugin {
+            state.add(plugin: _plugin)
+        } else {
+            timeline.add(plugin: plugin)
+        }
         return self
     }
 
     @discardableResult
     public func remove(plugin: Plugin) -> Amplitude {
-        timeline.remove(plugin: plugin)
+        if let _plugin = plugin as? ObservePlugin {
+            state.remove(plugin: _plugin)
+        } else {
+            timeline.remove(plugin: plugin)
+        }
         return self
     }
 

--- a/Sources/Amplitude/Constants.swift
+++ b/Sources/Amplitude/Constants.swift
@@ -55,7 +55,7 @@ public struct Constants {
     public struct Configuration {
         public static let FLUSH_QUEUE_SIZE = 30
         public static let FLUSH_INTERVAL_MILLIS = 30 * 1000  // 30s
-        public static let DEFAULT_INSTANCE = "default_instance"
+        public static let DEFAULT_INSTANCE = "$default_instance"
         public static let FLUSH_MAX_RETRIES = 5
         public static let MIN_TIME_BETWEEN_SESSIONS_MILLIS = 300000
         public static let IDENTIFY_BATCH_INTERVAL_MILLIS = 30 * 1000  // 30s

--- a/Sources/Amplitude/Plugins/AnalyticsConnectorIdentityPlugin.swift
+++ b/Sources/Amplitude/Plugins/AnalyticsConnectorIdentityPlugin.swift
@@ -1,0 +1,23 @@
+import Foundation
+import AnalyticsConnector
+
+class AnalyticsConnectorIdentityPlugin: ObservePlugin {
+    private var connector: AnalyticsConnector?
+
+    override func setup(amplitude: Amplitude) {
+        super.setup(amplitude: amplitude)
+        connector = AnalyticsConnector.getInstance(amplitude.configuration.instanceName)
+        connector?.identityStore.editIdentity()
+            .setUserId(amplitude.getUserId())
+            .setDeviceId(amplitude.getDeviceId())
+            .commit()
+    }
+
+    override func onUserIdChanged(_ userId: String?) {
+        connector?.identityStore.editIdentity().setUserId(userId).commit()
+    }
+
+    override func onDeviceIdChanged(_ deviceId: String?) {
+        connector?.identityStore.editIdentity().setDeviceId(deviceId).commit()
+    }
+}

--- a/Sources/Amplitude/Plugins/AnalyticsConnectorPlugin.swift
+++ b/Sources/Amplitude/Plugins/AnalyticsConnectorPlugin.swift
@@ -1,0 +1,30 @@
+import Foundation
+import AnalyticsConnector
+
+class AnalyticsConnectorPlugin: BeforePlugin {
+    private static let EXPOSURE_EVENT = "$exposure"
+    private var connector: AnalyticsConnector?
+
+    override func setup(amplitude: Amplitude) {
+        super.setup(amplitude: amplitude)
+        connector = AnalyticsConnector.getInstance(amplitude.configuration.instanceName)
+        connector!.eventBridge.setEventReceiver { event in
+            amplitude.track(event: BaseEvent(
+                eventType: event.eventType,
+                eventProperties: event.eventProperties as? [String: Any],
+                userProperties: event.userProperties as? [String: Any]
+            ))
+        }
+    }
+
+    override func execute(event: BaseEvent) -> BaseEvent? {
+        guard let userProperties = event.userProperties else {
+            return event
+        }
+        if userProperties.count == 0 || event.eventType == AnalyticsConnectorPlugin.EXPOSURE_EVENT {
+            return event
+        }
+        connector?.identityStore.editIdentity().updateUserProperties(userProperties as NSDictionary).commit()
+        return event
+    }
+}

--- a/Sources/Amplitude/Plugins/BasePlugins.swift
+++ b/Sources/Amplitude/Plugins/BasePlugins.swift
@@ -29,4 +29,7 @@ open class UtilityPlugin: BasePlugin, Plugin {
 
 open class ObservePlugin: BasePlugin, Plugin {
     public let type: PluginType = .observe
+
+    open func onUserIdChanged(_ userId: String?) {}
+    open func onDeviceIdChanged(_ deviceId: String?) {}
 }

--- a/Sources/Amplitude/State.swift
+++ b/Sources/Amplitude/State.swift
@@ -8,6 +8,29 @@
 import Foundation
 
 class State {
-    var userId: String?
-    var deviceId: String?
+    var userId: String? {
+        didSet {
+            for plugin in plugins {
+                plugin.onUserIdChanged(userId)
+            }
+        }
+    }
+
+    var deviceId: String? {
+        didSet {
+            for plugin in plugins {
+                plugin.onDeviceIdChanged(deviceId)
+            }
+        }
+    }
+
+    private var plugins: [ObservePlugin] = []
+
+    func add(plugin: ObservePlugin) {
+        plugins.append(plugin)
+    }
+
+    func remove(plugin: ObservePlugin) {
+        plugins.removeAll(where: { $0 === plugin })
+    }
 }


### PR DESCRIPTION
### Summary

Support integration with experiment ios.
Based on [Amplitude-Kotlin](https://github.com/amplitude/Amplitude-Kotlin/pull/92/files#diff-6d55e2d5810c4d89bd2b78fdec680139ac4b867421ac08ccba98187023c52c6e) and Amplitude-iOS implementation.

Possible issue:
`DEFAULT_INSTANCE` name is `default_instance` in [Amplitude-Swift](https://github.com/amplitude/Amplitude-Swift/blob/main/Sources/Amplitude/Constants.swift#L58) and `$default_instance` in [experiment-ios-client](https://github.com/amplitude/experiment-ios-client/blob/main/Sources/Experiment/ExperimentConfig.swift#L82)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
