### PR TITLE
chore: expose DET utils for flutter plugin

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		8EDECEC5F98F9974DF3E576F /* ObjCIdentify.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC5A50E197C9C5067C19E /* ObjCIdentify.swift */; };
 		8EDECF81C2B1B38D472FD7EF /* ObjCConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDECEC5AAE15FD05E76359A /* ObjCConfiguration.swift */; };
 		8EDECFCCF4219767F26210D6 /* Sessions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC2B8B38E04CDB51F0E83 /* Sessions.swift */; };
+		B605396A2BB767390027FC24 /* DefaultEventUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60539692BB767390027FC24 /* DefaultEventUtils.swift */; };
 		B6CCC6CD2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CCC6CC2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift */; };
 		B6EDB4D02B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6EDB4CF2B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift */; };
 		B6F338A32B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F338A22B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift */; };
@@ -181,6 +182,7 @@
 		8EDECE07F682FAAE47F77B24 /* ObjCEventOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCEventOptions.swift; sourceTree = "<group>"; };
 		8EDECEC5AAE15FD05E76359A /* ObjCConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCConfiguration.swift; sourceTree = "<group>"; };
 		8EDECF8CF745F7339B65D6DB /* ObjCStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCStorage.swift; sourceTree = "<group>"; };
+		B60539692BB767390027FC24 /* DefaultEventUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultEventUtils.swift; sourceTree = "<group>"; };
 		B6CCC6CC2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjCNetworkConnectivityCheckerPlugin.swift; sourceTree = "<group>"; };
 		B6DF481F2B5B45BE00B3E6AA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B6EDB4CF2B643C8400454B90 /* NetworkConnectivityCheckerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkConnectivityCheckerPlugin.swift; sourceTree = "<group>"; };
@@ -427,6 +429,7 @@
 				D010435E2B6C59EE00F8173C /* SandboxHelper.swift */,
 				3E281B8B2B967F19009D913B /* Diagonostics.swift */,
 				3E281B902B9BCC14009D913B /* DispatchQueueHolder.swift */,
+				B60539692BB767390027FC24 /* DefaultEventUtils.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -751,6 +754,7 @@
 				B6CCC6CD2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift in Sources */,
 				OBJ_111 /* InMemoryStorage.swift in Sources */,
 				3E281B912B9BCC14009D913B /* DispatchQueueHolder.swift in Sources */,
+				B605396A2BB767390027FC24 /* DefaultEventUtils.swift in Sources */,
 				OBJ_112 /* PersistentStorage.swift in Sources */,
 				BA9BEA4B299FB43B00BC0F7C /* IdentifyInterceptor.swift in Sources */,
 				BA0639F62A4DD491000F1CEE /* LegacyDatabaseStorage.swift in Sources */,

--- a/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
+++ b/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
@@ -18,6 +18,7 @@
             UIApplication.didFinishLaunchingNotification,
         ]
         private var trackAppOpenedEventOnEnterForeground: Bool = true
