### PR TITLE
feat: add client upload time

### DIFF
--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -70,11 +70,9 @@ class HttpClient {
         return request
     }
 
-    func getRequestData(events: String, currentTime: Date = Date()) -> Data? {
+    func getRequestData(events: String) -> Data? {
         let apiKey = configuration.apiKey
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions.insert(.withFractionalSeconds)
-        let clientUploadTime: String = formatter.string(from: currentTime)
+        let clientUploadTime: String = ISO8601DateFormatter().string(from: Date())
         var requestPayload = """
             {"api_key":"\(apiKey)","client_upload_time":"\(clientUploadTime)","events":\(events)
             """

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -72,8 +72,9 @@ class HttpClient {
 
     func getRequestData(events: String) -> Data? {
         let apiKey = configuration.apiKey
+        let clientUploadTime: String = ISO8601DateFormatter().string(from: Date())
         var requestPayload = """
-            {"api_key":"\(apiKey)","events":\(events)
+            {"api_key":"\(apiKey)","client_upload_time":"\(clientUploadTime)","events":\(events)
             """
         if let minIdLength = configuration.minIdLength {
             requestPayload += """

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -86,6 +86,7 @@ class HttpClient {
         requestPayload += "}"
         return requestPayload.data(using: .utf8)
     }
+
     func getDate() -> Date {
         return Date()
     }

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -72,7 +72,9 @@ class HttpClient {
 
     func getRequestData(events: String) -> Data? {
         let apiKey = configuration.apiKey
-        let clientUploadTime: String = ISO8601DateFormatter().string(from: Date())
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions.insert(.withFractionalSeconds)
+        let clientUploadTime: String = formatter.string(from: getDate())
         var requestPayload = """
             {"api_key":"\(apiKey)","client_upload_time":"\(clientUploadTime)","events":\(events)
             """
@@ -83,6 +85,9 @@ class HttpClient {
         }
         requestPayload += "}"
         return requestPayload.data(using: .utf8)
+    }
+    func getDate() -> Date {
+        return Date()
     }
 }
 

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -70,9 +70,11 @@ class HttpClient {
         return request
     }
 
-    func getRequestData(events: String) -> Data? {
+    func getRequestData(events: String, currentTime: Date = Date()) -> Data? {
         let apiKey = configuration.apiKey
-        let clientUploadTime: String = ISO8601DateFormatter().string(from: Date())
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions.insert(.withFractionalSeconds)
+        let clientUploadTime: String = formatter.string(from: currentTime)
         var requestPayload = """
             {"api_key":"\(apiKey)","client_upload_time":"\(clientUploadTime)","events":\(events)
             """

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -129,7 +129,6 @@ class FakeHttpClient: HttpClient {
         completion(Result.success(200))
         return nil
     }
-    
     override func getDate() -> Date {
         // timestamp of 2023-10-24T18:16:24.000 in UTC time zone
         return Date(timeIntervalSince1970: 1698171384)

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -129,6 +129,11 @@ class FakeHttpClient: HttpClient {
         completion(Result.success(200))
         return nil
     }
+    
+    override func getDate() -> Date {
+        // timestamp of 2023-10-24T18:16:24.000 in UTC time zone
+        return Date(timeIntervalSince1970: 1698171384)
+    }
 }
 
 class FakeResponseHandler: ResponseHandler {

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -129,6 +129,7 @@ class FakeHttpClient: HttpClient {
         completion(Result.success(200))
         return nil
     }
+
     override func getDate() -> Date {
         // timestamp of 2023-10-24T18:16:24.000 in UTC time zone
         return Date(timeIntervalSince1970: 1698171384)

--- a/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
+++ b/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
@@ -46,13 +46,15 @@ final class HttpClientTests: XCTestCase {
         let httpClient = HttpClient(configuration: configuration)
         let event = BaseEvent(userId: "unit-test user", eventType: "unit-test event")
 
-        let currentTime = Date(timeIntervalSince1970: 1698171384)
+        let dateFormatter = ISO8601DateFormatter()
+        let currentDate = Date()
+        let expectedClientUploadTime = dateFormatter.string(from: currentDate)
 
         let expectedRequestPayload = """
-            {"api_key":"testApiKey","client_upload_time":"2023-10-24T18:16:24.000Z","events":[\(event.toString())]}
+            {"api_key":"testApiKey","client_upload_time":"\(expectedClientUploadTime)","events":[\(event.toString())]}
             """.data(using: .utf8)
 
-        let result = httpClient.getRequestData(events: "[\(event.toString())]", currentTime: currentTime)
+        let result = httpClient.getRequestData(events: "[\(event.toString())]")
 
         XCTAssertEqual(result, expectedRequestPayload)
     }

--- a/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
+++ b/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
@@ -43,15 +43,11 @@ final class HttpClientTests: XCTestCase {
     }
 
     func testGetRequestData() {
-        let httpClient = HttpClient(configuration: configuration)
+        let httpClient = FakeHttpClient(configuration: configuration)
         let event = BaseEvent(userId: "unit-test user", eventType: "unit-test event")
 
-        let dateFormatter = ISO8601DateFormatter()
-        let currentDate = Date()
-        let expectedClientUploadTime = dateFormatter.string(from: currentDate)
-
         let expectedRequestPayload = """
-            {"api_key":"testApiKey","client_upload_time":"\(expectedClientUploadTime)","events":[\(event.toString())]}
+            {"api_key":"testApiKey","client_upload_time":"2023-10-24T18:16:24.000Z","events":[\(event.toString())]}
             """.data(using: .utf8)
 
         let result = httpClient.getRequestData(events: "[\(event.toString())]")

--- a/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
+++ b/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
@@ -46,15 +46,13 @@ final class HttpClientTests: XCTestCase {
         let httpClient = HttpClient(configuration: configuration)
         let event = BaseEvent(userId: "unit-test user", eventType: "unit-test event")
 
-        let dateFormatter = ISO8601DateFormatter()
-        let currentDate = Date()
-        let expectedClientUploadTime = dateFormatter.string(from: currentDate)
+        let currentTime = Date(timeIntervalSince1970: 1698171384)
 
         let expectedRequestPayload = """
-            {"api_key":"testApiKey","client_upload_time":"\(expectedClientUploadTime)","events":[\(event.toString())]}
+            {"api_key":"testApiKey","client_upload_time":"2023-10-24T18:16:24.000Z","events":[\(event.toString())]}
             """.data(using: .utf8)
 
-        let result = httpClient.getRequestData(events: "[\(event.toString())]")
+        let result = httpClient.getRequestData(events: "[\(event.toString())]", currentTime: currentTime)
 
         XCTAssertEqual(result, expectedRequestPayload)
     }

--- a/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
+++ b/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
@@ -42,6 +42,23 @@ final class HttpClientTests: XCTestCase {
         }
     }
 
+    func testGetRequestData() {
+        let httpClient = HttpClient(configuration: configuration)
+        let event = BaseEvent(userId: "unit-test user", eventType: "unit-test event")
+
+        let dateFormatter = ISO8601DateFormatter()
+        let currentDate = Date()
+        let expectedClientUploadTime = dateFormatter.string(from: currentDate)
+
+        let expectedRequestPayload = """
+            {"api_key":"testApiKey","client_upload_time":"\(expectedClientUploadTime)","events":[\(event.toString())]}
+            """.data(using: .utf8)
+
+        let result = httpClient.getRequestData(events: "[\(event.toString())]")
+
+        XCTAssertEqual(result, expectedRequestPayload)
+    }
+
     func testUploadWithInvalidApiKey() {
         // TODO: currently this test is sending request to real Amplitude host, update to mock for better stability
         let httpClient = HttpClient(configuration: configuration)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

https://amplitude.atlassian.net/browse/AMP-87208
Adding `client_upload_time` so that when client-side clock is drifted, backend can [correct it](https://discourse.amplitude.com/t/is-it-possible-to-enable-event-time-adjustments-if-discrepancy-is-less-than-60-seconds/11627/5?u=justin)

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
