### PR TITLE
chore: delete tracking domains from privacy manifest

### DIFF
--- a/Sources/Amplitude/PrivacyInfo.xcprivacy
+++ b/Sources/Amplitude/PrivacyInfo.xcprivacy
@@ -52,12 +52,5 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSPrivacyTrackingDomains</key>
-	<array>
-		<string>https://api2.amplitude.com/2/httpapi</string>
-		<string>https://api.eu.amplitude.com/2/httpapi</string>
-		<string>https://api2.amplitude.com/batch</string>
-		<string>https://api.eu.amplitude.com/batch</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

> If you set NSPrivacyTracking to true then you need to provide at least one internet domain in NSPrivacyTrackingDomains; otherwise, you can provide zero or more domains.

This PR is from https://github.com/amplitude/amplitude-dev-center/pull/276#discussion_r1550220212. 

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
