### PR TITLE
fix: add Objective-C support to get property values

### DIFF
--- a/Examples/AmplitudeObjCExample/AmplitudeObjCExampleTests/AmplitudeObjCExampleTests.m
+++ b/Examples/AmplitudeObjCExample/AmplitudeObjCExampleTests/AmplitudeObjCExampleTests.m
@@ -245,6 +245,16 @@
     XCTAssertEqualObjects(@"Event-C", [collectedEvents objectAtIndex:2].eventType);
 }
 
+- (void)testEventProperties {
+    AMPBaseEvent* event = [AMPBaseEvent initWithEventType:@"Event-A" eventProperties:@{@"prop-1": @"123"}];
+    [event.eventProperties set:@"prop-2" value:@111];
+    XCTAssertEqualObjects(@"123", [event.eventProperties get:@"prop-1"]);
+    XCTAssertEqualObjects(@111, [event.eventProperties get:@"prop-2"]);
+    [event.eventProperties remove:@"prop-1"];
+    XCTAssertEqualObjects(nil, [event.eventProperties get:@"prop-1"]);
+    XCTAssertEqualObjects(@111, [event.eventProperties get:@"prop-2"]);
+}
+
 - (Amplitude *)getAmplitude:(NSString *)instancePrefix {
     NSString* instanceName = [NSString stringWithFormat:@"%@-%f", instancePrefix, [[NSDate date] timeIntervalSince1970]];
     AMPConfiguration* configuration = [AMPConfiguration initWithApiKey:@"API-KEY" instanceName:instanceName];

--- a/Sources/Amplitude/Events/BaseEvent.swift
+++ b/Sources/Amplitude/Events/BaseEvent.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class BaseEvent: EventOptions, Codable {
+open class BaseEvent: EventOptions, Codable {
     public var eventType: String
     public var eventProperties: [String: Any?]?
     public var userProperties: [String: Any?]?

--- a/Sources/Amplitude/Events/EventOptions.swift
+++ b/Sources/Amplitude/Events/EventOptions.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class EventOptions {
+open class EventOptions {
     public var userId: String?
     public var deviceId: String?
     public var timestamp: Int64?

--- a/Sources/Amplitude/Events/Identify.swift
+++ b/Sources/Amplitude/Events/Identify.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class Identify {
+open class Identify {
     static let UNSET_VALUE = "-"
 
     enum Operation: String {

--- a/Sources/Amplitude/ObjC/ObjCBaseEvent.swift
+++ b/Sources/Amplitude/ObjC/ObjCBaseEvent.swift
@@ -39,7 +39,10 @@ public class ObjCBaseEvent: ObjCEventOptions {
 
     @objc
     public var eventProperties: ObjCProperties {
-        ObjCProperties(setter: { (key, value) in
+        ObjCProperties(getter: { key in
+            guard let eventProperties = self.event.eventProperties else { return nil }
+            return eventProperties[key] ?? nil
+        }, setter: { (key, value) in
             if self.event.eventProperties == nil {
                 self.event.eventProperties = [:]
             }
@@ -51,7 +54,10 @@ public class ObjCBaseEvent: ObjCEventOptions {
 
     @objc
     public var userProperties: ObjCProperties {
-        ObjCProperties(setter: { (key, value) in
+        ObjCProperties(getter: { key in
+            guard let userProperties = self.event.userProperties else { return nil }
+            return userProperties[key] ?? nil
+        }, setter: { (key, value) in
             if self.event.userProperties == nil {
                 self.event.userProperties = [:]
             }
@@ -63,7 +69,10 @@ public class ObjCBaseEvent: ObjCEventOptions {
 
     @objc
     public var groups: ObjCProperties {
-        ObjCProperties(setter: { (key, value) in
+        ObjCProperties(getter: { key in
+            guard let groups = self.event.groups else { return nil }
+            return groups[key] ?? nil
+        }, setter: { (key, value) in
             if self.event.groups == nil {
                 self.event.groups = [:]
             }
@@ -75,7 +84,10 @@ public class ObjCBaseEvent: ObjCEventOptions {
 
     @objc
     public var groupProperties: ObjCProperties {
-        ObjCProperties(setter: { (key, value) in
+        ObjCProperties(getter: { key in
+            guard let groupProperties = self.event.groupProperties else { return nil }
+            return groupProperties[key] ?? nil
+        }, setter: { (key, value) in
             if self.event.groupProperties == nil {
                 self.event.groupProperties = [:]
             }

--- a/Sources/Amplitude/ObjC/ObjCEventOptions.swift
+++ b/Sources/Amplitude/ObjC/ObjCEventOptions.swift
@@ -354,7 +354,10 @@ public class ObjCEventOptions: NSObject {
 
     @objc
     public var extra: ObjCProperties {
-        ObjCProperties(setter: { (key, value) in
+        ObjCProperties(getter: { key in
+            guard let extra = self.options.extra else { return nil }
+            return extra[key]
+        }, setter: { (key, value) in
             if self.options.extra == nil {
                 self.options.extra = [:]
             }

--- a/Sources/Amplitude/ObjC/ObjCProperties.swift
+++ b/Sources/Amplitude/ObjC/ObjCProperties.swift
@@ -2,15 +2,23 @@ import Foundation
 
 @objc(AMPProperties)
 public class ObjCProperties: NSObject {
+    internal let getter: (String) -> Any?
     internal let setter: (String, Any) -> Void
     internal let remover: (String) -> Void
 
     internal init(
+        getter: @escaping (String) -> Any?,
         setter: @escaping (String, Any) -> Void,
         remover: @escaping (String) -> Void
     ) {
+        self.getter = getter
         self.setter = setter
         self.remover = remover
+    }
+
+    @objc(get:)
+    public func get(key: String) -> Any? {
+        getter(key)
     }
 
     @objc(set:value:)

--- a/Sources/Amplitude/ObjC/ObjCRevenue.swift
+++ b/Sources/Amplitude/ObjC/ObjCRevenue.swift
@@ -76,7 +76,10 @@ public class ObjCRevenue: NSObject {
 
     @objc
     public var properties: ObjCProperties {
-        ObjCProperties(setter: { (key, value) in
+        ObjCProperties(getter: { key in
+            guard let properties = self.instance.properties else { return nil }
+            return properties[key] ?? nil
+        }, setter: { (key, value) in
             if self.instance.properties == nil {
                 self.instance.properties = [:]
             }


### PR DESCRIPTION
### Summary

Adds support to get property values in Objective-C (required in unit tests).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
