### PR TITLE
fix: prevent creation of multiple instances with the same instanceName

### DIFF
--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/LocationPlugin.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/LocationPlugin.swift
@@ -42,7 +42,7 @@ class LocationPlugin: NSObject, Plugin, CLLocationManagerDelegate {
     }
 
     func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        amplitude?.logger?.error(message: error.localizedDescription)
+        amplitude?.logger.error(message: error.localizedDescription)
         clearReferences()
     }
 

--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/TroubleShootingPlugin.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/TroubleShootingPlugin.swift
@@ -15,7 +15,7 @@ class TroubleShootingPlugin: DestinationPlugin {
         let serverZone = amplitude.configuration.serverZone.rawValue;
         let serverUrl = amplitude.configuration.serverUrl ?? "null";
 
-        self.amplitude?.logger?.debug(message: "Current Configuration : {\"apiKey\": "+apiKey+", \"serverZone\": "+serverZone+", \"serverUrl\": "+serverUrl+"}")
+        self.amplitude?.logger.debug(message: "Current Configuration : {\"apiKey\": "+apiKey+", \"serverZone\": "+serverZone+", \"serverUrl\": "+serverUrl+"}")
     }
 
     open override func track(event: BaseEvent) -> BaseEvent? {
@@ -23,7 +23,7 @@ class TroubleShootingPlugin: DestinationPlugin {
         let eventJsonData = try! jsonEncoder.encode(event)
         let eventJson = String(data: eventJsonData, encoding: String.Encoding.utf8)
 
-        self.amplitude?.logger?.debug(message: "Processed event: \(String(describing: eventJson))")
+        self.amplitude?.logger.debug(message: "Processed event: \(String(describing: eventJson))")
         return event
     }
 }

--- a/Sources/Amplitude/Migration/RemnantDataMigration.swift
+++ b/Sources/Amplitude/Migration/RemnantDataMigration.swift
@@ -113,7 +113,7 @@ class RemnantDataMigration {
             removeFromSource(rowId!)
             return rowId!
         } catch {
-            amplitude.logger?.error(message: "event migration failed: \(error)")
+            amplitude.logger.error(message: "event migration failed: \(error)")
             return -1
         }
     }

--- a/Sources/Amplitude/Sessions.swift
+++ b/Sources/Amplitude/Sessions.swift
@@ -11,7 +11,7 @@ public class Sessions {
             do {
                 try amplitude.storage.write(key: StorageKey.PREVIOUS_SESSION_ID, value: _sessionId)
             } catch {
-                amplitude.logger?.warn(message: "Can't write PREVIOUS_SESSION_ID to storage: \(error)")
+                amplitude.logger.warn(message: "Can't write PREVIOUS_SESSION_ID to storage: \(error)")
             }
         }
     }
@@ -24,7 +24,7 @@ public class Sessions {
             do {
                 try amplitude.storage.write(key: StorageKey.LAST_EVENT_ID, value: _lastEventId)
             } catch {
-                amplitude.logger?.warn(message: "Can't write LAST_EVENT_ID to storage: \(error)")
+                amplitude.logger.warn(message: "Can't write LAST_EVENT_ID to storage: \(error)")
             }
         }
     }
@@ -37,7 +37,7 @@ public class Sessions {
             do {
                 try amplitude.storage.write(key: StorageKey.LAST_EVENT_TIME, value: _lastEventTime)
             } catch {
-                amplitude.logger?.warn(message: "Can't write LAST_EVENT_TIME to storage: \(error)")
+                amplitude.logger.warn(message: "Can't write LAST_EVENT_TIME to storage: \(error)")
             }
         }
     }

--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -69,7 +69,7 @@ class PersistentStorage: Storage {
         do {
             content = try String(contentsOf: eventBlock, encoding: .utf8)
         } catch {
-            amplitude?.logger?.error(message: error.localizedDescription)
+            amplitude?.logger.error(message: error.localizedDescription)
         }
         return content
     }
@@ -79,7 +79,7 @@ class PersistentStorage: Storage {
             do {
                 try fileManager.removeItem(atPath: eventBlock.path)
             } catch {
-                amplitude?.logger?.error(message: error.localizedDescription)
+                amplitude?.logger.error(message: error.localizedDescription)
             }
         }
     }
@@ -95,7 +95,7 @@ class PersistentStorage: Storage {
             do {
                 try fileManager.removeItem(atPath: eventBlock.path)
             } catch {
-                amplitude?.logger?.error(message: error.localizedDescription)
+                amplitude?.logger.error(message: error.localizedDescription)
             }
         }
     }
