### PR TITLE
fix: fix setOnce identify operation

### DIFF
--- a/Examples/AmplitudeObjCExample/AmplitudeObjCExampleTests/AmplitudeObjCExampleTests.m
+++ b/Examples/AmplitudeObjCExample/AmplitudeObjCExampleTests/AmplitudeObjCExampleTests.m
@@ -66,7 +66,7 @@
     
     NSDictionary* expectedUserProperties = @{
         @"$set": @{@"user-string-prop": @"string-value"},
-        @"$set_once": @{@"user-int-prop": @111},
+        @"$setOnce": @{@"user-int-prop": @111},
         @"$append": @{@"user-number-prop": @123.4},
         @"$prepend": @{@"user-bool-prop": @true},
         @"$add": @{@"user-sum-prop": @7},
@@ -142,7 +142,7 @@
     
     NSDictionary* expectedGroupProperties = @{
         @"$set": @{@"user-string-prop": @"string-value"},
-        @"$set_once": @{@"user-int-prop": @111},
+        @"$setOnce": @{@"user-int-prop": @111},
         @"$append": @{@"user-number-prop": @123.4},
         @"$prepend": @{@"user-bool-prop": @true},
         @"$add": @{@"user-sum-prop": @7},

--- a/Sources/Amplitude/Events/Identify.swift
+++ b/Sources/Amplitude/Events/Identify.swift
@@ -12,7 +12,7 @@ open class Identify {
 
     enum Operation: String {
         case SET = "$set"
-        case SET_ONCE = "$set_once"
+        case SET_ONCE = "$setOnce"
         case ADD = "$add"
         case APPEND = "$append"
         case CLEAR_ALL = "$clearAll"


### PR DESCRIPTION
### Summary
- Same fix as in https://github.com/amplitude/Amplitude-Swift/pull/116 with unit test fix

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
