### PR TITLE
chore: add required reason api to privacy manifest

### DIFF
--- a/Sources/Amplitude/PrivacyInfo.xcprivacy
+++ b/Sources/Amplitude/PrivacyInfo.xcprivacy
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>1C8F.1</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array>
 		<dict>

--- a/Sources/Amplitude/PrivacyInfo.xcprivacy
+++ b/Sources/Amplitude/PrivacyInfo.xcprivacy
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPrivacyTracking</key>
-	<false/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/Sources/Amplitude/PrivacyInfo.xcprivacy
+++ b/Sources/Amplitude/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This PR declares the usage of [UserDefaults](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278401) and reason of using it in the privacy manifest as we use it for [identity storage](https://github.com/amplitude/Amplitude-Swift/blob/891da3a2892df519a4ccf51a8442f8a5110623f0/Sources/Amplitude/Storages/PersistentStorage.swift#L22). 
[Segment](https://github.com/segmentio/analytics-swift/blob/7eeb2abf8452153af056baae5369679589f10936/Sources/Segment/Resources/PrivacyInfo.xcprivacy#L59C1-L68C10) declares it too.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
