### PR TITLE
fix(spm): PrivacyInfo.xcprivacy must be defined in resources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,10 @@ let package = Package(
                 .product(name: "AnalyticsConnector", package: "analytics-connector-ios")
             ],
             path: "Sources/Amplitude",
-            exclude: ["../../Examples/", "../../Tests/"]
+            exclude: ["../../Examples/", "../../Tests/"],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy")
+            ]
         ),
         .testTarget(
             name: "Amplitude-SwiftTests",


### PR DESCRIPTION
### Summary

Fix integration of `PrivacyInfo.xcprivacy`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
