### PR TITLE
fix: tests on iOS 17

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   lint:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set Xcode 14
+      - name: Set Xcode 15
         run: |
-          sudo xcode-select -switch /Applications/Xcode_14.1.app
+          sudo xcode-select -switch /Applications/Xcode_15.2.app
       - name: Lint
         run: swiftlint --strict # force to fix warnings too

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   authorize:
     name: Authorize
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: ${{ github.actor }} permission check to do a release
         uses: octokit/request-action@v2.1.9
@@ -23,20 +23,20 @@ jobs:
 
   release:
     name: Release
-    runs-on: macos-12
+    runs-on: macos-13
     needs: [authorize]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set Xcode 14
+      - name: Set Xcode 15
         run: |
-          sudo xcode-select -switch /Applications/Xcode_14.1.app
+          sudo xcode-select -switch /Applications/Xcode_15.2.app
       - name: iOS Tests
         run: |
           xcodebuild test \
             -scheme Amplitude-Swift-Package \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 14'
+            -destination 'platform=iOS Simulator,name=iPhone 15'
       - name: macOS Tests
         run: |
           xcodebuild test \
@@ -63,7 +63,7 @@ jobs:
           xcodebuild test \
             -scheme AmplitudeObjCExample \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 14'
+            -destination 'platform=iOS Simulator,name=iPhone 15'
 
       - name: Validate Podfile
         run: pod lib lint --allow-warnings

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,13 +9,13 @@ on:
 
 jobs:
   test:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set Xcode 14
+      - name: Set Xcode 15
         run: |
-          sudo xcode-select -switch /Applications/Xcode_14.1.app
+          sudo xcode-select -switch /Applications/Xcode_15.2.app
       - name: List Simulators
         run: |
           xcrun simctl list
@@ -27,7 +27,7 @@ jobs:
           xcodebuild test \
             -scheme Amplitude-Swift-Package \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 14'
+            -destination 'platform=iOS Simulator,name=iPhone 15'
       - name: macOS Tests
         run: |
           xcodebuild test \
@@ -54,4 +54,4 @@ jobs:
           xcodebuild test \
             -scheme AmplitudeObjCExample \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 14'
+            -destination 'platform=iOS Simulator,name=iPhone 15'

--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */

--- a/Sources/Amplitude/Events/BaseEvent.swift
+++ b/Sources/Amplitude/Events/BaseEvent.swift
@@ -246,6 +246,7 @@ extension BaseEvent {
         var returnString = ""
         do {
             let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
             let json = try encoder.encode(self)
             if let printed = String(data: json, encoding: .utf8) {
                 returnString = printed

--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -502,6 +502,7 @@ extension PersistentStorage {
         var result = ""
         do {
             let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
             let json = try encoder.encode(events)
             if let printed = String(data: json, encoding: .utf8) {
                 result = printed

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -68,7 +68,15 @@ class HttpClient {
 
     func getRequest() throws -> URLRequest {
         let url = getUrl()
-        guard let requestUrl = URL(string: url) else {
+
+        let requestUrl: URL?
+        if #available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *) {
+            requestUrl = URL(string: url, encodingInvalidCharacters: false)
+        } else {
+            requestUrl = URL(string: url)
+        }
+
+        guard let requestUrl else {
             throw Exception.invalidUrl(url: url)
         }
         var request = URLRequest(url: requestUrl, timeoutInterval: 60)

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -87,10 +87,10 @@ final class AmplitudeTests: XCTestCase {
     func testFilterAndEnrichmentPlugin() {
         let apiKey = "testFilterAndEnrichmentPlugin"
         let enrichedEventType = "Enriched Event"
-        storageTest = TestPersistentStorage(storagePrefix: "storage-\(apiKey)", logger: self.logger, diagonostics: self.diagonostics)
+        let storage = FakeInMemoryStorage()
         let amplitude = Amplitude(configuration: Configuration(
             apiKey: apiKey,
-            storageProvider: storageTest
+            storageProvider: storage
         ))
 
         class TestFilterAndEnrichmentPlugin: EnrichmentPlugin {
@@ -110,7 +110,7 @@ final class AmplitudeTests: XCTestCase {
         amplitude.track(event: BaseEvent(eventType: enrichedEventType))
         amplitude.track(event: BaseEvent(eventType: "Other Event"))
 
-        let events = storageTest.events()
+        let events = storage.events()
         XCTAssertEqual(events[0].eventType, enrichedEventType)
         XCTAssertEqual(getDictionary(events[0].eventProperties!), [
             "testPropertyKey": "testPropertyValue"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This updated CI to run on the latest versions of MacOS/Xcode.

Running the tests locally with the latest Xcode results in a few failures, so I've fixed the following:
- Use sorted key output for JSON, as iOS 17+ uses a more secure dictionary type that randomizes key order
- Use strict URL parsing as the `URL(string:)` default behavior has changed in iOS 17
- Clean up testFilterAndEnrichmentPlugin results so that events aren't duplicated between runs (this does not appear to be an issue on CI, only while running locally). (@yuhao900914, can this test just use an in-memory store instead?)

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
