### PR TITLE
fix: Don't use idfv as deviceID if disabled

### DIFF
--- a/Sources/Amplitude/Plugins/ContextPlugin.swift
+++ b/Sources/Amplitude/Plugins/ContextPlugin.swift
@@ -160,13 +160,13 @@ class ContextPlugin: BeforePlugin {
         if isValidDeviceId(deviceId) {
             return
         }
-        if deviceId == nil {
+        if deviceId == nil, amplitude?.configuration.trackingOptions.shouldTrackIDFV() ?? false {
             deviceId = staticContext["idfv"] as? String
         }
         if deviceId == nil {
             deviceId = NSUUID().uuidString
         }
-        _ = amplitude?.setDeviceId(deviceId: deviceId)
+        amplitude?.setDeviceId(deviceId: deviceId)
     }
 
     func isValidDeviceId(_ deviceId: String?) -> Bool {

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -141,6 +141,17 @@ final class AmplitudeTests: XCTestCase {
         XCTAssertNil(lastEvent?.country)
     }
 
+    func testDeviceIdWithDisableIDFV() {
+        let configuration = Configuration(
+            apiKey: "testApiKeyDeviceIDWithDisableIDFV",
+            storageProvider: storage,
+            trackingOptions: TrackingOptions().disableTrackIDFV())
+
+        let amplitude = Amplitude(configuration: configuration)
+
+        XCTAssertNotEqual(amplitude.getDeviceId(), VendorSystem.current.identifierForVendor)
+    }
+
     func testSetUserId() {
         let amplitude = Amplitude(configuration: configurationWithFakeStorage)
         XCTAssertEqual(amplitude.getUserId(), nil)


### PR DESCRIPTION
### Summary

Fix for https://github.com/amplitude/Amplitude-Swift/issues/107. Note that users that have an existing deviceID set from IDFV will maintain their current deviceID.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