@@ -285,7 +285,7 @@ extension PersistentStorage {
         let jsonString = event.toString()
         do {
             if outputStream == nil {
-                amplitude?.logger?.error(message: "OutputStream is nil with file: \(storeFile)")
+                amplitude?.logger.error(message: "OutputStream is nil with file: \(storeFile)")
             }
             if newFile == false {
                 // prepare for the next entry
@@ -293,7 +293,7 @@ extension PersistentStorage {
             }
             try outputStream?.write(jsonString)
         } catch {
-            amplitude?.logger?.error(message: error.localizedDescription)
+            amplitude?.logger.error(message: error.localizedDescription)
         }
     }
 
@@ -308,11 +308,11 @@ extension PersistentStorage {
         let jsonString = events.map { $0.toString() }.joined(separator: ", ")
         do {
             if outputStream == nil {
-                amplitude?.logger?.error(message: "OutputStream is nil with file: \(storeFile)")
+                amplitude?.logger.error(message: "OutputStream is nil with file: \(storeFile)")
             }
             try outputStream?.write(jsonString)
         } catch {
-            amplitude?.logger?.error(message: error.localizedDescription)
+            amplitude?.logger.error(message: error.localizedDescription)
         }
         finish(file: storeFile)
     }
@@ -324,7 +324,7 @@ extension PersistentStorage {
             try outputStream?.create()
             try outputStream?.write(contents)
         } catch {
-            amplitude?.logger?.error(message: error.localizedDescription)
+            amplitude?.logger.error(message: error.localizedDescription)
         }
     }
 
@@ -337,7 +337,7 @@ extension PersistentStorage {
                     try outputStream.open()
                 }
             } catch {
-                amplitude?.logger?.error(message: error.localizedDescription)
+                amplitude?.logger.error(message: error.localizedDescription)
             }
         }
     }
@@ -352,7 +352,7 @@ extension PersistentStorage {
             try outputStream.write(fileEnding)
             try outputStream.close()
         } catch {
-            amplitude?.logger?.error(message: error.localizedDescription)
+            amplitude?.logger.error(message: error.localizedDescription)
         }
         self.outputStream = nil
 
@@ -360,7 +360,7 @@ extension PersistentStorage {
         do {
             try fileManager.moveItem(at: file, to: fileWithoutTemp)
         } catch {
-            amplitude?.logger?.error(message: "Unable to rename file: \(file.path)")
+            amplitude?.logger.error(message: "Unable to rename file: \(file.path)")
         }
 
         let currentFileIndex: Int = (getCurrentEventFileIndex() ?? 0) + 1

--- a/Sources/Amplitude/Utilities/EventPipeline.swift
+++ b/Sources/Amplitude/Utilities/EventPipeline.swift
@@ -40,12 +40,12 @@ public class EventPipeline {
             }
             completion?()
         } catch {
-            amplitude.logger?.error(message: "Error when storing event: \(error.localizedDescription)")
+            amplitude.logger.error(message: "Error when storing event: \(error.localizedDescription)")
         }
     }
 
     func flush(completion: (() -> Void)? = nil) {
-        amplitude.logger?.log(message: "Start flushing \(eventCount) events")
+        amplitude.logger.log(message: "Start flushing \(eventCount) events")
         eventCount = 0
         guard let storage = self.storage else { return }
         storage.rollover()
@@ -106,7 +106,7 @@ extension EventPipeline {
             }
             uploads = newPending
             let after = uploads.count
-            amplitude.logger?.log(message: "Cleaned up \(before - after) non-running uploads.")
+            amplitude.logger.log(message: "Cleaned up \(before - after) non-running uploads.")
         }
     }
 

