### PR TITLE
fix: migrate storage to instanceName-apiKey to isolate by instance

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -41,6 +41,7 @@ public class Amplitude {
 
         migrateApiKeyStorages()
         migrateDefaultInstanceStorages()
+        migrateInstanceOnlyStorages()
 
         if configuration.migrateLegacyData {
             RemnantDataMigration(self).execute()
@@ -359,6 +360,22 @@ public class Amplitude {
         if let persistentIdentifyStorage = configuration.identifyStorageProvider as? PersistentStorage {
             let legacyIdentifyStorage = PersistentStorage(storagePrefix: "identify-\(legacyDefaultInstanceName)")
             StoragePrefixMigration(source: legacyIdentifyStorage, destination: persistentIdentifyStorage, logger: logger).execute()
+        }
+    }
+    
+    private func migrateInstanceOnlyStorages() {
+        let instanceName = configuration.getNormalizeInstanceName()
+        
+        if let persistentStorage = configuration.storageProvider as? PersistentStorage {
+            let instanceOnlyEventPrefix = "\(PersistentStorage.DEFAULT_STORAGE_PREFIX)-storage-\(instanceName)"
+            let instanceNameOnlyStorage = PersistentStorage(storagePrefix: instanceOnlyEventPrefix)
+            StoragePrefixMigration(source: instanceNameOnlyStorage, destination: persistentStorage, logger: logger).execute()
+        }
+
+        if let persistentIdentifyStorage = configuration.identifyStorageProvider as? PersistentStorage {
+            let instanceOnlyIdentifyPrefix = "\(PersistentStorage.DEFAULT_STORAGE_PREFIX)-identify-\(instanceName)"
+            let instanceNameOnlyIdentifyStorage = PersistentStorage(storagePrefix: instanceOnlyIdentifyPrefix)
+            StoragePrefixMigration(source: instanceNameOnlyIdentifyStorage, destination: persistentIdentifyStorage, logger: logger).execute()
         }
     }
 }

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -364,11 +364,11 @@ public class Amplitude {
     }
 
     private func migrateInstanceOnlyStorages() {
-        // Only migrate sandboxed apps to avoid potential data polution
+        // Only migrate sandboxed apps to avoid potential data pollution
         if (!SandboxHelper().isSandboxEnabled()) {
             return;
         }
-        
+
         let instanceName = configuration.getNormalizeInstanceName()
         if let persistentStorage = configuration.storageProvider as? PersistentStorage {
             let instanceOnlyEventPrefix = "\(PersistentStorage.DEFAULT_STORAGE_PREFIX)-storage-\(instanceName)"

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -41,7 +41,7 @@ public class Amplitude {
 
         migrateApiKeyStorages()
         migrateDefaultInstanceStorages()
-        if configuration.migrateLegacyData && getStorageVersion() < .INSTANCE_NAME_AND_API_KEY {
+        if configuration.migrateLegacyData && getStorageVersion() < .API_KEY_AND_INSTANCE_NAME {
             RemnantDataMigration(self).execute()
         }
         migrateInstanceOnlyStorages()
@@ -374,7 +374,7 @@ public class Amplitude {
     }
 
     private func migrateInstanceOnlyStorages() {
-        if getStorageVersion() >= .INSTANCE_NAME_AND_API_KEY {
+        if getStorageVersion() >= .API_KEY_AND_INSTANCE_NAME {
             return
         }
         configuration.loggerProvider.error(message: "Running migrateInstanceOnlyStorages")
@@ -401,9 +401,9 @@ public class Amplitude {
             // Store the current storage version
             try configuration.storageProvider.write(
                 key: .STORAGE_VERSION,
-                value: PersistentStorageVersion.INSTANCE_NAME_AND_API_KEY.rawValue as Int
+                value: PersistentStorageVersion.API_KEY_AND_INSTANCE_NAME.rawValue as Int
             )
-            configuration.loggerProvider.debug(message: "Updated STORAGE_VERSION to .INSTANCE_NAME_AND_API_KEY")
+            configuration.loggerProvider.debug(message: "Updated STORAGE_VERSION to .API_KEY_AND_INSTANCE_NAME")
         } catch {
             configuration.loggerProvider.error(message: "Unable to set STORAGE_VERSION in storageProvider during migration")
         }

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -41,7 +41,7 @@ public class Amplitude {
 
         migrateApiKeyStorages()
         migrateDefaultInstanceStorages()
-        if (configuration.migrateLegacyData && getStorageVersion() < .INSTANCE_NAME_AND_API_KEY) {
+        if configuration.migrateLegacyData && getStorageVersion() < .INSTANCE_NAME_AND_API_KEY {
             RemnantDataMigration(self).execute()
         }
         migrateInstanceOnlyStorages()
@@ -340,8 +340,8 @@ public class Amplitude {
     }
 
     private func migrateApiKeyStorages() {
-        if (getStorageVersion() >= PersistentStorageVersion.API_KEY) {
-            return;
+        if getStorageVersion() >= PersistentStorageVersion.API_KEY {
+            return
         }
         configuration.loggerProvider.error(message: "Running migrateApiKeyStorages")
         if let persistentStorage = configuration.storageProvider as? PersistentStorage {
@@ -356,8 +356,8 @@ public class Amplitude {
     }
 
     private func migrateDefaultInstanceStorages() {
-        if (getStorageVersion() >= PersistentStorageVersion.INSTANCE_NAME ||
-            configuration.instanceName != Constants.Configuration.DEFAULT_INSTANCE) {
+        if getStorageVersion() >= PersistentStorageVersion.INSTANCE_NAME ||
+            configuration.instanceName != Constants.Configuration.DEFAULT_INSTANCE {
             return
         }
         configuration.loggerProvider.error(message: "Running migrateDefaultInstanceStorages")
@@ -374,13 +374,13 @@ public class Amplitude {
     }
 
     private func migrateInstanceOnlyStorages() {
-        if (getStorageVersion() >= .INSTANCE_NAME_AND_API_KEY) {
-            return;
+        if getStorageVersion() >= .INSTANCE_NAME_AND_API_KEY {
+            return
         }
         configuration.loggerProvider.error(message: "Running migrateInstanceOnlyStorages")
 
         // Only migrate sandboxed apps to avoid potential data pollution
-        if (SandboxHelper().isSandboxEnabled()) {
+        if SandboxHelper().isSandboxEnabled() {
             let instanceName = configuration.getNormalizeInstanceName()
             if let persistentStorage = configuration.storageProvider as? PersistentStorage {
                 let instanceOnlyEventPrefix = "\(PersistentStorage.DEFAULT_STORAGE_PREFIX)-storage-\(instanceName)"

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -362,10 +362,14 @@ public class Amplitude {
             StoragePrefixMigration(source: legacyIdentifyStorage, destination: persistentIdentifyStorage, logger: logger).execute()
         }
     }
-    
+
     private func migrateInstanceOnlyStorages() {
-        let instanceName = configuration.getNormalizeInstanceName()
+        // Only migrate sandboxed apps to avoid potential data polution
+        if (!SandboxHelper().isSandboxEnabled()) {
+            return;
+        }
         
+        let instanceName = configuration.getNormalizeInstanceName()
         if let persistentStorage = configuration.storageProvider as? PersistentStorage {
             let instanceOnlyEventPrefix = "\(PersistentStorage.DEFAULT_STORAGE_PREFIX)-storage-\(instanceName)"
             let instanceNameOnlyStorage = PersistentStorage(storagePrefix: instanceOnlyEventPrefix)

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -388,14 +388,14 @@ public class Amplitude {
         if skipEventMigration {
             configuration.loggerProvider.debug(message: "Skipping event migration in non-sandboxed app. Transfering UserDefaults only.")
         }
-        
+
         let instanceName = configuration.getNormalizeInstanceName()
         if let persistentStorage = configuration.storageProvider as? PersistentStorage {
             let instanceOnlyEventPrefix = "\(PersistentStorage.DEFAULT_STORAGE_PREFIX)-storage-\(instanceName)"
             let instanceNameOnlyStorage = PersistentStorage(storagePrefix: instanceOnlyEventPrefix)
             StoragePrefixMigration(
                 source: instanceNameOnlyStorage,
-                destination: persistentStorage, 
+                destination: persistentStorage,
                 logger: logger
             ).execute(skipEventFiles: skipEventMigration)
         }
@@ -421,8 +421,8 @@ public class Amplitude {
             configuration.loggerProvider.error(message: "Unable to set STORAGE_VERSION in storageProvider during migration")
         }
     }
-    
+
     internal func isSandboxEnabled() -> Bool {
-        return SandboxHelper().isSandboxEnabled();
+        return SandboxHelper().isSandboxEnabled()
     }
 }

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -62,7 +62,7 @@ public class Configuration {
         identifyBatchIntervalMillis: Int = Constants.Configuration.IDENTIFY_BATCH_INTERVAL_MILLIS,
         migrateLegacyData: Bool = true
     ) {
-        let normalizedInstanceName = getNormalizeInstanceName()
+        let normalizedInstanceName = Configuration.getNormalizeInstanceName(instanceName)
 
         self.apiKey = apiKey
         self.flushQueueSize = flushQueueSize
@@ -100,8 +100,12 @@ public class Configuration {
             && minTimeBetweenSessionsMillis > 0
             && (minIdLength == nil || minIdLength! > 0)
     }
+
+    private class func getNormalizeInstanceName(_ instanceName: String) -> String {
+        return instanceName == "" ? Constants.Configuration.DEFAULT_INSTANCE : instanceName
+    }
     
     internal func getNormalizeInstanceName() -> String {
-        return self.instanceName == "" ? Constants.Configuration.DEFAULT_INSTANCE : self.instanceName
+        return Configuration.getNormalizeInstanceName(self.instanceName)
     }
 }

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -104,7 +104,7 @@ public class Configuration {
     private class func getNormalizeInstanceName(_ instanceName: String) -> String {
         return instanceName == "" ? Constants.Configuration.DEFAULT_INSTANCE : instanceName
     }
-    
+
     internal func getNormalizeInstanceName() -> String {
         return Configuration.getNormalizeInstanceName(self.instanceName)
     }

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -62,7 +62,7 @@ public class Configuration {
         identifyBatchIntervalMillis: Int = Constants.Configuration.IDENTIFY_BATCH_INTERVAL_MILLIS,
         migrateLegacyData: Bool = true
     ) {
-        let normalizedInstanceName = instanceName == "" ? Constants.Configuration.DEFAULT_INSTANCE : instanceName
+        let normalizedInstanceName = getNormalizeInstanceName()
 
         self.apiKey = apiKey
         self.flushQueueSize = flushQueueSize
@@ -70,9 +70,9 @@ public class Configuration {
         self.instanceName = normalizedInstanceName
         self.optOut = optOut
         self.storageProvider = storageProvider
-            ?? PersistentStorage(storagePrefix: "storage-\(normalizedInstanceName)")
+            ?? PersistentStorage(storagePrefix: PersistentStorage.getEventStoragePrefix(apiKey, normalizedInstanceName))
         self.identifyStorageProvider = identifyStorageProvider
-            ?? PersistentStorage(storagePrefix: "identify-\(normalizedInstanceName)")
+            ?? PersistentStorage(storagePrefix: PersistentStorage.getIdentifyStoragePrefix(apiKey, normalizedInstanceName))
         self.logLevel = logLevel
         self.loggerProvider = loggerProvider
         self.minIdLength = minIdLength
@@ -99,5 +99,9 @@ public class Configuration {
         return !apiKey.isEmpty && flushQueueSize > 0 && flushIntervalMillis > 0
             && minTimeBetweenSessionsMillis > 0
             && (minIdLength == nil || minIdLength! > 0)
+    }
+    
+    internal func getNormalizeInstanceName() -> String {
+        return self.instanceName == "" ? Constants.Configuration.DEFAULT_INSTANCE : self.instanceName
     }
 }

--- a/Sources/Amplitude/Migration/StoragePrefixMigration.swift
+++ b/Sources/Amplitude/Migration/StoragePrefixMigration.swift
@@ -11,12 +11,15 @@ class StoragePrefixMigration {
         self.logger = logger
     }
 
-    func execute() {
+    func execute(skipEventFiles: Bool = false) {
         if source.storagePrefix == destination.storagePrefix {
             return
         }
 
-        moveSourceEventFilesToDestination()
+        if (!skipEventFiles) {
+            moveSourceEventFilesToDestination()
+        }
+        
         moveUserDefaults()
     }
 

--- a/Sources/Amplitude/Migration/StoragePrefixMigration.swift
+++ b/Sources/Amplitude/Migration/StoragePrefixMigration.swift
@@ -16,10 +16,10 @@ class StoragePrefixMigration {
             return
         }
 
-        if (!skipEventFiles) {
+        if !skipEventFiles {
             moveSourceEventFilesToDestination()
         }
-        
+
         moveUserDefaults()
     }
 

--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -11,11 +11,11 @@ class PersistentStorage: Storage {
     typealias EventBlock = URL
 
     static internal func getEventStoragePrefix(_ apiKey: String, _ instanceName: String) -> String {
-        return "storage-\(instanceName)-\(apiKey)"
+        return "storage-\(apiKey)-\(instanceName)"
     }
 
     static internal func getIdentifyStoragePrefix(_ apiKey: String, _ instanceName: String) -> String {
-        return "identify-\(instanceName)-\(apiKey)"
+        return "identify-\(apiKey)-\(instanceName)"
     }
 
     let storagePrefix: String

--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -13,11 +13,11 @@ class PersistentStorage: Storage {
     static internal func getEventStoragePrefix(_ apiKey: String, _ instanceName: String) -> String {
         return "storage-\(instanceName)-\(apiKey)"
     }
-    
+
     static internal func getIdentifyStoragePrefix(_ apiKey: String, _ instanceName: String) -> String {
         return "identify-\(instanceName)-\(apiKey)"
     }
-    
+
     let storagePrefix: String
     let userDefaults: UserDefaults?
     let fileManager: FileManager

--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -10,6 +10,14 @@ import Foundation
 class PersistentStorage: Storage {
     typealias EventBlock = URL
 
+    static internal func getEventStoragePrefix(_ apiKey: String, _ instanceName: String) -> String {
+        return "storage-\(instanceName)-\(apiKey)"
+    }
+    
+    static internal func getIdentifyStoragePrefix(_ apiKey: String, _ instanceName: String) -> String {
+        return "identify-\(instanceName)-\(apiKey)"
+    }
+    
     let storagePrefix: String
     let userDefaults: UserDefaults?
     let fileManager: FileManager

--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -76,7 +76,7 @@ public enum StorageKey: String, CaseIterable {
     case APP_VERSION = "app_version"
     // The version of PersistentStorage, used for data migrations
     // Value should be a PersistentStorageVersion value
-    // Note the first version is 2, which corresponds to instanceName-apiKey based storage
+    // Note the first version is 2, which corresponds to apiKey-instanceName based storage
     case STORAGE_VERSION = "storage_version"
 }
 

--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -90,7 +90,7 @@ public enum PersistentStorageVersion: Int, Comparable {
     case API_KEY = 0
     case INSTANCE_NAME = 1
     // This is the first version (2) we set a value in storageProvider.read(.StorageVersion)
-    case INSTANCE_NAME_AND_API_KEY = 2
+    case API_KEY_AND_INSTANCE_NAME = 2
 }
 
 public protocol Logger {

--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -74,6 +74,23 @@ public enum StorageKey: String, CaseIterable {
     case DEVICE_ID = "device_id"
     case APP_BUILD = "app_build"
     case APP_VERSION = "app_version"
+    // The version of PersistentStorage, used for data migrations
+    // Value should be a PersistentStorageVersion value
+    // Note the first version is 2, which corresponds to instanceName-apiKey based storage
+    case STORAGE_VERSION = "storage_version"
+}
+
+public enum PersistentStorageVersion: Int, Comparable {
+    public static func < (lhs: PersistentStorageVersion, rhs: PersistentStorageVersion) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+    
+    case NO_VERSION = -1
+    // Note that versioning was added after these storage changes (0, 1)
+    case API_KEY = 0
+    case INSTANCE_NAME = 1
+    // This is the first version (2) we set a value in storageProvider.read(.StorageVersion)
+    case INSTANCE_NAME_AND_API_KEY = 2
 }
 
 public protocol Logger {

--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -84,7 +84,7 @@ public enum PersistentStorageVersion: Int, Comparable {
     public static func < (lhs: PersistentStorageVersion, rhs: PersistentStorageVersion) -> Bool {
         return lhs.rawValue < rhs.rawValue
     }
-    
+
     case NO_VERSION = -1
     // Note that versioning was added after these storage changes (0, 1)
     case API_KEY = 0

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -325,7 +325,7 @@ final class AmplitudeTests: XCTestCase {
     }
 
     func testMigrationToApiKeyAndInstanceNameStorage() throws {
-        let legacyUserId = "legacy-user-id";
+        let legacyUserId = "legacy-user-id"
         let config = Configuration(
             apiKey: "amp-migration-api-key",
             // don't transfer any events
@@ -341,7 +341,7 @@ final class AmplitudeTests: XCTestCase {
 
         print("Creating legacy Amplitude instance")
         // Init Amplitude using legacy storage
-        let legacyStorageAmplitude = FakeAmplitudeWithNoApiAndInstanceNameMigration(configuration: Configuration(
+        let legacyStorageAmplitude = FakeAmplitudeWithNoInstNameOnlyMigration(configuration: Configuration(
             apiKey: config.apiKey,
             flushQueueSize: config.flushQueueSize,
             flushIntervalMillis: config.flushIntervalMillis,
@@ -410,7 +410,7 @@ final class AmplitudeTests: XCTestCase {
 
     #if os(macOS)
     func testMigrationToApiKeyAndInstanceNameStorageMacSandboxEnabled() throws {
-        let legacyUserId = "legacy-user-id";
+        let legacyUserId = "legacy-user-id"
         let config = Configuration(
             apiKey: "amp-mac-migration-api-key",
             // don't transfer any events
@@ -426,7 +426,7 @@ final class AmplitudeTests: XCTestCase {
 
         print("Creating legacy Amplitude instance")
         // Init Amplitude using legacy storage
-        let legacyStorageAmplitude = FakeAmplitudeWithNoApiAndInstanceNameMigration(configuration: Configuration(
+        let legacyStorageAmplitude = FakeAmplitudeWithNoInstNameOnlyMigration(configuration: Configuration(
             apiKey: config.apiKey,
             flushQueueSize: config.flushQueueSize,
             flushIntervalMillis: config.flushIntervalMillis,

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -339,7 +339,6 @@ final class AmplitudeTests: XCTestCase {
         let legacyEventStorage = PersistentStorage(storagePrefix: "storage-\(config.getNormalizeInstanceName())")
         let legacyIdentityStorage = PersistentStorage(storagePrefix: "identify-\(config.getNormalizeInstanceName())")
 
-        print("Creating legacy Amplitude instance")
         // Init Amplitude using legacy storage
         let legacyStorageAmplitude = FakeAmplitudeWithNoInstNameOnlyMigration(configuration: Configuration(
             apiKey: config.apiKey,
@@ -366,7 +365,6 @@ final class AmplitudeTests: XCTestCase {
         var legacyEventsString = ""
         legacyEventFiles?.forEach { file in
             legacyEventsString = legacyEventStorage.getEventsString(eventBlock: file) ?? ""
-            print(legacyEventsString)
         }
 
         XCTAssertEqual(legacyEventFiles?.count ?? 0, 1)
@@ -380,7 +378,6 @@ final class AmplitudeTests: XCTestCase {
         var eventsString = ""
         eventFiles?.forEach { file in
             eventsString = legacyEventStorage.getEventsString(eventBlock: file) ?? ""
-            print(eventsString)
         }
 
         XCTAssertEqual(legacyDeviceId != nil, true)
@@ -424,7 +421,6 @@ final class AmplitudeTests: XCTestCase {
         let legacyEventStorage = FakePersistentStorageAppSandboxEnabled(storagePrefix: "storage-\(config.getNormalizeInstanceName())")
         let legacyIdentityStorage = FakePersistentStorageAppSandboxEnabled(storagePrefix: "identify-\(config.getNormalizeInstanceName())")
 
-        print("Creating legacy Amplitude instance")
         // Init Amplitude using legacy storage
         let legacyStorageAmplitude = FakeAmplitudeWithNoInstNameOnlyMigration(configuration: Configuration(
             apiKey: config.apiKey,
@@ -451,7 +447,6 @@ final class AmplitudeTests: XCTestCase {
         var legacyEventsString = ""
         legacyEventFiles?.forEach { file in
             legacyEventsString = legacyEventStorage.getEventsString(eventBlock: file) ?? ""
-            print(legacyEventsString)
         }
 
         XCTAssertEqual(legacyEventFiles?.count ?? 0, 1)
@@ -465,7 +460,6 @@ final class AmplitudeTests: XCTestCase {
         var eventsString = ""
         eventFiles?.forEach { file in
             eventsString = legacyEventStorage.getEventsString(eventBlock: file) ?? ""
-            print(eventsString)
         }
 
         XCTAssertEqual(legacyDeviceId != nil, true)

--- a/Tests/AmplitudeTests/ConfigurationTests.swift
+++ b/Tests/AmplitudeTests/ConfigurationTests.swift
@@ -47,4 +47,45 @@ final class ConfigurationTests: XCTestCase {
         configuration = Configuration(apiKey: apiKey, minIdLength: 0)
         XCTAssertFalse(configuration.isValid())
     }
+
+    func testStorageByApiKeyAndInstanceName() throws {
+        let configuration = Configuration(apiKey: "migration-api-key")
+
+        let expectedStoragePostfix = "\(configuration.apiKey)-\(configuration.getNormalizeInstanceName())"
+
+        let eventsStorage = configuration.storageProvider as? PersistentStorage
+        let eventStorageUrl = eventsStorage != nil
+            ? eventsStorage?.getEventsStorageDirectory(createDirectory: false).absoluteString
+            : ""
+
+        let identifyStorage = configuration.storageProvider as? PersistentStorage
+        let identifyStorageUrl = identifyStorage != nil
+        ? identifyStorage?.getEventsStorageDirectory(createDirectory: false).absoluteString
+            : ""
+
+        XCTAssertTrue(eventStorageUrl?.contains(expectedStoragePostfix) ?? false)
+        XCTAssertTrue(identifyStorageUrl?.contains(expectedStoragePostfix) ?? false)
+    }
+
+    func testStorageByApiKeyAndInstanceNameWithCustomInstanceName() throws {
+        let configuration = Configuration(
+            apiKey: "migration-api-key",
+            instanceName: "test-instance"
+        )
+
+        let expectedStoragePostfix = "\(configuration.apiKey)-\(configuration.getNormalizeInstanceName())"
+
+        let eventsStorage = configuration.storageProvider as? PersistentStorage
+        let eventStorageUrl = eventsStorage != nil
+            ? eventsStorage?.getEventsStorageDirectory(createDirectory: false).absoluteString
+            : ""
+
+        let identifyStorage = configuration.storageProvider as? PersistentStorage
+        let identifyStorageUrl = identifyStorage != nil
+        ? identifyStorage?.getEventsStorageDirectory(createDirectory: false).absoluteString
+            : ""
+
+        XCTAssertTrue(eventStorageUrl?.contains(expectedStoragePostfix) ?? false)
+        XCTAssertTrue(identifyStorageUrl?.contains(expectedStoragePostfix) ?? false)
+    }
 }

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -260,3 +260,15 @@ class FakePersistentStorageAppSandboxEnabled: PersistentStorage {
         return true
     }
 }
+
+class FakeAmplitudeWithNoApiAndInstanceNameMigration: Amplitude {
+    override func migrateInstanceOnlyStorages() {
+        // do nothing
+    }
+}
+
+class FakeAmplitudeWithSandboxEnabled: Amplitude {
+    override internal func isSandboxEnabled() -> Bool {
+        return true
+    }
+}

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -263,8 +263,7 @@ class FakePersistentStorageAppSandboxEnabled: PersistentStorage {
     }
 }
 
-
-class FakeAmplitudeWithNoApiAndInstanceNameMigration: Amplitude {
+class FakeAmplitudeWithNoInstNameOnlyMigration: Amplitude {
     override func migrateInstanceOnlyStorages() {
         // do nothing
     }


### PR DESCRIPTION
### Summary

* Storage prefix now includes both **apiKey** and **instanceName** to prevent unintended data sharing
* Added migration to migrate legacy storage to new format
* Only migrate events in sandboxed apps to prevent data pollution across orgs
* Always migrate UserDefaults (deviceId, userId, etc) - these seem to be always sandboxed
* Added STORAGE_VERSION to UserDefaults to prevent duplicate migrations
* Added tests

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
