### PR TITLE
feat:add objc to ScreenViewedEvent init

### DIFF
--- a/Sources/Amplitude/Events/ScreenViewedEvent.swift
+++ b/Sources/Amplitude/Events/ScreenViewedEvent.swift
@@ -9,7 +9,7 @@ public class ScreenViewedEvent: BaseEvent {
         }
     }
 
-    public init(screenName: String) {
+    @objc public init(screenName: String) {
         super.init(eventType: Constants.AMP_SCREEN_VIEWED_EVENT, eventProperties: [
             Constants.AMP_APP_SCREEN_NAME_PROPERTY: screenName
         ])


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

ScreenViewedEvent used for default tracking of screens appeared.
Added objc to init, to be able swizzle init and change how event formed (for example - pass event with screenName as part of `eventType` and not `eventProperty` 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No. Only affect on existing code is fact that init for `ScreenViewedEvent` moved from Table dispatch to Message dispatch, which should not be a problem
