### PR TITLE
fix: better Carthage support

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -112,7 +112,7 @@
 		OBJ_156 /* HttpClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* HttpClientTests.swift */; };
 		OBJ_157 /* PersistentStorageResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* PersistentStorageResponseHandlerTests.swift */; };
 		OBJ_158 /* UrlExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* UrlExtensionTests.swift */; };
-		OBJ_160 /* Amplitude_Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "amplitude-swift::Amplitude-Swift::Product" /* Amplitude_Swift.framework */; };
+		OBJ_160 /* AmplitudeSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "amplitude-swift::Amplitude-Swift::Product" /* AmplitudeSwift.framework */; };
 		OBJ_88 /* Amplitude.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_8 /* Amplitude.swift */; };
 		OBJ_89 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* Configuration.swift */; };
 		OBJ_90 /* ConsoleLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* ConsoleLogger.swift */; };
@@ -253,7 +253,7 @@
 		OBJ_81 /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
 		OBJ_82 /* AmplitudeSwift.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = AmplitudeSwift.podspec; sourceTree = "<group>"; };
 		OBJ_9 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
-		"amplitude-swift::Amplitude-Swift::Product" /* Amplitude_Swift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = Amplitude_Swift.framework; path = AmplitudeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"amplitude-swift::Amplitude-Swift::Product" /* AmplitudeSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = AmplitudeSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"amplitude-swift::Amplitude-SwiftTests::Product" /* Amplitude_SwiftTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; name = Amplitude_SwiftTests.xctest; path = "Amplitude-SwiftTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -270,7 +270,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_160 /* Amplitude_Swift.framework in Frameworks */,
+				OBJ_160 /* AmplitudeSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -541,7 +541,7 @@
 		OBJ_75 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				"amplitude-swift::Amplitude-Swift::Product" /* Amplitude_Swift.framework */,
+				"amplitude-swift::Amplitude-Swift::Product" /* AmplitudeSwift.framework */,
 				"amplitude-swift::Amplitude-SwiftTests::Product" /* Amplitude_SwiftTests.xctest */,
 			);
 			name = Products;
@@ -567,7 +567,7 @@
 				BA34B23B2AA0723A00F88097 /* AnalyticsConnector */,
 			);
 			productName = Amplitude_Swift;
-			productReference = "amplitude-swift::Amplitude-Swift::Product" /* Amplitude_Swift.framework */;
+			productReference = "amplitude-swift::Amplitude-Swift::Product" /* AmplitudeSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		"amplitude-swift::Amplitude-SwiftTests" /* Amplitude-SwiftTests */ = {
@@ -954,6 +954,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
 				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -991,6 +992,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
 				DRIVERKIT_DEPLOYMENT_TARGET = 19.0;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "amplitude/analytics-connector-ios" ~> 1.0.0

--- a/Examples/AmplitudeObjCExample/AmplitudeObjCExample.xcodeproj/project.pbxproj
+++ b/Examples/AmplitudeObjCExample/AmplitudeObjCExample.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4E890A202BAB82DF00B3F736 /* Amplitude_Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E890A142BAB814A00B3F736 /* Amplitude_Swift.framework */; };
 		BA2E1DA42AC1EA220074E74F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2E1DA32AC1EA220074E74F /* AppDelegate.m */; };
 		BA2E1DA72AC1EA220074E74F /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2E1DA62AC1EA220074E74F /* SceneDelegate.m */; };
 		BA2E1DAA2AC1EA220074E74F /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2E1DA92AC1EA220074E74F /* ViewController.m */; };
@@ -15,11 +16,30 @@
 		BA2E1DB22AC1EA230074E74F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BA2E1DB02AC1EA230074E74F /* LaunchScreen.storyboard */; };
 		BA2E1DB52AC1EA230074E74F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2E1DB42AC1EA230074E74F /* main.m */; };
 		BA2E1DBF2AC1EA240074E74F /* AmplitudeObjCExampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2E1DBE2AC1EA240074E74F /* AmplitudeObjCExampleTests.m */; };
