### PR TITLE
fix: add setSessionId() method

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -286,6 +286,21 @@ public class Amplitude {
     }
 
     @discardableResult
+    public func sessionStart(at: Date = Date()) -> Amplitude {
+        let timestamp = Int64(at.timeIntervalSince1970 * 1000)
+        setSessionId(timestamp: timestamp)
+        return self
+    }
+
+    @discardableResult
+    public func sessionEnd(at: Date? = nil) -> Amplitude {
+        let timestamp = at != nil ? Int64(at!.timeIntervalSince1970 * 1000) : nil
+        let sessionEvents = sessions.assignEventId(events: sessions.endCurrentSession(timestamp: timestamp))
+        sessionEvents.forEach { e in timeline.processEvent(event: e) }
+        return self
+    }
+
+    @discardableResult
     public func reset() -> Amplitude {
         _ = setUserId(userId: nil)
         _ = setDeviceId(deviceId: nil)

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -279,6 +279,13 @@ public class Amplitude {
     }
 
     @discardableResult
+    public func setSessionId(timestamp: Int64) -> Amplitude {
+        let sessionEvents = sessions.assignEventId(events: sessions.startNewSession(timestamp: timestamp))
+        sessionEvents.forEach { e in timeline.processEvent(event: e) }
+        return self
+    }
+
+    @discardableResult
     public func reset() -> Amplitude {
         _ = setUserId(userId: nil)
         _ = setDeviceId(deviceId: nil)

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -280,23 +280,17 @@ public class Amplitude {
 
     @discardableResult
     public func setSessionId(timestamp: Int64) -> Amplitude {
-        let sessionEvents = sessions.assignEventId(events: sessions.startNewSession(timestamp: timestamp))
+        let sessionEvents = sessions.assignEventId(
+            events: timestamp >= 0 ? sessions.startNewSession(timestamp: timestamp) : sessions.endCurrentSession()
+        )
         sessionEvents.forEach { e in timeline.processEvent(event: e) }
         return self
     }
 
     @discardableResult
-    public func sessionStart(at: Date = Date()) -> Amplitude {
-        let timestamp = Int64(at.timeIntervalSince1970 * 1000)
+    public func setSessionId(date: Date) -> Amplitude {
+        let timestamp = Int64(date.timeIntervalSince1970 * 1000)
         setSessionId(timestamp: timestamp)
-        return self
-    }
-
-    @discardableResult
-    public func sessionEnd(at: Date? = nil) -> Amplitude {
-        let timestamp = at != nil ? Int64(at!.timeIntervalSince1970 * 1000) : nil
-        let sessionEvents = sessions.assignEventId(events: sessions.endCurrentSession(timestamp: timestamp))
-        sessionEvents.forEach { e in timeline.processEvent(event: e) }
         return self
     }
 

--- a/Sources/Amplitude/ObjC/ObjCAmplitude.swift
+++ b/Sources/Amplitude/ObjC/ObjCAmplitude.swift
@@ -200,38 +200,17 @@ public class ObjCAmplitude: NSObject {
         amplitude.getSessionId()
     }
 
-    @objc(setSessionId:)
+    @objc(setSessionIdWithTimestamp:)
     @discardableResult
     public func setSessionId(timestamp: Int64) -> ObjCAmplitude {
         amplitude.setSessionId(timestamp: timestamp)
         return self
     }
 
-    @objc(sessionStart)
+    @objc(setSessionIdWithDate:)
     @discardableResult
-    public func sessionStart() -> ObjCAmplitude {
-        amplitude.sessionStart()
-        return self
-    }
-
-    @objc(sessionStart:)
-    @discardableResult
-    public func sessionStart(at: Date) -> ObjCAmplitude {
-        amplitude.sessionStart(at: at)
-        return self
-    }
-
-    @objc(sessionEnd)
-    @discardableResult
-    public func sessionEnd() -> ObjCAmplitude {
-        amplitude.sessionEnd()
-        return self
-    }
-
-    @objc(sessionEnd:)
-    @discardableResult
-    public func sessionEnd(at: Date) -> ObjCAmplitude {
-        amplitude.sessionEnd(at: at)
+    public func setSessionId(date: Date) -> ObjCAmplitude {
+        amplitude.setSessionId(date: date)
         return self
     }
 

--- a/Sources/Amplitude/ObjC/ObjCAmplitude.swift
+++ b/Sources/Amplitude/ObjC/ObjCAmplitude.swift
@@ -207,6 +207,34 @@ public class ObjCAmplitude: NSObject {
         return self
     }
 
+    @objc(sessionStart)
+    @discardableResult
+    public func sessionStart() -> ObjCAmplitude {
+        amplitude.sessionStart()
+        return self
+    }
+
+    @objc(sessionStart:)
+    @discardableResult
+    public func sessionStart(at: Date) -> ObjCAmplitude {
+        amplitude.sessionStart(at: at)
+        return self
+    }
+
+    @objc(sessionEnd)
+    @discardableResult
+    public func sessionEnd() -> ObjCAmplitude {
+        amplitude.sessionEnd()
+        return self
+    }
+
+    @objc(sessionEnd:)
+    @discardableResult
+    public func sessionEnd(at: Date) -> ObjCAmplitude {
+        amplitude.sessionEnd(at: at)
+        return self
+    }
+
     @objc
     @discardableResult
     public func reset() -> ObjCAmplitude {

--- a/Sources/Amplitude/ObjC/ObjCAmplitude.swift
+++ b/Sources/Amplitude/ObjC/ObjCAmplitude.swift
@@ -200,6 +200,13 @@ public class ObjCAmplitude: NSObject {
         amplitude.getSessionId()
     }
 
+    @objc(setSessionId:)
+    @discardableResult
+    public func setSessionId(timestamp: Int64) -> ObjCAmplitude {
+        amplitude.setSessionId(timestamp: timestamp)
+        return self
+    }
+
     @objc
     @discardableResult
     public func reset() -> ObjCAmplitude {

--- a/Sources/Amplitude/Sessions.swift
+++ b/Sources/Amplitude/Sessions.swift
@@ -142,4 +142,25 @@ public class Sessions {
 
         return sessionEvents
     }
+
+    public func endCurrentSession(timestamp: Int64?) -> [BaseEvent] {
+        var sessionEvents: [BaseEvent] = Array()
+        let trackingSessionEvents = amplitude.configuration.defaultTracking.sessions
+
+        if trackingSessionEvents && self.sessionId >= 0 {
+            let sessionEndEvent = BaseEvent(
+                timestamp: timestamp ?? (self.lastEventTime > 0 ? self.lastEventTime : nil),
+                sessionId: self.sessionId,
+                eventType: Constants.AMP_SESSION_END_EVENT
+            )
+            sessionEvents.append(sessionEndEvent)
+
+            if let timestamp = timestamp, timestamp > (self.lastEventTime ?? 0) {
+                self.lastEventTime = timestamp
+            }
+        }
+
+        self.sessionId = -1
+        return sessionEvents
+    }
 }

--- a/Sources/Amplitude/Sessions.swift
+++ b/Sources/Amplitude/Sessions.swift
@@ -81,9 +81,13 @@ public class Sessions {
             result.append(event)
         }
 
+        return assignEventId(events: result)
+    }
+
+    func assignEventId(events: [BaseEvent]) -> [BaseEvent] {
         var newLastEventId = self.lastEventId
 
-        result.forEach({ event in
+        events.forEach({ event in
             if event.eventId == nil {
                 newLastEventId += 1
                 event.eventId = newLastEventId
@@ -92,7 +96,7 @@ public class Sessions {
 
         self.lastEventId = newLastEventId
 
-        return result
+        return events
     }
 
     private func isWithinMinTimeBetweenSessions(timestamp: Int64) -> Bool {

--- a/Sources/Amplitude/Sessions.swift
+++ b/Sources/Amplitude/Sessions.swift
@@ -143,21 +143,17 @@ public class Sessions {
         return sessionEvents
     }
 
-    public func endCurrentSession(timestamp: Int64?) -> [BaseEvent] {
+    public func endCurrentSession() -> [BaseEvent] {
         var sessionEvents: [BaseEvent] = Array()
         let trackingSessionEvents = amplitude.configuration.defaultTracking.sessions
 
         if trackingSessionEvents && self.sessionId >= 0 {
             let sessionEndEvent = BaseEvent(
-                timestamp: timestamp ?? (self.lastEventTime > 0 ? self.lastEventTime : nil),
+                timestamp: self.lastEventTime > 0 ? self.lastEventTime : nil,
                 sessionId: self.sessionId,
                 eventType: Constants.AMP_SESSION_END_EVENT
             )
             sessionEvents.append(sessionEndEvent)
-
-            if let timestamp = timestamp, timestamp > (self.lastEventTime ?? 0) {
-                self.lastEventTime = timestamp
-            }
         }
 
         self.sessionId = -1

--- a/Tests/AmplitudeTests/AmplitudeSessionTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeSessionTests.swift
@@ -525,57 +525,48 @@ final class AmplitudeSessionTests: XCTestCase {
         let eventCollector = EventCollectorPlugin()
         amplitude.add(plugin: eventCollector)
 
-        amplitude.track(event: BaseEvent(userId: "user", timestamp: 100, eventType: "test event 1"))
-        XCTAssertEqual(amplitude.sessionId, 100)
+        amplitude.track(event: BaseEvent(userId: "user", timestamp: 1000, eventType: "test event 1"))
+        XCTAssertEqual(amplitude.sessionId, 1000)
 
-        amplitude.sessionEnd()
+        amplitude.setSessionId(timestamp: -1)
         XCTAssertEqual(amplitude.sessionId, -1)
 
-        amplitude.track(event: BaseEvent(userId: "user", timestamp: 200, eventType: "test event 2"))
-        XCTAssertEqual(amplitude.sessionId, 200)
-
-        amplitude.sessionEnd(at: Date(timeIntervalSince1970: 1))
-        XCTAssertEqual(amplitude.sessionId, -1)
+        amplitude.track(event: BaseEvent(userId: "user", timestamp: 2000, eventType: "test event 2"))
+        XCTAssertEqual(amplitude.sessionId, 2000)
 
         let collectedEvents = eventCollector.events
 
-        XCTAssertEqual(collectedEvents.count, 6)
+        XCTAssertEqual(collectedEvents.count, 5)
 
         var event = collectedEvents[0]
         XCTAssertEqual(event.eventType, Constants.AMP_SESSION_START_EVENT)
-        XCTAssertEqual(event.sessionId, 100)
-        XCTAssertEqual(event.timestamp, 100)
+        XCTAssertEqual(event.sessionId, 1000)
+        XCTAssertEqual(event.timestamp, 1000)
         XCTAssertEqual(event.eventId, lastEventId+1)
 
         event = collectedEvents[1]
         XCTAssertEqual(event.eventType, "test event 1")
-        XCTAssertEqual(event.sessionId, 100)
-        XCTAssertEqual(event.timestamp, 100)
+        XCTAssertEqual(event.sessionId, 1000)
+        XCTAssertEqual(event.timestamp, 1000)
         XCTAssertEqual(event.eventId, lastEventId+2)
 
         event = collectedEvents[2]
         XCTAssertEqual(event.eventType, Constants.AMP_SESSION_END_EVENT)
-        XCTAssertEqual(event.sessionId, 100)
-        XCTAssertEqual(event.timestamp, 100)
+        XCTAssertEqual(event.sessionId, 1000)
+        XCTAssertEqual(event.timestamp, 1000)
         XCTAssertEqual(event.eventId, lastEventId+3)
 
         event = collectedEvents[3]
         XCTAssertEqual(event.eventType, Constants.AMP_SESSION_START_EVENT)
-        XCTAssertEqual(event.sessionId, 200)
-        XCTAssertEqual(event.timestamp, 200)
+        XCTAssertEqual(event.sessionId, 2000)
+        XCTAssertEqual(event.timestamp, 2000)
         XCTAssertEqual(event.eventId, lastEventId+4)
 
         event = collectedEvents[4]
         XCTAssertEqual(event.eventType, "test event 2")
-        XCTAssertEqual(event.sessionId, 200)
-        XCTAssertEqual(event.timestamp, 200)
+        XCTAssertEqual(event.sessionId, 2000)
+        XCTAssertEqual(event.timestamp, 2000)
         XCTAssertEqual(event.eventId, lastEventId+5)
-
-        event = collectedEvents[5]
-        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_END_EVENT)
-        XCTAssertEqual(event.sessionId, 200)
-        XCTAssertEqual(event.timestamp, 1000)
-        XCTAssertEqual(event.eventId, lastEventId+6)
     }
 
     func testSessionEndInForegroundShouldEndCurrentSession() throws {
@@ -587,58 +578,49 @@ final class AmplitudeSessionTests: XCTestCase {
         let eventCollector = EventCollectorPlugin()
         amplitude.add(plugin: eventCollector)
 
-        amplitude.onEnterForeground(timestamp: 100)
-        amplitude.track(event: BaseEvent(userId: "user", timestamp: 150, eventType: "test event 1"))
-        XCTAssertEqual(amplitude.sessionId, 100)
+        amplitude.onEnterForeground(timestamp: 1000)
+        amplitude.track(event: BaseEvent(userId: "user", timestamp: 1500, eventType: "test event 1"))
+        XCTAssertEqual(amplitude.sessionId, 1000)
 
-        amplitude.sessionEnd()
+        amplitude.setSessionId(timestamp: -1)
         XCTAssertEqual(amplitude.sessionId, -1)
 
-        amplitude.track(event: BaseEvent(userId: "user", timestamp: 200, eventType: "test event 2"))
-        XCTAssertEqual(amplitude.sessionId, 200)
-
-        amplitude.sessionEnd(at: Date(timeIntervalSince1970: 1))
-        XCTAssertEqual(amplitude.sessionId, -1)
+        amplitude.track(event: BaseEvent(userId: "user", timestamp: 2000, eventType: "test event 2"))
+        XCTAssertEqual(amplitude.sessionId, 2000)
 
         let collectedEvents = eventCollector.events
 
-        XCTAssertEqual(collectedEvents.count, 6)
+        XCTAssertEqual(collectedEvents.count, 5)
 
         var event = collectedEvents[0]
         XCTAssertEqual(event.eventType, Constants.AMP_SESSION_START_EVENT)
-        XCTAssertEqual(event.sessionId, 100)
-        XCTAssertEqual(event.timestamp, 100)
+        XCTAssertEqual(event.sessionId, 1000)
+        XCTAssertEqual(event.timestamp, 1000)
         XCTAssertEqual(event.eventId, lastEventId+1)
 
         event = collectedEvents[1]
         XCTAssertEqual(event.eventType, "test event 1")
-        XCTAssertEqual(event.sessionId, 100)
-        XCTAssertEqual(event.timestamp, 150)
+        XCTAssertEqual(event.sessionId, 1000)
+        XCTAssertEqual(event.timestamp, 1500)
         XCTAssertEqual(event.eventId, lastEventId+2)
 
         event = collectedEvents[2]
         XCTAssertEqual(event.eventType, Constants.AMP_SESSION_END_EVENT)
-        XCTAssertEqual(event.sessionId, 100)
-        XCTAssertEqual(event.timestamp, 150)
+        XCTAssertEqual(event.sessionId, 1000)
+        XCTAssertEqual(event.timestamp, 1500)
         XCTAssertEqual(event.eventId, lastEventId+3)
 
         event = collectedEvents[3]
         XCTAssertEqual(event.eventType, Constants.AMP_SESSION_START_EVENT)
-        XCTAssertEqual(event.sessionId, 200)
-        XCTAssertEqual(event.timestamp, 200)
+        XCTAssertEqual(event.sessionId, 2000)
+        XCTAssertEqual(event.timestamp, 2000)
         XCTAssertEqual(event.eventId, lastEventId+4)
 
         event = collectedEvents[4]
         XCTAssertEqual(event.eventType, "test event 2")
-        XCTAssertEqual(event.sessionId, 200)
-        XCTAssertEqual(event.timestamp, 200)
+        XCTAssertEqual(event.sessionId, 2000)
+        XCTAssertEqual(event.timestamp, 2000)
         XCTAssertEqual(event.eventId, lastEventId+5)
-
-        event = collectedEvents[5]
-        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_END_EVENT)
-        XCTAssertEqual(event.sessionId, 200)
-        XCTAssertEqual(event.timestamp, 1000)
-        XCTAssertEqual(event.eventId, lastEventId+6)
     }
 
     func getDictionary(_ props: [String: Any?]) -> NSDictionary {

--- a/Tests/AmplitudeTests/AmplitudeSessionTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeSessionTests.swift
@@ -516,6 +516,131 @@ final class AmplitudeSessionTests: XCTestCase {
         XCTAssertEqual(event.eventId, lastEventId+5)
     }
 
+    func testSessionEndInBackgroundShouldEndCurrentSession() throws {
+        let lastEventId: Int64 = 123
+        try storageMem.write(key: StorageKey.LAST_EVENT_ID, value: lastEventId)
+
+        let amplitude = Amplitude(configuration: configuration)
+
+        let eventCollector = EventCollectorPlugin()
+        amplitude.add(plugin: eventCollector)
+
+        amplitude.track(event: BaseEvent(userId: "user", timestamp: 100, eventType: "test event 1"))
+        XCTAssertEqual(amplitude.sessionId, 100)
+
+        amplitude.sessionEnd()
+        XCTAssertEqual(amplitude.sessionId, -1)
+
+        amplitude.track(event: BaseEvent(userId: "user", timestamp: 200, eventType: "test event 2"))
+        XCTAssertEqual(amplitude.sessionId, 200)
+
+        amplitude.sessionEnd(at: Date(timeIntervalSince1970: 1))
+        XCTAssertEqual(amplitude.sessionId, -1)
+
+        let collectedEvents = eventCollector.events
+
+        XCTAssertEqual(collectedEvents.count, 6)
+
+        var event = collectedEvents[0]
+        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_START_EVENT)
+        XCTAssertEqual(event.sessionId, 100)
+        XCTAssertEqual(event.timestamp, 100)
+        XCTAssertEqual(event.eventId, lastEventId+1)
+
+        event = collectedEvents[1]
+        XCTAssertEqual(event.eventType, "test event 1")
+        XCTAssertEqual(event.sessionId, 100)
+        XCTAssertEqual(event.timestamp, 100)
+        XCTAssertEqual(event.eventId, lastEventId+2)
+
+        event = collectedEvents[2]
+        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_END_EVENT)
+        XCTAssertEqual(event.sessionId, 100)
+        XCTAssertEqual(event.timestamp, 100)
+        XCTAssertEqual(event.eventId, lastEventId+3)
+
+        event = collectedEvents[3]
+        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_START_EVENT)
+        XCTAssertEqual(event.sessionId, 200)
+        XCTAssertEqual(event.timestamp, 200)
+        XCTAssertEqual(event.eventId, lastEventId+4)
+
+        event = collectedEvents[4]
+        XCTAssertEqual(event.eventType, "test event 2")
+        XCTAssertEqual(event.sessionId, 200)
+        XCTAssertEqual(event.timestamp, 200)
+        XCTAssertEqual(event.eventId, lastEventId+5)
+
+        event = collectedEvents[5]
+        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_END_EVENT)
+        XCTAssertEqual(event.sessionId, 200)
+        XCTAssertEqual(event.timestamp, 1000)
+        XCTAssertEqual(event.eventId, lastEventId+6)
+    }
+
+    func testSessionEndInForegroundShouldEndCurrentSession() throws {
+        let lastEventId: Int64 = 123
+        try storageMem.write(key: StorageKey.LAST_EVENT_ID, value: lastEventId)
+
+        let amplitude = Amplitude(configuration: configuration)
+
+        let eventCollector = EventCollectorPlugin()
+        amplitude.add(plugin: eventCollector)
+
+        amplitude.onEnterForeground(timestamp: 100)
+        amplitude.track(event: BaseEvent(userId: "user", timestamp: 150, eventType: "test event 1"))
+        XCTAssertEqual(amplitude.sessionId, 100)
+
+        amplitude.sessionEnd()
+        XCTAssertEqual(amplitude.sessionId, -1)
+
+        amplitude.track(event: BaseEvent(userId: "user", timestamp: 200, eventType: "test event 2"))
+        XCTAssertEqual(amplitude.sessionId, 200)
+
+        amplitude.sessionEnd(at: Date(timeIntervalSince1970: 1))
+        XCTAssertEqual(amplitude.sessionId, -1)
+
+        let collectedEvents = eventCollector.events
+
+        XCTAssertEqual(collectedEvents.count, 6)
+
+        var event = collectedEvents[0]
+        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_START_EVENT)
+        XCTAssertEqual(event.sessionId, 100)
+        XCTAssertEqual(event.timestamp, 100)
+        XCTAssertEqual(event.eventId, lastEventId+1)
+
+        event = collectedEvents[1]
+        XCTAssertEqual(event.eventType, "test event 1")
+        XCTAssertEqual(event.sessionId, 100)
+        XCTAssertEqual(event.timestamp, 150)
+        XCTAssertEqual(event.eventId, lastEventId+2)
+
+        event = collectedEvents[2]
+        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_END_EVENT)
+        XCTAssertEqual(event.sessionId, 100)
+        XCTAssertEqual(event.timestamp, 150)
+        XCTAssertEqual(event.eventId, lastEventId+3)
+
+        event = collectedEvents[3]
+        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_START_EVENT)
+        XCTAssertEqual(event.sessionId, 200)
+        XCTAssertEqual(event.timestamp, 200)
+        XCTAssertEqual(event.eventId, lastEventId+4)
+
+        event = collectedEvents[4]
+        XCTAssertEqual(event.eventType, "test event 2")
+        XCTAssertEqual(event.sessionId, 200)
+        XCTAssertEqual(event.timestamp, 200)
+        XCTAssertEqual(event.eventId, lastEventId+5)
+
+        event = collectedEvents[5]
+        XCTAssertEqual(event.eventType, Constants.AMP_SESSION_END_EVENT)
+        XCTAssertEqual(event.sessionId, 200)
+        XCTAssertEqual(event.timestamp, 1000)
+        XCTAssertEqual(event.eventId, lastEventId+6)
+    }
+
     func getDictionary(_ props: [String: Any?]) -> NSDictionary {
         return NSDictionary(dictionary: props as [AnyHashable: Any])
     }


### PR DESCRIPTION
### Summary

Adds `setSessionId()` method.

Typical usage is `amplitude.setSessionId(timestamp: Int64(NSDate().timeIntervalSince1970 * 1000))`

Maybe it makes sense to add:
* method `startNewSession()` (without any parameters, the same as `setSessionId(timestamp: Int64(NSDate().timeIntervalSince1970 * 1000))`)
* method `endCurrentSession()` to end the current session but do not start new session. Can be used in client `Log Out` logic. Maybe it can be used inside SDK `reset()` method.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
