### PR TITLE
fix: setOnce operation name

### DIFF
--- a/Sources/Amplitude/Events/Identify.swift
+++ b/Sources/Amplitude/Events/Identify.swift
@@ -12,7 +12,7 @@ open class Identify {
 
     enum Operation: String {
         case SET = "$set"
-        case SET_ONCE = "$set_once"
+        case SET_ONCE = "$setOnce"
         case ADD = "$add"
         case APPEND = "$append"
         case CLEAR_ALL = "$clearAll"


### PR DESCRIPTION
### Summary

* Fix setOnce operation name in code so it is handled correctly by Amplitude

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
