### PR TITLE
test: fix flaky tests on WatchOS

### DIFF
--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -26,12 +26,15 @@ final class EventPipelineTests: XCTestCase {
         configuration = Configuration(
             apiKey: "testApiKey",
             flushIntervalMillis: Int(Self.FLUSH_INTERVAL_SECONDS * 1000),
-            storageProvider: storage
+            storageProvider: storage,
+            offline: NetworkConnectivityCheckerPlugin.Disabled
         )
         let amplitude = Amplitude(configuration: configuration)
         httpClient = FakeHttpClient(configuration: configuration, diagnostics: configuration.diagonostics)
         pipeline = EventPipeline(amplitude: amplitude)
         pipeline.httpClient = httpClient
+        pipeline.flushTimer?.suspend()
+
     }
 
     override func tearDown() {
@@ -74,6 +77,8 @@ final class EventPipelineTests: XCTestCase {
     }
 
     func testFlushWhenOffline() {
+        pipeline.amplitude.configuration.offline = false
+
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
 
@@ -91,6 +96,9 @@ final class EventPipelineTests: XCTestCase {
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
 
+        let httpResponseExpectation = expectation(description: "httpresponse")
+        httpClient.uploadExpectations = [httpResponseExpectation]
+
         let flushExpectations = (0..<2).map { _ in
             let expectation = expectation(description: "flush")
             pipeline.flush {
@@ -99,8 +107,9 @@ final class EventPipelineTests: XCTestCase {
             return expectation
         }
 
-        let waitResult = XCTWaiter.wait(for: flushExpectations, timeout: 1)
-        XCTAssertNotEqual(waitResult, .timedOut)
+        wait(for: flushExpectations, timeout: 1)
+        wait(for: [httpResponseExpectation], timeout: 1)
+
         XCTAssertEqual(httpClient.uploadCount, 1)
         let uploadedEvents = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
         XCTAssertEqual(uploadedEvents?.count, 1)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

We were getting flushes in an unexpected order while running tests because our connectivity monitor was running, delaying requests until it detected a connection. This delay was compounded by the flush timer, which could fire other flush events during this delay.  Disable them both for EventPipeline tests.

Additionally, wait for a connection response vs just firing off a request in the simultaneous connection test to ensure it is completed before we attempt to clean up.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
