### PR TITLE
fix: add support for CGFloat property values

### DIFF
--- a/Sources/Amplitude/Utilities/CodableExtension.swift
+++ b/Sources/Amplitude/Utilities/CodableExtension.swift
@@ -130,6 +130,8 @@ extension KeyedEncodingContainer {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? Float {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
+            } else if let val = item.value as? CGFloat {
+                try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? Bool {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? [Any] {

--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -29,7 +29,9 @@ final class BaseEventTests: XCTestCase {
                 "string": "stringValue",
                 "array": [1, 2, 3],
                 "int64": 1 as Int64,
-                "int32": 1 as Int32
+                "int32": 1 as Int32,
+                "cgfloat": 3.14 as CGFloat,
+                "double": 3.14 as Double
             ]
         )
 
@@ -51,6 +53,14 @@ final class BaseEventTests: XCTestCase {
         XCTAssertEqual(
             baseEventDict!["event_properties"]!["int64" as NSString] as! Int64,
             1
+        )
+        XCTAssertEqual(
+            baseEventDict!["event_properties"]!["cgfloat" as NSString] as! CGFloat,
+            3.14
+        )
+        XCTAssertEqual(
+            baseEventDict!["event_properties"]!["double" as NSString] as! Double,
+            3.14
         )
         XCTAssertEqual(
             baseEventDict!["event_properties"]!["string" as NSString] as! String,


### PR DESCRIPTION
### Summary

Add support for sending CGFloat values in event properties.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
