### PR TITLE
feat: add offline mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+
+Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
+Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@ DerivedData/
 .swiftpm/config/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
-
-Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/
-Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/

--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		8EDECEC5F98F9974DF3E576F /* ObjCIdentify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC5A50E197C9C5067C19E /* ObjCIdentify.swift */; };
 		8EDECF81C2B1B38D472FD7EF /* ObjCConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDECEC5AAE15FD05E76359A /* ObjCConfiguration.swift */; };
 		8EDECFCCF4219767F26210D6 /* Sessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC2B8B38E04CDB51F0E83 /* Sessions.swift */; };
+		B6CCC6CD2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CCC6CC2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift */; };
 		B6EDB4D02B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EDB4CF2B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift */; };
 		B6F338A32B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F338A22B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift */; };
 		BA0359CA2A51585D007C383B /* legacy_v3.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = BA0359C92A51585D007C383B /* legacy_v3.sqlite */; };
@@ -171,6 +172,7 @@
 		8EDECE07F682FAAE47F77B24 /* ObjCEventOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCEventOptions.swift; sourceTree = "<group>"; };
 		8EDECEC5AAE15FD05E76359A /* ObjCConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCConfiguration.swift; sourceTree = "<group>"; };
 		8EDECF8CF745F7339B65D6DB /* ObjCStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCStorage.swift; sourceTree = "<group>"; };
+		B6CCC6CC2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCNetworkConnectivityCheckerPlugin.swift; sourceTree = "<group>"; };
 		B6DF481F2B5B45BE00B3E6AA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B6EDB4CF2B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityCheckerPlugin.swift; sourceTree = "<group>"; };
 		B6F338A22B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityCheckerPluginTests.swift; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 		8EDECAFD8271434E8DC7BA78 /* ObjC */ = {
 			isa = PBXGroup;
 			children = (
+				B6CCC6CC2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift */,
 				8EDECEC5AAE15FD05E76359A /* ObjCConfiguration.swift */,
 				8EDECB1FA2AFF022A19104EE /* ObjCPlan.swift */,
 				8EDEC500EBDA8B813056E2DB /* ObjCIngestionMetadata.swift */,
@@ -700,6 +703,7 @@
 				OBJ_108 /* IOSLifecycleMonitor.swift in Sources */,
 				OBJ_109 /* WatchOSLifecycleMonitor.swift in Sources */,
 				OBJ_110 /* State.swift in Sources */,
+				B6CCC6CD2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift in Sources */,
 				OBJ_111 /* InMemoryStorage.swift in Sources */,
 				OBJ_112 /* PersistentStorage.swift in Sources */,
 				BA9BEA4B299FB43B00BC0F7C /* IdentifyInterceptor.swift in Sources */,

--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		8EDECEC5F98F9974DF3E576F /* ObjCIdentify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC5A50E197C9C5067C19E /* ObjCIdentify.swift */; };
 		8EDECF81C2B1B38D472FD7EF /* ObjCConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDECEC5AAE15FD05E76359A /* ObjCConfiguration.swift */; };
 		8EDECFCCF4219767F26210D6 /* Sessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC2B8B38E04CDB51F0E83 /* Sessions.swift */; };
+		B6EDB4D02B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EDB4CF2B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift */; };
 		BA0359CA2A51585D007C383B /* legacy_v3.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = BA0359C92A51585D007C383B /* legacy_v3.sqlite */; };
 		BA0639F62A4DD491000F1CEE /* LegacyDatabaseStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0639F52A4DD491000F1CEE /* LegacyDatabaseStorage.swift */; };
 		BA1EC0F42A9F2FC700C2D547 /* DefaultTrackingOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1EC0F32A9F2FC700C2D547 /* DefaultTrackingOptionsTests.swift */; };