--- a/Tests/AmplitudeTests/AmplitudeIOSTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeIOSTests.swift
@@ -22,6 +22,7 @@ final class AmplitudeIOSTests: XCTestCase {
     func testDidFinishLaunching_ApplicationInstalled() {
         let configuration = Configuration(
             apiKey: "api-key",
+            instanceName: NSUUID().uuidString,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             defaultTracking: DefaultTrackingOptions(sessions: false, appLifecycles: true)
@@ -51,6 +52,7 @@ final class AmplitudeIOSTests: XCTestCase {
     func testDidFinishLaunching_ApplicationUpdated() throws {
         let configuration = Configuration(
             apiKey: "api-key",
+            instanceName: NSUUID().uuidString,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             defaultTracking: DefaultTrackingOptions(sessions: false, appLifecycles: true)
@@ -85,6 +87,7 @@ final class AmplitudeIOSTests: XCTestCase {
     func testDidFinishLaunching_ApplicationOpened() throws {
         let configuration = Configuration(
             apiKey: "api-key",
+            instanceName: NSUUID().uuidString,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             defaultTracking: DefaultTrackingOptions(sessions: false, appLifecycles: true)
@@ -113,6 +116,7 @@ final class AmplitudeIOSTests: XCTestCase {
     func testWillEnterForeground() throws {
         let configuration = Configuration(
             apiKey: "api-key",
+            instanceName: NSUUID().uuidString,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             defaultTracking: DefaultTrackingOptions(sessions: false, appLifecycles: true)
@@ -138,6 +142,7 @@ final class AmplitudeIOSTests: XCTestCase {
     func testDidEnterBackground() throws {
         let configuration = Configuration(
             apiKey: "api-key",
+            instanceName: NSUUID().uuidString,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             defaultTracking: DefaultTrackingOptions(sessions: false, appLifecycles: true)

--- a/Tests/AmplitudeTests/AmplitudeSessionTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeSessionTests.swift
@@ -16,6 +16,7 @@ final class AmplitudeSessionTests: XCTestCase {
 
         configuration = Configuration(
             apiKey: apiKey,
+            instanceName: NSUUID().uuidString,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             minTimeBetweenSessionsMillis: 100

--- a/Tests/AmplitudeTests/TimelineTests.swift
+++ b/Tests/AmplitudeTests/TimelineTests.swift
@@ -13,7 +13,10 @@ final class TimelineTests: XCTestCase {
             return true
         }
 
-        let amplitude = Amplitude(configuration: Configuration(apiKey: "testApiKey"))
+        let amplitude = Amplitude(configuration: Configuration(
+            apiKey: "testApiKey",
+            instanceName: NSUUID().uuidString
+        ))
         amplitude.add(plugin: testPlugin)
         amplitude.track(event: BaseEvent(eventType: "testEvent"))
 
@@ -33,7 +36,10 @@ final class TimelineTests: XCTestCase {
             return true
         }
 
-        let amplitude = Amplitude(configuration: Configuration(apiKey: "testApiKey"))
+        let amplitude = Amplitude(configuration: Configuration(
+            apiKey: "testApiKey",
+            instanceName: NSUUID().uuidString
+        ))
         amplitude.add(plugin: testPlugin)
         amplitude.add(plugin: testPlugin2)
         amplitude.track(event: BaseEvent(eventType: "testEvent"))

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -22,6 +22,7 @@ final class EventPipelineTests: XCTestCase {
         configuration = Configuration(
             apiKey: "testApiKey",
             flushIntervalMillis: Int(Self.FLUSH_INTERVAL_SECONDS * 1000),
+            instanceName: NSUUID().uuidString,
             storageProvider: storage
         )
         let amplitude = Amplitude(configuration: configuration)

--- a/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
+++ b/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
@@ -19,6 +19,7 @@ final class IdentifyInterceptorTests: XCTestCase {
         let identifyBatchIntervalMillis = Int(Self.IDENTIFY_UPLOAD_INTERVAL_SECONDS * 1000)
         configuration = Configuration(
             apiKey: "testApiKey",
+            instanceName: NSUUID().uuidString,
             storageProvider: storage,
             identifyStorageProvider: identifyStorage,
             identifyBatchIntervalMillis: identifyBatchIntervalMillis

--- a/Tests/AmplitudeTests/Utilities/PersistentStorageResponseHandlerTests.swift
+++ b/Tests/AmplitudeTests/Utilities/PersistentStorageResponseHandlerTests.swift
@@ -20,7 +20,11 @@ final class PersistentStorageResponseHandlerTests: XCTestCase {
     override func setUp() {
         super.setUp()
         storage = PersistentStorage(storagePrefix: "storage")
-        configuration = Configuration(apiKey: "testApiKey", storageProvider: storage)
+        configuration = Configuration(
+            apiKey: "testApiKey",
+            instanceName: NSUUID().uuidString,
+            storageProvider: storage
+        )
         amplitude = Amplitude(configuration: configuration)
         eventPipeline = EventPipeline(amplitude: amplitude)
         eventBlock = URL(string: "test")


### PR DESCRIPTION
### Summary

Prevents creation of multiple instances with the same instanceName - dummy instances are created.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  Affects users who use multiple instances with the same name