-		BA2E1DDE2AC1F1CA0074E74F /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BA2E1DDD2AC1F1CA0074E74F /* AmplitudeSwift */; };
-		BAB79A442AC3042200F191C9 /* AmplitudeSwift in Frameworks */ = {isa = PBXBuildFile; productRef = BAB79A432AC3042200F191C9 /* AmplitudeSwift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4E890A132BAB814A00B3F736 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4E890A0C2BAB814A00B3F736 /* Amplitude-Swift.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "amplitude-swift::Amplitude-Swift::Product";
+			remoteInfo = "Amplitude-Swift";
+		};
+		4E890A152BAB814A00B3F736 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4E890A0C2BAB814A00B3F736 /* Amplitude-Swift.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "amplitude-swift::Amplitude-SwiftTests::Product";
+			remoteInfo = "Amplitude-SwiftTests";
+		};
+		4E890A192BAB826900B3F736 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4E890A0C2BAB814A00B3F736 /* Amplitude-Swift.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = "amplitude-swift::Amplitude-Swift";
+			remoteInfo = "Amplitude-Swift";
+		};
 		BA2E1DBB2AC1EA230074E74F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = BA2E1D972AC1EA220074E74F /* Project object */;
@@ -30,6 +50,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4E890A0C2BAB814A00B3F736 /* Amplitude-Swift.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "Amplitude-Swift.xcodeproj"; path = "../../Amplitude-Swift.xcodeproj"; sourceTree = "<group>"; };
 		BA2E1D9F2AC1EA220074E74F /* AmplitudeObjCExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AmplitudeObjCExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA2E1DA22AC1EA220074E74F /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		BA2E1DA32AC1EA220074E74F /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -51,7 +72,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BA2E1DDE2AC1F1CA0074E74F /* AmplitudeSwift in Frameworks */,
+				4E890A202BAB82DF00B3F736 /* Amplitude_Swift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,16 +80,25 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BAB79A442AC3042200F191C9 /* AmplitudeSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4E890A0D2BAB814A00B3F736 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4E890A142BAB814A00B3F736 /* Amplitude_Swift.framework */,
+				4E890A162BAB814A00B3F736 /* Amplitude_SwiftTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		BA2E1D962AC1EA220074E74F = {
 			isa = PBXGroup;
 			children = (
+				4E890A0C2BAB814A00B3F736 /* Amplitude-Swift.xcodeproj */,
 				BA2E1DA12AC1EA220074E74F /* AmplitudeObjCExample */,
 				BA2E1DBD2AC1EA240074E74F /* AmplitudeObjCExampleTests */,
 				BA2E1DA02AC1EA220074E74F /* Products */,
@@ -132,10 +162,10 @@
 			buildRules = (
 			);
 			dependencies = (
+				4E890A1A2BAB826900B3F736 /* PBXTargetDependency */,
 			);
 			name = AmplitudeObjCExample;
 			packageProductDependencies = (
-				BA2E1DDD2AC1F1CA0074E74F /* AmplitudeSwift */,
 			);
 			productName = AmplitudeObjCExample;
 			productReference = BA2E1D9F2AC1EA220074E74F /* AmplitudeObjCExample.app */;
@@ -156,7 +186,6 @@
 			);
 			name = AmplitudeObjCExampleTests;
 			packageProductDependencies = (
-				BAB79A432AC3042200F191C9 /* AmplitudeSwift */,
 			);
 			productName = AmplitudeObjCExampleTests;
 			productReference = BA2E1DBA2AC1EA230074E74F /* AmplitudeObjCExampleTests.xctest */;
@@ -190,10 +219,15 @@
 			);
 			mainGroup = BA2E1D962AC1EA220074E74F;
 			packageReferences = (
-				BA2E1DDC2AC1F1CA0074E74F /* XCRemoteSwiftPackageReference "Amplitude-Swift" */,
 			);
 			productRefGroup = BA2E1DA02AC1EA220074E74F /* Products */;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 4E890A0D2BAB814A00B3F736 /* Products */;
+					ProjectRef = 4E890A0C2BAB814A00B3F736 /* Amplitude-Swift.xcodeproj */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				BA2E1D9E2AC1EA220074E74F /* AmplitudeObjCExample */,
@@ -201,6 +235,25 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		4E890A142BAB814A00B3F736 /* Amplitude_Swift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			name = Amplitude_Swift.framework;
+			path = AmplitudeSwift.framework;
+			remoteRef = 4E890A132BAB814A00B3F736 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		4E890A162BAB814A00B3F736 /* Amplitude_SwiftTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = file;
+			name = Amplitude_SwiftTests.xctest;
+			path = "Amplitude-SwiftTests.xctest";
+			remoteRef = 4E890A152BAB814A00B3F736 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		BA2E1D9D2AC1EA220074E74F /* Resources */ = {
@@ -245,6 +298,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4E890A1A2BAB826900B3F736 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Amplitude-Swift";
+			targetProxy = 4E890A192BAB826900B3F736 /* PBXContainerItemProxy */;
+		};
 		BA2E1DBC2AC1EA230074E74F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = BA2E1D9E2AC1EA220074E74F /* AmplitudeObjCExample */;
@@ -499,30 +557,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		BA2E1DDC2AC1F1CA0074E74F /* XCRemoteSwiftPackageReference "Amplitude-Swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "../../../Amplitude-Swift";
-			requirement = {
-				branch = HEAD;
-				kind = branch;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		BA2E1DDD2AC1F1CA0074E74F /* AmplitudeSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = BA2E1DDC2AC1F1CA0074E74F /* XCRemoteSwiftPackageReference "Amplitude-Swift" */;
-			productName = AmplitudeSwift;
-		};
-		BAB79A432AC3042200F191C9 /* AmplitudeSwift */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = BA2E1DDC2AC1F1CA0074E74F /* XCRemoteSwiftPackageReference "Amplitude-Swift" */;
-			productName = AmplitudeSwift;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = BA2E1D972AC1EA220074E74F /* Project object */;
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Carthage support has a few issues that need to be resolved:
- As of Carthage 0.37.0, Carthage will build all subprojects in a dependency, which means it includes our sample apps. Our ObjC sample app is currently broken on the latest versions of Xcode as you are no longer allowed to reference a package that is a direct ancestor of the project. I converted this to a direct project reference instead, and enabled emitting a module to keep the same semantics.
- analytics-connector-ios needs to be added as a dependency in a Cartfile, similar to https://github.com/amplitude/Amplitude-iOS/blob/main/Cartfile. This resolves #139 .

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
