### PR TITLE
fix: Objective-C support for plugin flush()

### DIFF
--- a/Examples/AmplitudeObjCExample/AmplitudeObjCExample/AppDelegate.m
+++ b/Examples/AmplitudeObjCExample/AmplitudeObjCExample/AppDelegate.m
@@ -26,6 +26,15 @@
         return event;
     }]];
     
+    NSMutableArray<AMPBaseEvent*>* collectedEvents = [NSMutableArray array];
+    [amplitude add:[AMPPlugin initWithType:AMPPluginTypeDestination execute:^AMPBaseEvent* _Nullable(AMPBaseEvent* _Nonnull event) {
+        [collectedEvents addObject:event];
+        return nil;
+    } flush:^() {
+        NSLog(@"Plugin Flush: %lu events", (unsigned long)collectedEvents.count);
+        [collectedEvents removeAllObjects];
+    }]];
+    
     [amplitude setUserId:@"User-ObjC"];
     
     AMPIdentify* identify = [AMPIdentify new];

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/TroubleShootingPlugin.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/TroubleShootingPlugin.swift
@@ -15,7 +15,7 @@ class TroubleShootingPlugin: DestinationPlugin {
         let serverZone = amplitude.configuration.serverZone.rawValue;
         let serverUrl = amplitude.configuration.serverUrl ?? "null";
 
-        self.amplitude?.logger?.debug(message: "Current Configuration : {\"apiKey\": "+apiKey+", \"serverZone\": "+serverZone.rawValue+", \"serverUrl\": "+serverUrl+"}")
+        self.amplitude?.logger?.debug(message: "Current Configuration : {\"apiKey\": "+apiKey+", \"serverZone\": "+serverZone+", \"serverUrl\": "+serverUrl+"}")
     }
 
     open override func track(event: BaseEvent) -> BaseEvent? {

--- a/Sources/Amplitude/ObjC/ObjCPlugin.swift
+++ b/Sources/Amplitude/ObjC/ObjCPlugin.swift
@@ -5,6 +5,7 @@ public class ObjCPlugin: NSObject {
     internal let type: PluginType
     internal let setup: ((ObjCAmplitude) -> Void)?
     internal let execute: (ObjCBaseEvent) -> ObjCBaseEvent?
+    internal let flush: (() -> Void)?
 
     @objc(initWithType:setup:execute:)
     public static func initWithType(
@@ -23,6 +24,25 @@ public class ObjCPlugin: NSObject {
         ObjCPlugin(type: type, execute: execute)
     }
 
+    @objc(initWithType:setup:execute:flush:)
+    public static func initWithType(
+        type: PluginType,
+        setup: @escaping (ObjCAmplitude) -> Void,
+        execute: @escaping (ObjCBaseEvent) -> ObjCBaseEvent?,
+        flush: @escaping () -> Void
+    ) -> ObjCPlugin {
+        ObjCPlugin(type: type, setup: setup, execute: execute, flush: flush)
+    }
+
+    @objc(initWithType:execute:flush:)
+    public static func initWithType(
+        type: PluginType,
+        execute: @escaping (ObjCBaseEvent) -> ObjCBaseEvent?,
+        flush: @escaping () -> Void
+    ) -> ObjCPlugin {
+        ObjCPlugin(type: type, execute: execute, flush: flush)
+    }
+
     @objc(initWithType:setup:execute:)
     public init(
         type: PluginType,
@@ -32,6 +52,7 @@ public class ObjCPlugin: NSObject {
         self.type = type
         self.setup = setup
         self.execute = execute
+        self.flush = nil
     }
 
     @objc(initWithType:execute:)
@@ -39,10 +60,36 @@ public class ObjCPlugin: NSObject {
         self.type = type
         self.setup = nil
         self.execute = execute
+        self.flush = nil
+    }
+
+    @objc(initWithType:setup:execute:flush:)
+    public init(
+        type: PluginType,
+        setup: @escaping (ObjCAmplitude) -> Void,
+        execute: @escaping (ObjCBaseEvent) -> ObjCBaseEvent?,
+        flush: @escaping () -> Void
+    ) {
+        self.type = type
+        self.setup = setup
+        self.execute = execute
+        self.flush = flush
+    }
+
+    @objc(initWithType:execute:flush:)
+    public init(
+        type: PluginType,
+        execute: @escaping (ObjCBaseEvent) -> ObjCBaseEvent?,
+        flush: @escaping() -> Void)
+    {
+        self.type = type
+        self.setup = nil
+        self.execute = execute
+        self.flush = flush
     }
 }
 
-class ObjCPluginWrapper: Plugin {
+class ObjCPluginWrapper: Plugin, EventPlugin {
     weak var amplitude: ObjCAmplitude?
     let type: PluginType
     let wrapped: ObjCPlugin
@@ -60,5 +107,25 @@ class ObjCPluginWrapper: Plugin {
 
     func execute(event: BaseEvent) -> BaseEvent? {
         wrapped.execute(ObjCBaseEvent(event: event))?.event
+    }
+
+    func track(event: BaseEvent) -> BaseEvent? {
+        execute(event: event)
+    }
+
+    func identify(event: IdentifyEvent) -> IdentifyEvent? {
+        execute(event: event) as? IdentifyEvent
+    }
+
+    func groupIdentify(event: GroupIdentifyEvent) -> GroupIdentifyEvent? {
+        execute(event: event) as? GroupIdentifyEvent
+    }
+
+    func revenue(event: RevenueEvent) -> RevenueEvent? {
+        execute(event: event) as? RevenueEvent
+    }
+
+    func flush() {
+        wrapped.flush?()
     }
 }


### PR DESCRIPTION
### Summary

1. Adds `flush()` support for destination plugins in Objective-C.
2. Fixes example TroubleShootingPlugin.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
