### PR TITLE
fix: Adopt resource bundle for privacy manifest in Cocoapods

### DIFF
--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -13,21 +13,21 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target  = '13.0'
   s.ios.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
-  s.ios.resources          = 'Sources/Amplitude/PrivacyInfo.xcprivacy'
+  s.ios.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   s.tvos.deployment_target = '13.0'
   s.tvos.source_files      = 'Sources/Amplitude/**/*.{h,swift}'
-  s.tvos.resources          = 'Sources/Amplitude/PrivacyInfo.xcprivacy'
+  s.tvos.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   s.osx.deployment_target  = '10.15'
   s.osx.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
-  s.osx.resources          = 'Sources/Amplitude/PrivacyInfo.xcprivacy'
+  s.osx.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   # temporary disable watchos support due to: https://github.com/CocoaPods/CocoaPods/issues/11558
   # unpaired watchos will cause failure, the fix of the above issue is merged but not released
   # s.watchos.deployment_target  = '7.0'
   # s.watchos.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
-  # s.watchos.resources          = 'Sources/Amplitude/PrivacyInfo.xcprivacy'
+  # s.watchos.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   s.dependency 'AnalyticsConnector', '~> 1.0.1'
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Use resource_bundle to prevent name conflicts with statically linked pods

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
