### PR TITLE
perf: Use a single DateFormatter in HttpClient

### DIFF
--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -10,6 +10,12 @@ import Foundation
 class HttpClient {
     let configuration: Configuration
     internal let session: URLSession
+    
+    private lazy var dateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions.insert(.withFractionalSeconds)
+        return formatter
+    }()
 
     init(configuration: Configuration) {
         self.configuration = configuration
@@ -72,9 +78,7 @@ class HttpClient {
 
     func getRequestData(events: String) -> Data? {
         let apiKey = configuration.apiKey
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions.insert(.withFractionalSeconds)
-        let clientUploadTime: String = formatter.string(from: getDate())
+        let clientUploadTime: String = dateFormatter.string(from: getDate())
         var requestPayload = """
             {"api_key":"\(apiKey)","client_upload_time":"\(clientUploadTime)","events":\(events)
             """


### PR DESCRIPTION
### Summary

This is a slight performance improvement to initialise and use a single `DateFormatter` rather than recreating it whenever `getRequestData` is called. The initialization of `DateFormatter` can be quite constly on Apple platforms and should ideally be reused if the formatting is unchanged.

Here's an example screenshot we see from our Sentry performance logging:

<img width="794" alt="Screenshot 2024-02-28 at 10 48 08" src="https://github.com/amplitude/Amplitude-Swift/assets/4714866/3cd85a9a-1c08-4c80-ae15-8ebf9be5afc0">


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
