### PR TITLE
fix: Fixes for automatic screen tracking

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		3E281B8C2B967F19009D913B /* Diagonostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E281B8B2B967F19009D913B /* Diagonostics.swift */; };
 		3E281B8E2B96833D009D913B /* DiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E281B8D2B96833D009D913B /* DiagnosticsTests.swift */; };
 		3E281B912B9BCC14009D913B /* DispatchQueueHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E281B902B9BCC14009D913B /* DispatchQueueHolder.swift */; };
+		4E2B646B2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */; };
 		8EDEC02B99EE2092B567A61D /* ObjCIngestionMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC500EBDA8B813056E2DB /* ObjCIngestionMetadata.swift */; };
 		8EDEC1073A308B12B5CCD975 /* AnalyticsConnectorPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDECD39BAA97DD4320C0AA5 /* AnalyticsConnectorPlugin.swift */; };
 		8EDEC10C56FA7F7DEEB48B6F /* ObjCBaseEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDECCFD935A0C5A6FE85E87 /* ObjCBaseEvent.swift */; };
@@ -147,6 +148,7 @@
 		3E281B8B2B967F19009D913B /* Diagonostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagonostics.swift; sourceTree = "<group>"; };
 		3E281B8D2B96833D009D913B /* DiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTests.swift; sourceTree = "<group>"; };
 		3E281B902B9BCC14009D913B /* DispatchQueueHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueHolder.swift; sourceTree = "<group>"; };
+		4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitScreenViewsPluginTests.swift; sourceTree = "<group>"; };
 		8EDEC0630C3B587334275D9B /* AmplitudeSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmplitudeSessionTests.swift; sourceTree = "<group>"; };
 		8EDEC1160D95DC3F0E48DDF7 /* ObjCPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCPlugin.swift; sourceTree = "<group>"; };
 		8EDEC1576C95A2EB2FEF00A8 /* ObjCAmplitude.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCAmplitude.swift; sourceTree = "<group>"; };
@@ -325,6 +327,7 @@
 			isa = PBXGroup;
 			children = (
 				B6F338A22B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift */,
+				4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */,
 			);
 			path = Plugins;
 			sourceTree = "<group>";
@@ -702,6 +705,7 @@
 				BA1EC0F62A9F63FD00C2D547 /* AmplitudeIOSTests.swift in Sources */,
 				8EDEC14255F82E24CEE00B36 /* AmplitudeSessionTests.swift in Sources */,
 				8EDEC972AEB33E4528F7FEEB /* StoragePrefixMigrationTests.swift in Sources */,
+				4E2B646B2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift in Sources */,
 				BA994B9A2A4F48DE00D0913F /* LegacyDatabaseStorageTests.swift in Sources */,
 				8EDEC2E0CC80DF79F5463ACC /* RemnantDataMigrationTests.swift in Sources */,
 			);

--- a/Tests/AmplitudeTests/Plugins/UIKitScreenViewsPluginTests.swift
+++ b/Tests/AmplitudeTests/Plugins/UIKitScreenViewsPluginTests.swift
@@ -1,0 +1,44 @@
+//
+//  UIKitScreenViewsTests.swift
+//  Amplitude-SwiftTests
+//
+//  Created by Chris Leonavicius on 3/12/24.
+//
+
+import XCTest
+
+@testable import AmplitudeSwift
+
+#if os(iOS)
+
+final class UIKitScreenViewsPluginTests: XCTestCase {
+
+    func testScreenNameWithTitle() {
+        let viewController = UIKitScreenViewsPluginTestViewController()
+        viewController.title = "My test screen"
+
+        XCTAssertEqual(viewController.title, UIKitScreenViews.screenName(for: viewController))
+    }
+
+    func testScreenNameFromClass() {
+        let viewController = UIKitScreenViewsPluginTestViewController()
+
+        XCTAssertEqual("UIKitScreenViewsPluginTest", UIKitScreenViews.screenName(for: viewController))
+    }
+
+    func testScreenNameFallback() {
+        let viewController = ViewControllerViewController()
+
+        XCTAssertEqual("Unknown", UIKitScreenViews.screenName(for: viewController))
+    }
+
+    private class UIKitScreenViewsPluginTestViewController: UIViewController {
+
+    }
+
+    private class ViewControllerViewController: UIViewController {
+
+    }
+}
+
+#endif


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Use class name vs instance name of untitled view controllers for automatic screen tracking (#100)
- Resolve symlinks in paths before comparison (#121)

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: Yes, screen names will now be resolved properly