+        private var utils: DefaultEventUtils?
 
         override init() {
             // TODO: Check if lifecycle plugin works for app extension
@@ -30,6 +31,7 @@
 
         public override func setup(amplitude: Amplitude) {
             super.setup(amplitude: amplitude)
+            utils = DefaultEventUtils(amplitude: amplitude)
             if amplitude.configuration.defaultTracking.screenViews {
                 UIKitScreenViews.register(amplitude)
             }
@@ -91,40 +93,7 @@
         func applicationDidFinishLaunchingNotification(notification: NSNotification) {
             self.trackAppOpenedEventOnEnterForeground = false
 
-            let info = Bundle.main.infoDictionary
-            let currentBuild = info?["CFBundleVersion"] as? String
-            let currentVersion = info?["CFBundleShortVersionString"] as? String
-            let previousBuild: String? = amplitude?.storage.read(key: StorageKey.APP_BUILD)
-            let previousVersion: String? = amplitude?.storage.read(key: StorageKey.APP_VERSION)
-
-            if self.amplitude?.configuration.defaultTracking.appLifecycles == true {
-                let lastEventTime: Int64? = amplitude?.storage.read(key: StorageKey.LAST_EVENT_TIME)
-                if lastEventTime == nil {
-                    self.amplitude?.track(eventType: Constants.AMP_APPLICATION_INSTALLED_EVENT, eventProperties: [
-                        Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
-                        Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
-                    ])
-                } else if currentBuild != previousBuild {
-                    self.amplitude?.track(eventType: Constants.AMP_APPLICATION_UPDATED_EVENT, eventProperties: [
-                        Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
-                        Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
-                        Constants.AMP_APP_PREVIOUS_BUILD_PROPERTY: previousBuild ?? "",
-                        Constants.AMP_APP_PREVIOUS_VERSION_PROPERTY: previousVersion ?? "",
-                    ])
-                }
-                self.amplitude?.track(eventType: Constants.AMP_APPLICATION_OPENED_EVENT, eventProperties: [
-                    Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
-                    Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
-                    Constants.AMP_APP_FROM_BACKGROUND_PROPERTY: false,
-                ])
-            }
-
-            if currentBuild != previousBuild {
-                try? amplitude?.storage.write(key: StorageKey.APP_BUILD, value: currentBuild)
-            }
-            if currentVersion != previousVersion {
-                try? amplitude?.storage.write(key: StorageKey.APP_VERSION, value: currentVersion)
-            }
+            utils?.trackAppUpdatedInstalledEvent()
         }
     }
 

--- a/Sources/Amplitude/Utilities/DefaultEventUtils.swift
+++ b/Sources/Amplitude/Utilities/DefaultEventUtils.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public class DefaultEventUtils {
+    private var amplitude: Amplitude?
+
+    public init(amplitude: Amplitude) {
+        self.amplitude = amplitude
+    }
+
+    public func trackAppUpdatedInstalledEvent() {
+        let info = Bundle.main.infoDictionary
+        let currentBuild = info?["CFBundleVersion"] as? String
+        let currentVersion = info?["CFBundleShortVersionString"] as? String
+        let previousBuild: String? = amplitude?.storage.read(key: StorageKey.APP_BUILD)
+        let previousVersion: String? = amplitude?.storage.read(key: StorageKey.APP_VERSION)
+
+        if self.amplitude?.configuration.defaultTracking.appLifecycles == true {
+            let lastEventTime: Int64? = amplitude?.storage.read(key: StorageKey.LAST_EVENT_TIME)
+            if lastEventTime == nil {
+                self.amplitude?.track(eventType: Constants.AMP_APPLICATION_INSTALLED_EVENT, eventProperties: [
+                    Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
+                    Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
+                ])
+            } else if currentBuild != previousBuild {
+                self.amplitude?.track(eventType: Constants.AMP_APPLICATION_UPDATED_EVENT, eventProperties: [
+                    Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
+                    Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
+                    Constants.AMP_APP_PREVIOUS_BUILD_PROPERTY: previousBuild ?? "",
+                    Constants.AMP_APP_PREVIOUS_VERSION_PROPERTY: previousVersion ?? "",
+                ])
+            }
+            self.amplitude?.track(eventType: Constants.AMP_APPLICATION_OPENED_EVENT, eventProperties: [
+                Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
+                Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
+                Constants.AMP_APP_FROM_BACKGROUND_PROPERTY: false,
+            ])
+        }
+
+        if currentBuild != previousBuild {
+            try? amplitude?.storage.write(key: StorageKey.APP_BUILD, value: currentBuild)
+        }
+        if currentVersion != previousVersion {
+            try? amplitude?.storage.write(key: StorageKey.APP_VERSION, value: currentVersion)
+        }
+    }
+
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

https://amplitude.atlassian.net/browse/AMP-96756

Expose default event tracking utils so that they can be used in the Flutter iOS plugin.

- Create a class `DefaultEventUtils`
- Call `DefaultEventUtils. trackAppUpdatedInstalledEvent()` to track app updated & installed events 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
