### PR TITLE
fix: should track coarse location by default

### DIFF
--- a/Sources/Amplitude/PrivacyInfo.xcprivacy
+++ b/Sources/Amplitude/PrivacyInfo.xcprivacy
@@ -30,7 +30,7 @@
 		</dict>
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
-			<string>NSPrivacyCollectedDataTypePreciseLocation</string>
+			<string>NSPrivacyCollectedDataTypeCoarseLocation</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
 			<true/>
 			<key>NSPrivacyCollectedDataTypeTracking</key>


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

The SDK tracks coarse location (less than [3 decimal](https://support.garmin.com/en-CA/?faq=hRMBoCTy5a7HqVkxukhHd8)) by default by [IP address](https://www.if-so.com/geo-targeting/). Customers can use a [LocationPlugin](https://github.com/amplitude/Amplitude-Swift/blob/cf0ca474f50864fbaa5ea8ae7e70a58814456e61/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ExamplePlugins/LocationPlugin.swift) to track latitude and longitude and add precise location to privacy manifest.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