@@ -170,6 +171,7 @@
 		8EDECEC5AAE15FD05E76359A /* ObjCConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCConfiguration.swift; sourceTree = "<group>"; };
 		8EDECF8CF745F7339B65D6DB /* ObjCStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCStorage.swift; sourceTree = "<group>"; };
 		B6DF481F2B5B45BE00B3E6AA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		B6EDB4CF2B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityCheckerPlugin.swift; sourceTree = "<group>"; };
 		BA0359C92A51585D007C383B /* legacy_v3.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = legacy_v3.sqlite; sourceTree = "<group>"; };
 		BA0639F52A4DD491000F1CEE /* LegacyDatabaseStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyDatabaseStorage.swift; sourceTree = "<group>"; };
 		BA1EC0F32A9F2FC700C2D547 /* DefaultTrackingOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTrackingOptionsTests.swift; sourceTree = "<group>"; };
@@ -338,6 +340,7 @@
 				8EDEC448C42C8C0A464FAA15 /* BasePlugins.swift */,
 				8EDECD39BAA97DD4320C0AA5 /* AnalyticsConnectorPlugin.swift */,
 				8EDEC48916EFEF6D5B3EEF9A /* AnalyticsConnectorIdentityPlugin.swift */,
+				B6EDB4CF2B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift */,
 			);
 			path = Plugins;
 			sourceTree = "<group>";
@@ -727,6 +730,7 @@
 				8EDECA4DAFA67CD4785D0161 /* ObjCDefaultTrackingOptions.swift in Sources */,
 				8EDEC43520B2DCF584F1035D /* ObjCScreenViewedEvent.swift in Sources */,
 				8EDECC1FC97DDF0BEFAA96E7 /* ObjCDeepLinkOpenedEvent.swift in Sources */,
+				B6EDB4D02B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift in Sources */,
 				8EDEC5F7208B1C327C8703D7 /* ObjCStorage.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		8EDECF81C2B1B38D472FD7EF /* ObjCConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDECEC5AAE15FD05E76359A /* ObjCConfiguration.swift */; };
 		8EDECFCCF4219767F26210D6 /* Sessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC2B8B38E04CDB51F0E83 /* Sessions.swift */; };
 		B6EDB4D02B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EDB4CF2B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift */; };
+		B6F338A32B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F338A22B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift */; };
 		BA0359CA2A51585D007C383B /* legacy_v3.sqlite in Resources */ = {isa = PBXBuildFile; fileRef = BA0359C92A51585D007C383B /* legacy_v3.sqlite */; };
 		BA0639F62A4DD491000F1CEE /* LegacyDatabaseStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA0639F52A4DD491000F1CEE /* LegacyDatabaseStorage.swift */; };
 		BA1EC0F42A9F2FC700C2D547 /* DefaultTrackingOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA1EC0F32A9F2FC700C2D547 /* DefaultTrackingOptionsTests.swift */; };
