### PR TITLE
Use Application Support Directory for Persistent Storage

### DIFF
--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -281,23 +281,18 @@ extension PersistentStorage {
     }
 
     internal func getEventsStorageDirectory(createDirectory: Bool = true) -> URL {
-        // TODO: Update to use applicationSupportDirectory for all platforms (this will require a migration)
-        // let searchPathDirectory = FileManager.SearchPathDirectory.applicationSupportDirectory
-        // tvOS doesn't have access to document
-        // macOS /Documents dir might be synced with iCloud
-        #if os(tvOS) || os(macOS)
-            let searchPathDirectory = FileManager.SearchPathDirectory.cachesDirectory
-        #else
-            let searchPathDirectory = FileManager.SearchPathDirectory.documentDirectory
-        #endif
-
+        let searchPathDirectory = FileManager.SearchPathDirectory.applicationSupportDirectory
         let urls = fileManager.urls(for: searchPathDirectory, in: .userDomainMask)
         let docUrl = urls[0]
-        let storageUrl = docUrl.appendingPathComponent("amplitude/\(appPath ?? "")\(eventsFileKey)/")
+        var storageUrl = docUrl.appendingPathComponent("amplitude/\(appPath ?? "")\(eventsFileKey)/")
         if createDirectory {
             // try to create it, will fail if already exists.
             // tvOS, watchOS regularly clear out data.
-            try? FileManager.default.createDirectory(at: storageUrl, withIntermediateDirectories: true, attributes: nil)
+          var values = URLResourceValues()
+          values.isExcludedFromBackup = true
+          try? FileManager.default.createDirectory(
+              at: storageUrl, withIntermediateDirectories: true, attributes: nil)
+          try? storageUrl.setResourceValues(values)
         }
         return storageUrl
     }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Changes the persistent storage directory to use the application support directory. 
See #104 for more info. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No. But some events may be lost in transition. 