@@ -172,6 +173,7 @@
 		8EDECF8CF745F7339B65D6DB /* ObjCStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCStorage.swift; sourceTree = "<group>"; };
 		B6DF481F2B5B45BE00B3E6AA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B6EDB4CF2B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityCheckerPlugin.swift; sourceTree = "<group>"; };
+		B6F338A22B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityCheckerPluginTests.swift; sourceTree = "<group>"; };
 		BA0359C92A51585D007C383B /* legacy_v3.sqlite */ = {isa = PBXFileReference; lastKnownFileType = file; path = legacy_v3.sqlite; sourceTree = "<group>"; };
 		BA0639F52A4DD491000F1CEE /* LegacyDatabaseStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyDatabaseStorage.swift; sourceTree = "<group>"; };
 		BA1EC0F32A9F2FC700C2D547 /* DefaultTrackingOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTrackingOptionsTests.swift; sourceTree = "<group>"; };
@@ -310,6 +312,14 @@
 			path = Migration;
 			sourceTree = "<group>";
 		};
+		B6F3389F2B6854A8006179E2 /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				B6F338A22B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift */,
+			);
+			path = Plugins;
+			sourceTree = "<group>";
+		};
 		OBJ_13 /* Events */ = {
 			isa = PBXGroup;
 			children = (
@@ -424,6 +434,7 @@
 		OBJ_53 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				B6F3389F2B6854A8006179E2 /* Plugins */,
 				OBJ_54 /* AmplitudeTests.swift */,
 				OBJ_55 /* ConfigurationTests.swift */,
 				OBJ_56 /* ConsoleLoggerTests.swift */,
@@ -648,6 +659,7 @@
 				OBJ_153 /* TimelineTests.swift in Sources */,
 				OBJ_154 /* TypesTests.swift in Sources */,
 				OBJ_155 /* EventPipelineTests.swift in Sources */,
+				B6F338A32B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift in Sources */,
 				OBJ_156 /* HttpClientTests.swift in Sources */,
 				D01043612B6C5A8500F8173C /* SandboxHelperTests.swift in Sources */,
 				OBJ_157 /* PersistentStorageResponseHandlerTests.swift in Sources */,

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -53,6 +53,9 @@ public class Amplitude {
             state.userId = userId
         }
 
+        if self.configuration.offline != NetworkConnectivityCheckerPlugin.Disabled {
+            _ = add(plugin: NetworkConnectivityCheckerPlugin())
+        }
         // required plugin for specific platform, only has lifecyclePlugin now
         if let requiredPlugin = VendorSystem.current.requiredPlugin {
             _ = add(plugin: requiredPlugin)

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -33,6 +33,7 @@ public class Configuration {
     public var identifyBatchIntervalMillis: Int
     public internal(set) var migrateLegacyData: Bool
     public var defaultTracking: DefaultTrackingOptions
+    public var offline: Bool?
 
     public init(
         apiKey: String,
@@ -60,7 +61,8 @@ public class Configuration {
         // `trackingSessionEvents` has been replaced by `defaultTracking.sessions`
         defaultTracking: DefaultTrackingOptions = DefaultTrackingOptions(),
         identifyBatchIntervalMillis: Int = Constants.Configuration.IDENTIFY_BATCH_INTERVAL_MILLIS,
-        migrateLegacyData: Bool = true
+        migrateLegacyData: Bool = true,
+        offline: Bool = false
     ) {
         let normalizedInstanceName = instanceName == "" ? Constants.Configuration.DEFAULT_INSTANCE : instanceName
 
@@ -93,6 +95,7 @@ public class Configuration {
         self.migrateLegacyData = migrateLegacyData
         // Logging is OFF by default
         self.loggerProvider.logLevel = logLevel.rawValue
+        self.offline = offline
     }
 
     func isValid() -> Bool {

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -62,7 +62,7 @@ public class Configuration {
         defaultTracking: DefaultTrackingOptions = DefaultTrackingOptions(),
         identifyBatchIntervalMillis: Int = Constants.Configuration.IDENTIFY_BATCH_INTERVAL_MILLIS,
         migrateLegacyData: Bool = true,
-        offline: Bool = false
+        offline: Bool? = false
     ) {
         let normalizedInstanceName = instanceName == "" ? Constants.Configuration.DEFAULT_INSTANCE : instanceName
 

--- a/Sources/Amplitude/Mediator.swift
+++ b/Sources/Amplitude/Mediator.swift
@@ -15,7 +15,11 @@ internal class Mediator {
 
     internal func remove(plugin: Plugin) {
         plugins.removeAll { (storedPlugin) -> Bool in
-            return storedPlugin === plugin
+            if storedPlugin === plugin {
+                storedPlugin.teardown()
+                return true
+            }
+            return false
         }
     }
 

--- a/Sources/Amplitude/ObjC/ObjCConfiguration.swift
+++ b/Sources/Amplitude/ObjC/ObjCConfiguration.swift
@@ -272,4 +272,14 @@ public class ObjCConfiguration: NSObject {
             configuration.migrateLegacyData = value
         }
     }
+
+    @objc
+    public var offline: NSNumber? {
+        get {
+            return configuration.offline as NSNumber?
+        }
+        set(value) {
+            configuration.offline = value?.boolValue
+        }
+    }
 }

--- a/Sources/Amplitude/ObjC/ObjCNetworkConnectivityCheckerPlugin.swift
+++ b/Sources/Amplitude/ObjC/ObjCNetworkConnectivityCheckerPlugin.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+@objc(AMPNetworkConnectivityCheckerPlugin)
+public class ObjCNetworkConnectivityCheckerPlugin: NSObject {
+    @objc public static let Disabled: NSNumber? = nil
+}

--- a/Sources/Amplitude/Plugins/BasePlugins.swift
+++ b/Sources/Amplitude/Plugins/BasePlugins.swift
@@ -13,6 +13,10 @@ open class BasePlugin {
     open func execute(event: BaseEvent) -> BaseEvent? {
         return event
     }
+
+    public func teardown(){
+        // Clean up any resources from setup if necessary
+    }
 }
 
 open class BeforePlugin: BasePlugin, Plugin {

--- a/Sources/Amplitude/Plugins/NetworkConnectivityCheckerPlugin.swift
+++ b/Sources/Amplitude/Plugins/NetworkConnectivityCheckerPlugin.swift
@@ -59,6 +59,9 @@ open class NetworkConnectivityCheckerPlugin: BeforePlugin {
                 let isOnline = networkPath.status == .satisfied
                 self?.amplitude?.logger?.debug(message: "Network connectivity changed to \(isOnline ? "online" : "offline").")
                 self?.amplitude?.configuration.offline = !isOnline
+                if isOnline {
+                    amplitude.flush()
+                }
             })
     }
 

--- a/Sources/Amplitude/Plugins/NetworkConnectivityCheckerPlugin.swift
+++ b/Sources/Amplitude/Plugins/NetworkConnectivityCheckerPlugin.swift
@@ -56,10 +56,13 @@ open class NetworkConnectivityCheckerPlugin: BeforePlugin {
         pathCreation.start()
         pathUpdateCancellable = pathCreation.networkPathPublisher?
             .sink(receiveValue: { [weak self] networkPath in
-                let isOnline = networkPath.status == .satisfied
-                self?.amplitude?.logger?.debug(message: "Network connectivity changed to \(isOnline ? "online" : "offline").")
-                self?.amplitude?.configuration.offline = !isOnline
-                if isOnline {
+                let isOffline = !(networkPath.status == .satisfied)
+                if self?.amplitude?.configuration.offline == isOffline {
+                    return
+                }
+                self?.amplitude?.logger?.debug(message: "Network connectivity changed to \(isOffline ? "offline" : "online").")
+                self?.amplitude?.configuration.offline = isOffline
+                if !isOffline {
                     amplitude.flush()
                 }
             })

--- a/Sources/Amplitude/Plugins/NetworkConnectivityCheckerPlugin.swift
+++ b/Sources/Amplitude/Plugins/NetworkConnectivityCheckerPlugin.swift
@@ -12,7 +12,6 @@ open class NetworkConnectivityCheckerPlugin: BeforePlugin {
     public static let Disabled: Bool? = nil
     let monitor = NWPathMonitor()
 
-
     open override func setup(amplitude: Amplitude) {
         super.setup(amplitude: amplitude)
         self.amplitude?.logger?.debug(message: "Installing AndroidNetworkConnectivityPlugin, offline feature should be supported.")

--- a/Sources/Amplitude/Plugins/NetworkConnectivityCheckerPlugin.swift
+++ b/Sources/Amplitude/Plugins/NetworkConnectivityCheckerPlugin.swift
@@ -1,0 +1,40 @@
+//
+//  NetworkConnectivityCheckerPlugin.swift
+//  Amplitude-Swift
+//
+//  Created by Xinyi.Ye on 1/26/24.
+//
+
+import Foundation
+import Network
+
+open class NetworkConnectivityCheckerPlugin: BeforePlugin {
+    public static let Disabled: Bool? = nil
+    let monitor = NWPathMonitor()
+
+
+    open override func setup(amplitude: Amplitude) {
+        super.setup(amplitude: amplitude)
+        self.amplitude?.logger?.debug(message: "Installing AndroidNetworkConnectivityPlugin, offline feature should be supported.")
+
+        // Define handler for network changes
+        monitor.pathUpdateHandler = { path in
+            if path.status == .satisfied {
+                self.amplitude?.logger?.debug(message: "Network connectivity changed to online.")
+                self.amplitude?.configuration.offline = false
+            } else {
+                self.amplitude?.logger?.debug(message: "Network connectivity changed to offline.")
+                self.amplitude?.configuration.offline = true
+            }
+        }
+
+        // Start network monitor
+        let queue = DispatchQueue(label: "networkConnectivityChecker.amplitude.com")
+        monitor.start(queue: queue)
+    }
+
+    open override func teardown() {
+        monitor.cancel()
+    }
+
+}

--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -98,6 +98,7 @@ public protocol Plugin: AnyObject {
     var type: PluginType { get }
     func setup(amplitude: Amplitude)
     func execute(event: BaseEvent) -> BaseEvent?
+    func teardown()
 }
 
 public protocol EventPlugin: Plugin {
@@ -115,6 +116,10 @@ extension Plugin {
     }
 
     public func setup(amplitude: Amplitude) {
+    }
+
+    public func teardown(){
+        // Clean up any resources from setup if necessary
     }
 }
 

--- a/Sources/Amplitude/Utilities/EventPipeline.swift
+++ b/Sources/Amplitude/Utilities/EventPipeline.swift
@@ -49,7 +49,7 @@ public class EventPipeline {
             self.amplitude.logger?.debug(message: "Skipping flush while offline.")
             return
         }
-        
+
         amplitude.logger?.log(message: "Start flushing \(eventCount) events")
         eventCount = 0
         guard let storage = self.storage else { return }

--- a/Sources/Amplitude/Utilities/EventPipeline.swift
+++ b/Sources/Amplitude/Utilities/EventPipeline.swift
@@ -45,6 +45,11 @@ public class EventPipeline {
     }
 
     func flush(completion: (() -> Void)? = nil) {
+        if self.amplitude.configuration.offline == true {
+            self.amplitude.logger?.debug(message: "Skipping flush while offline.")
+            return
+        }
+        
         amplitude.logger?.log(message: "Start flushing \(eventCount) events")
         eventCount = 0
         guard let storage = self.storage else { return }

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -324,6 +324,10 @@ final class AmplitudeTests: XCTestCase {
         ])
     }
 
+    func testInit_Offline() {
+        XCTAssertEqual(Amplitude(configuration: configuration).configuration.offline, false)
+    }
+
     func getDictionary(_ props: [String: Any?]) -> NSDictionary {
         return NSDictionary(dictionary: props as [AnyHashable: Any])
     }

--- a/Tests/AmplitudeTests/Plugins/NetworkConnectivityCheckerPluginTests.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkConnectivityCheckerPluginTests.swift
@@ -1,0 +1,34 @@
+//
+//  NetworkConnectivityCheckerPluginTests.swift
+//  Amplitude-SwiftTests
+//
+//  Created by Xinyi.Ye on 1/29/24.
+//
+
+import XCTest
+
+@testable import AmplitudeSwift
+
+final class NetworkConnectivityCheckerPluginTests: XCTestCase {
+    private var mockPathCreation: MockPathCreation!
+    private var plugin: NetworkConnectivityCheckerPlugin!
+    private var amplitude: Amplitude!
+
+    override func setUp() {
+        super.setUp()
+        mockPathCreation = MockPathCreation()
+        amplitude = Amplitude(configuration: Configuration(apiKey: "test-api-key"))
+        plugin = NetworkConnectivityCheckerPlugin(pathCreation: mockPathCreation)
+        plugin.setup(amplitude: amplitude)
+    }
+
+    func testNetworkBecomesOnline() {
+        mockPathCreation.simulateNetworkChange(status: .satisfied)
+        XCTAssertEqual(amplitude.configuration.offline, false)
+    }
+
+    func testNetworkBecomesOffline() {
+        mockPathCreation.simulateNetworkChange(status: .unsatisfied)
+        XCTAssertEqual(amplitude.configuration.offline, true)
+    }
+}

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -1,5 +1,7 @@
 import Foundation
 import XCTest
+import Network
+import Combine
 
 @testable import AmplitudeSwift
 
@@ -258,5 +260,20 @@ class FakeSandboxHelperWithAppSandboxContainer: SandboxHelper {
 class FakePersistentStorageAppSandboxEnabled: PersistentStorage {
     override internal func isStorageSandboxed() -> Bool {
         return true
+    }
+}
+
+final class MockPathCreation: PathCreationProtocol {
+    var networkPathPublisher: AnyPublisher<NetworkPath, Never>?
+    private let subject = PassthroughSubject<NetworkPath, Never>()
+
+    func start() {
+        networkPathPublisher = subject.eraseToAnyPublisher()
+    }
+
+    // Method to simulate network change in tests
+    func simulateNetworkChange(status: NWPath.Status) {
+        let networkPath = NetworkPath(status: status)
+        subject.send(networkPath)
     }
 }

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -63,4 +63,18 @@ final class EventPipelineTests: XCTestCase {
         XCTAssertEqual(uploadedEvents?.count, 1)
         XCTAssertEqual(uploadedEvents![0].eventType, "testEvent")
     }
+
+    func testFlushWhenOffline() {
+        let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
+        try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
+
+        XCTAssertEqual(httpClient.uploadCount, 0)
+        XCTAssertEqual(pipeline.amplitude.configuration.offline, false)
+
+        pipeline.amplitude.configuration.offline = true
+        pipeline.flush()
+
+        XCTAssertEqual(pipeline.amplitude.configuration.offline, true)
+        XCTAssertEqual(httpClient.uploadCount, 0, "There should be no uploads when offline")
+    }
 }

--- a/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
+++ b/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
@@ -21,7 +21,8 @@ final class IdentifyInterceptorTests: XCTestCase {
             apiKey: "testApiKey",
             storageProvider: storage,
             identifyStorageProvider: identifyStorage,
-            identifyBatchIntervalMillis: identifyBatchIntervalMillis
+            identifyBatchIntervalMillis: identifyBatchIntervalMillis,
+            offline: NetworkConnectivityCheckerPlugin.Disabled
         )
         let amplitude = Amplitude(configuration: configuration)
         httpClient = FakeHttpClient(configuration: configuration)

--- a/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
+++ b/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
@@ -11,6 +11,7 @@ final class IdentifyInterceptorTests: XCTestCase {
     private var interceptor: TestIdentifyInterceptor!
     private var configuration: Configuration!
     private var pipeline: EventPipeline!
+    private var mockPathCreation: MockPathCreation!
 
     override func setUp() {
         super.setUp()
@@ -25,6 +26,8 @@ final class IdentifyInterceptorTests: XCTestCase {
             offline: NetworkConnectivityCheckerPlugin.Disabled
         )
         let amplitude = Amplitude(configuration: configuration)
+        mockPathCreation = MockPathCreation()
+        amplitude.add(plugin: NetworkConnectivityCheckerPlugin(pathCreation: mockPathCreation))
         httpClient = FakeHttpClient(configuration: configuration)
         pipeline = EventPipeline(amplitude: amplitude)
         pipeline.httpClient = httpClient


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

#### User interfaces

This feature is enabled by default. 

To opt out of using `NetworkConnectivityCheckerPlugin` and implement custom offline logic, setting `config.offline` to `NetworkConnectivityCheckerPlugin.Disabled` will prevent the plugin from installing. 

```
var testInstance = Amplitude(
    configuration: Configuration(
        apiKey: "API_KEY",
        offline: NetworkConnectivityCheckerPlugin.Disabled
    )
)
```

#### Tests
Tests to toggling network connection are based on https://amplitude.atlassian.net/wiki/spaces/GOV/pages/2319024851/Mock+network+changes.

#### Note
Note that simulators don't accurately reflect network changes of Mac ([example](https://stackoverflow.com/questions/57223756/nwpathmonitor-not-calling-satisfied-in-swift)). So test it on a real device.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
