### PR TITLE
feat: Dispatch operations to internal queue

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		3E281B8C2B967F19009D913B /* Diagonostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E281B8B2B967F19009D913B /* Diagonostics.swift */; };
 		3E281B8E2B96833D009D913B /* DiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E281B8D2B96833D009D913B /* DiagnosticsTests.swift */; };
 		3E281B912B9BCC14009D913B /* DispatchQueueHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E281B902B9BCC14009D913B /* DispatchQueueHolder.swift */; };
+		4E05BB942BE41AEB009DE475 /* Amplitude+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E05BB932BE41AEB009DE475 /* Amplitude+Extensions.swift */; };
 		4E2B646B2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */; };
 		4E3871622BB34DBC002890AB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B6DF481F2B5B45BE00B3E6AA /* PrivacyInfo.xcprivacy */; };
 		8EDEC02B99EE2092B567A61D /* ObjCIngestionMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC500EBDA8B813056E2DB /* ObjCIngestionMetadata.swift */; };
@@ -150,6 +151,7 @@
 		3E281B8B2B967F19009D913B /* Diagonostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diagonostics.swift; sourceTree = "<group>"; };
 		3E281B8D2B96833D009D913B /* DiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTests.swift; sourceTree = "<group>"; };
 		3E281B902B9BCC14009D913B /* DispatchQueueHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueHolder.swift; sourceTree = "<group>"; };
+		4E05BB932BE41AEB009DE475 /* Amplitude+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Amplitude+Extensions.swift"; sourceTree = "<group>"; };
 		4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitScreenViewsPluginTests.swift; sourceTree = "<group>"; };
 		8EDEC0630C3B587334275D9B /* AmplitudeSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmplitudeSessionTests.swift; sourceTree = "<group>"; };
 		8EDEC1160D95DC3F0E48DDF7 /* ObjCPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCPlugin.swift; sourceTree = "<group>"; };
@@ -466,6 +468,7 @@
 				8EDECBC5925DC68913C7CB89 /* Migration */,
 				BA1EC0F32A9F2FC700C2D547 /* DefaultTrackingOptionsTests.swift */,
 				BA1EC0F52A9F63FD00C2D547 /* AmplitudeIOSTests.swift */,
+				4E05BB932BE41AEB009DE475 /* Amplitude+Extensions.swift */,
 			);
 			name = Tests;
 			path = Tests/AmplitudeTests;
@@ -662,6 +665,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3E281B8F2B98EC92009D913B /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -713,6 +717,7 @@
 				OBJ_156 /* HttpClientTests.swift in Sources */,
 				D01043612B6C5A8500F8173C /* SandboxHelperTests.swift in Sources */,
 				OBJ_157 /* PersistentStorageResponseHandlerTests.swift in Sources */,
+				4E05BB942BE41AEB009DE475 /* Amplitude+Extensions.swift in Sources */,
 				OBJ_158 /* UrlExtensionTests.swift in Sources */,
 				8EDEC4EE0DE1C89889F451B5 /* QueueTimeTests.swift in Sources */,
 				BA1EC0F62A9F63FD00C2D547 /* AmplitudeIOSTests.swift in Sources */,

--- a/Examples/AmplitudeObjCExample/AmplitudeObjCExample.xcodeproj/project.pbxproj
+++ b/Examples/AmplitudeObjCExample/AmplitudeObjCExample.xcodeproj/project.pbxproj
@@ -3,11 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 63;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		4E890A202BAB82DF00B3F736 /* Amplitude_Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E890A142BAB814A00B3F736 /* Amplitude_Swift.framework */; };
+		4E3ECB742BE5B96400FD5CC0 /* TestAmplitude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E3ECB732BE5B96400FD5CC0 /* TestAmplitude.swift */; };
+		4E890A202BAB82DF00B3F736 /* AmplitudeSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E890A142BAB814A00B3F736 /* AmplitudeSwift.framework */; };
 		BA2E1DA42AC1EA220074E74F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2E1DA32AC1EA220074E74F /* AppDelegate.m */; };
 		BA2E1DA72AC1EA220074E74F /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2E1DA62AC1EA220074E74F /* SceneDelegate.m */; };
 		BA2E1DAA2AC1EA220074E74F /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BA2E1DA92AC1EA220074E74F /* ViewController.m */; };
@@ -50,6 +51,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4E3ECB732BE5B96400FD5CC0 /* TestAmplitude.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAmplitude.swift; sourceTree = "<group>"; };
 		4E890A0C2BAB814A00B3F736 /* Amplitude-Swift.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = "Amplitude-Swift.xcodeproj"; path = "../../Amplitude-Swift.xcodeproj"; sourceTree = "<group>"; };
 		BA2E1D9F2AC1EA220074E74F /* AmplitudeObjCExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AmplitudeObjCExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA2E1DA22AC1EA220074E74F /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -72,7 +74,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4E890A202BAB82DF00B3F736 /* Amplitude_Swift.framework in Frameworks */,
+				4E890A202BAB82DF00B3F736 /* AmplitudeSwift.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -89,7 +91,7 @@
 		4E890A0D2BAB814A00B3F736 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				4E890A142BAB814A00B3F736 /* Amplitude_Swift.framework */,
+				4E890A142BAB814A00B3F736 /* AmplitudeSwift.framework */,
 				4E890A162BAB814A00B3F736 /* Amplitude_SwiftTests.xctest */,
 			);
 			name = Products;
@@ -137,6 +139,7 @@
 			isa = PBXGroup;
 			children = (
 				BA2E1DBE2AC1EA240074E74F /* AmplitudeObjCExampleTests.m */,
+				4E3ECB732BE5B96400FD5CC0 /* TestAmplitude.swift */,
 			);
 			path = AmplitudeObjCExampleTests;
 			sourceTree = "<group>";
@@ -205,12 +208,12 @@
 					};
 					BA2E1DB92AC1EA230074E74F = {
 						CreatedOnToolsVersion = 14.2;
-						TestTargetID = BA2E1D9E2AC1EA220074E74F;
+						LastSwiftMigration = 1530;
 					};
 				};
 			};
 			buildConfigurationList = BA2E1D9A2AC1EA220074E74F /* Build configuration list for PBXProject "AmplitudeObjCExample" */;
-			compatibilityVersion = "Xcode 14.0";
+			compatibilityVersion = "Xcode 15.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -237,10 +240,9 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		4E890A142BAB814A00B3F736 /* Amplitude_Swift.framework */ = {
+		4E890A142BAB814A00B3F736 /* AmplitudeSwift.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
-			name = Amplitude_Swift.framework;
 			path = AmplitudeSwift.framework;
 			remoteRef = 4E890A132BAB814A00B3F736 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
@@ -292,6 +294,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BA2E1DBF2AC1EA240074E74F /* AmplitudeObjCExampleTests.m in Sources */,
+				4E3ECB742BE5B96400FD5CC0 /* TestAmplitude.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -495,7 +498,7 @@
 		BA2E1DD22AC1EA240074E74F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -504,15 +507,16 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amplitude.AmplitudeObjCExampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AmplitudeObjCExample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AmplitudeObjCExample";
 			};
 			name = Debug;
 		};
 		BA2E1DD32AC1EA240074E74F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -521,8 +525,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.amplitude.AmplitudeObjCExampleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/AmplitudeObjCExample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/AmplitudeObjCExample";
 			};
 			name = Release;
 		};

--- a/Examples/AmplitudeObjCExample/AmplitudeObjCExample.xcodeproj/xcshareddata/xcschemes/AmplitudeObjCExample.xcscheme
+++ b/Examples/AmplitudeObjCExample/AmplitudeObjCExample.xcodeproj/xcshareddata/xcschemes/AmplitudeObjCExample.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA2E1D9E2AC1EA220074E74F"
+               BuildableName = "AmplitudeObjCExample.app"
+               BlueprintName = "AmplitudeObjCExample"
+               ReferencedContainer = "container:AmplitudeObjCExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "BA2E1DB92AC1EA230074E74F"
+               BuildableName = "AmplitudeObjCExampleTests.xctest"
+               BlueprintName = "AmplitudeObjCExampleTests"
+               ReferencedContainer = "container:AmplitudeObjCExample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BA2E1D9E2AC1EA220074E74F"
+            BuildableName = "AmplitudeObjCExample.app"
+            BlueprintName = "AmplitudeObjCExample"
+            ReferencedContainer = "container:AmplitudeObjCExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "BA2E1D9E2AC1EA220074E74F"
+            BuildableName = "AmplitudeObjCExample.app"
+            BlueprintName = "AmplitudeObjCExample"
+            ReferencedContainer = "container:AmplitudeObjCExample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/AmplitudeObjCExample/AmplitudeObjCExampleTests/TestAmplitude.swift
+++ b/Examples/AmplitudeObjCExample/AmplitudeObjCExampleTests/TestAmplitude.swift
@@ -1,0 +1,135 @@
+//
+//  TestAmplitude.swift
+//  AmplitudeObjCExampleTests
+//
+//  Created by Chris Leonavicius on 5/3/24.
+//
+
+@testable import AmplitudeSwift
+import XCTest
+
+@objc
+public class TestAmplitude: ObjCAmplitude {
+
+    @objc
+    public override init(configuration: ObjCConfiguration) {
+        let config = configuration.configuration
+        let updatedConfig = Configuration(apiKey: config.apiKey,
+                                          flushQueueSize: config.flushQueueSize,
+                                          flushIntervalMillis: config.flushIntervalMillis,
+                                          instanceName: config.instanceName,
+                                          optOut: config.optOut,
+                                          storageProvider: TestStorage(),
+                                          identifyStorageProvider: TestStorage(),
+                                          logLevel: config.logLevel,
+                                          loggerProvider: config.loggerProvider,
+                                          minIdLength: config.minIdLength,
+                                          partnerId: config.partnerId,
+                                          callback: config.callback,
+                                          flushMaxRetries: config.flushMaxRetries,
+                                          useBatch: config.useBatch,
+                                          serverZone: config.serverZone,
+                                          serverUrl: "https://127.0.0.1",
+                                          plan: config.plan,
+                                          ingestionMetadata: config.ingestionMetadata,
+                                          trackingOptions: config.trackingOptions,
+                                          enableCoppaControl: config.enableCoppaControl,
+                                          flushEventsOnClose: config.flushEventsOnClose,
+                                          minTimeBetweenSessionsMillis: config.minTimeBetweenSessionsMillis,
+                                          defaultTracking: config.defaultTracking,
+                                          identifyBatchIntervalMillis: config.identifyBatchIntervalMillis,
+                                          migrateLegacyData: config.migrateLegacyData,
+                                          offline: NetworkConnectivityCheckerPlugin.Disabled)
+
+        super.init(configuration: ObjCConfiguration(configuration: updatedConfig))
+    }
+}
+
+class TestStorage: Storage {
+
+    private let eventsURL = URL(string: NSTemporaryDirectory())
+    private var storage: [String: Any] = [:]
+    private var events: [BaseEvent] = []
+
+    func write(key: StorageKey, value: Any?) throws {
+        switch key {
+        case .EVENTS:
+            if let event = value as? BaseEvent {
+                events.append(event)
+                event.callback?(event, events.count, "")
+            }
+        default:
+            storage[key.rawValue] = value
+        }
+    }
+
+    func read<T>(key: StorageKey) -> T? {
+        switch key {
+        case .EVENTS:
+            return [eventsURL] as? T
+        default:
+            return storage[key.rawValue] as? T
+        }
+    }
+
+    func getEventsString(eventBlock: URL) -> String? {
+        let eventsData = try? JSONEncoder().encode(events)
+        return eventsData.flatMap { String(data: $0, encoding: .utf8) }
+    }
+
+    func remove(eventBlock: URL) {
+        // no-op
+    }
+
+    func splitBlock(eventBlock: URL, events: [BaseEvent]) {
+        // no-op
+    }
+
+    func rollover() {
+        // no-op
+    }
+
+    func reset() {
+        storage.removeAll()
+        events.removeAll()
+    }
+
+    func getResponseHandler(
+        configuration: Configuration,
+        eventPipeline: EventPipeline,
+        eventBlock: URL,
+        eventsString: String
+    ) -> ResponseHandler {
+        class TestResponseHandler: ResponseHandler {
+
+            func handle(result: Result<Int, Error>) {
+                // no-op
+            }
+
+            func handleSuccessResponse(code: Int) {
+                // no-op
+            }
+
+            func handleBadRequestResponse(data: [String: Any]) {
+                // no-op
+            }
+
+            func handlePayloadTooLargeResponse(data: [String: Any]) {
+                // no-op
+            }
+
+            func handleTooManyRequestsResponse(data: [String: Any]) {
+                // no-op
+            }
+
+            func handleTimeoutResponse(data: [String: Any]) {
+                // no-op
+            }
+
+            func handleFailedResponse(data: [String: Any]) {
+                // no-op
+            }
+        }
+        return TestResponseHandler()
+    }
+}

--- a/Sources/Amplitude/Plugins/ContextPlugin.swift
+++ b/Sources/Amplitude/Plugins/ContextPlugin.swift
@@ -155,8 +155,8 @@ class ContextPlugin: BeforePlugin {
         }
     }
 
-    func initializeDeviceId() {
-        var deviceId = amplitude?.state.deviceId
+    func initializeDeviceId(forceReset: Bool = false) {
+        var deviceId = forceReset ? nil : amplitude?.state.deviceId
         if isValidDeviceId(deviceId) {
             return
         }

--- a/Sources/Amplitude/Sessions.swift
+++ b/Sources/Amplitude/Sessions.swift
@@ -4,7 +4,7 @@ public class Sessions {
     private let amplitude: Amplitude
 
     private var _sessionId: Int64 = -1
-    var sessionId: Int64 {
+    private(set) var sessionId: Int64 {
         get { _sessionId }
         set {
             _sessionId = newValue
@@ -17,7 +17,7 @@ public class Sessions {
     }
 
     private var _lastEventId: Int64 = 0
-    var lastEventId: Int64 {
+    private(set) var lastEventId: Int64 {
         get { _lastEventId }
         set {
             _lastEventId = newValue

--- a/Sources/Amplitude/State.swift
+++ b/Sources/Amplitude/State.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 class State {
-    var userId: String? {
+    @Atomic var userId: String? {
         didSet {
             for plugin in plugins {
                 plugin.onUserIdChanged(userId)
@@ -16,7 +16,7 @@ class State {
         }
     }
 
-    var deviceId: String? {
+    @Atomic var deviceId: String? {
         didSet {
             for plugin in plugins {
                 plugin.onDeviceIdChanged(deviceId)

--- a/Sources/Amplitude/Utilities/EventPipeline.swift
+++ b/Sources/Amplitude/Utilities/EventPipeline.swift
@@ -23,8 +23,10 @@ public class EventPipeline {
 
     init(amplitude: Amplitude) {
         self.amplitude = amplitude
-        self.httpClient = HttpClient(configuration: amplitude.configuration, diagnostics: amplitude.configuration.diagonostics)
-        self.flushTimer = QueueTimer(interval: getFlushInterval()) { [weak self] in
+        self.httpClient = HttpClient(configuration: amplitude.configuration,
+                                     diagnostics: amplitude.configuration.diagonostics,
+                                     callbackQueue: amplitude.trackingQueue)
+        self.flushTimer = QueueTimer(interval: getFlushInterval(), queue: amplitude.trackingQueue) { [weak self] in
             self?.flush()
         }
     }

--- a/Tests/AmplitudeTests/Amplitude+Extensions.swift
+++ b/Tests/AmplitudeTests/Amplitude+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  Amplitude+Extensions.swift
+//  Amplitude-SwiftTests
+//
+//  Created by Chris Leonavicius on 5/2/24.
+//
+
+@testable import AmplitudeSwift
+import XCTest
+
+extension Amplitude {
+
+    func waitForTrackingQueue() {
+        let waitForQueueExpectation = XCTestExpectation(description: "Wait for trackingQueue")
+        // Because trackingQueue is serial, this acts as a barrier in which any previous operations will
+        // have guaranteed to complete after this has run. 
+        trackingQueue.async {
+            waitForQueueExpectation.fulfill()
+        }
+
+        XCTWaiter().wait(for: [waitForQueueExpectation])
+    }
+}

--- a/Tests/AmplitudeTests/AmplitudeIOSTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeIOSTests.swift
@@ -26,8 +26,10 @@ final class AmplitudeIOSTests: XCTestCase {
             identifyStorageProvider: interceptStorageMem,
             defaultTracking: DefaultTrackingOptions(sessions: false, appLifecycles: true)
         )
-        _ = Amplitude(configuration: configuration)
+        let amplitude = Amplitude(configuration: configuration)
         NotificationCenter.default.post(name: UIApplication.didFinishLaunchingNotification, object: nil)
+
+        amplitude.waitForTrackingQueue()
 
         let info = Bundle.main.infoDictionary
         let currentBuild = info?["CFBundleVersion"] ?? ""
@@ -58,8 +60,9 @@ final class AmplitudeIOSTests: XCTestCase {
         try storageMem.write(key: StorageKey.LAST_EVENT_TIME, value: 123 as Int64)
         try storageMem.write(key: StorageKey.APP_BUILD, value: "abc")
         try storageMem.write(key: StorageKey.APP_VERSION, value: "xyz")
-        _ = Amplitude(configuration: configuration)
+        let amplitude = Amplitude(configuration: configuration)
         NotificationCenter.default.post(name: UIApplication.didFinishLaunchingNotification, object: nil)
+        amplitude.waitForTrackingQueue()
 
         let info = Bundle.main.infoDictionary
         let currentBuild = info?["CFBundleVersion"] ?? ""
@@ -97,8 +100,9 @@ final class AmplitudeIOSTests: XCTestCase {
         try storageMem.write(key: StorageKey.LAST_EVENT_TIME, value: 123 as Int64)
         try storageMem.write(key: StorageKey.APP_BUILD, value: currentBuild)
         try storageMem.write(key: StorageKey.APP_VERSION, value: currentVersion)
-        _ = Amplitude(configuration: configuration)
+        let amplitude = Amplitude(configuration: configuration)
         NotificationCenter.default.post(name: UIApplication.didFinishLaunchingNotification, object: nil)
+        amplitude.waitForTrackingQueue()
 
         let events = storageMem.events()
         XCTAssertEqual(events.count, 1)
@@ -122,8 +126,9 @@ final class AmplitudeIOSTests: XCTestCase {
         let currentBuild = info?["CFBundleVersion"] ?? ""
         let currentVersion = info?["CFBundleShortVersionString"] ?? ""
 
-        _ = Amplitude(configuration: configuration)
+        let amplitude = Amplitude(configuration: configuration)
         NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+        amplitude.waitForTrackingQueue()
 
         let events = storageMem.events()
         XCTAssertEqual(events.count, 1)
@@ -143,8 +148,9 @@ final class AmplitudeIOSTests: XCTestCase {
             defaultTracking: DefaultTrackingOptions(sessions: false, appLifecycles: true)
         )
 
-        _ = Amplitude(configuration: configuration)
+        let amplitude = Amplitude(configuration: configuration)
         NotificationCenter.default.post(name: UIApplication.didEnterBackgroundNotification, object: nil)
+        amplitude.waitForTrackingQueue()
 
         let events = storageMem.events()
         XCTAssertEqual(events.count, 1)

--- a/Tests/AmplitudeTests/AmplitudeSessionTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeSessionTests.swift
@@ -33,6 +33,7 @@ final class AmplitudeSessionTests: XCTestCase {
 
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1000, eventType: "test event 1"))
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1050, eventType: "test event 2"))
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -69,6 +70,7 @@ final class AmplitudeSessionTests: XCTestCase {
 
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1000, eventType: "test event 1"))
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 2000, eventType: "test event 2"))
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -123,6 +125,7 @@ final class AmplitudeSessionTests: XCTestCase {
         let eventType = "out of session event"
         amplitude.track(eventType: eventType, options: eventOptions)
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1050, eventType: "test event"))
+        amplitude.waitForTrackingQueue()
         let collectedEvents = eventCollector.events
         XCTAssertEqual(collectedEvents.count, 2)
         var event = collectedEvents[0]
@@ -146,6 +149,8 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.onEnterForeground(timestamp: 1000)
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1050, eventType: "test event 1"))
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 2000, eventType: "test event 2"))
+
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -183,6 +188,8 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.onEnterForeground(timestamp: 1050)
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 2000, eventType: "test event 2"))
 
+        amplitude.waitForTrackingQueue()
+
         let collectedEvents = eventCollector.events
 
         XCTAssertEqual(collectedEvents.count, 3)
@@ -218,6 +225,8 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1000, eventType: "test event 1"))
         amplitude.onEnterForeground(timestamp: 2000)
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 3000, eventType: "test event 2"))
+
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -267,6 +276,7 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1500, eventType: "test event 1"))
         amplitude.onExitForeground(timestamp: 2000)
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 2050, eventType: "test event 2"))
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -304,6 +314,7 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1500, eventType: "test event 1"))
         amplitude.onExitForeground(timestamp: 2000)
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 3000, eventType: "test event 2"))
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -343,6 +354,7 @@ final class AmplitudeSessionTests: XCTestCase {
     func testSessionDataShouldBePersisted() throws {
         let amplitude1 = Amplitude(configuration: configuration)
         amplitude1.onEnterForeground(timestamp: 1000)
+        amplitude1.waitForTrackingQueue()
 
         XCTAssertEqual(amplitude1.sessionId, 1000)
         XCTAssertEqual(amplitude1.sessions.sessionId, 1000)
@@ -350,6 +362,7 @@ final class AmplitudeSessionTests: XCTestCase {
         XCTAssertEqual(amplitude1.sessions.lastEventId, 1)
 
         amplitude1.track(event: BaseEvent(userId: "user", timestamp: 1200, eventType: "test event 1"))
+        amplitude1.waitForTrackingQueue()
 
         XCTAssertEqual(amplitude1.sessionId, 1000)
         XCTAssertEqual(amplitude1.sessions.sessionId, 1000)
@@ -357,6 +370,7 @@ final class AmplitudeSessionTests: XCTestCase {
         XCTAssertEqual(amplitude1.sessions.lastEventId, 2)
 
         let amplitude2 = Amplitude(configuration: configuration)
+        amplitude2.waitForTrackingQueue()
 
         XCTAssertEqual(amplitude2.sessionId, 1000)
         XCTAssertEqual(amplitude2.sessions.sessionId, 1000)
@@ -376,6 +390,7 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1000, eventType: "test event 1"))
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1050, sessionId: 3000, eventType: "test event 2"))
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1100, eventType: "test event 3"))
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -418,6 +433,7 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1000, eventType: "test event 1"))
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1050, sessionId: -1, eventType: "test event 2"))
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1100, eventType: "test event 3"))
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -460,6 +476,7 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 100, eventType: "test event 1"))
         amplitude.setSessionId(timestamp: 150)
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 200, eventType: "test event 2"))
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -509,6 +526,7 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1050, eventType: "test event 1"))
         amplitude.setSessionId(timestamp: 1100)
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 2000, eventType: "test event 2"))
+        amplitude.waitForTrackingQueue()
 
         let collectedEvents = eventCollector.events
 
@@ -555,12 +573,15 @@ final class AmplitudeSessionTests: XCTestCase {
         amplitude.add(plugin: eventCollector)
 
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1000, eventType: "test event 1"))
+        amplitude.waitForTrackingQueue()
         XCTAssertEqual(amplitude.sessionId, 1000)
 
         amplitude.setSessionId(timestamp: -1)
+        amplitude.waitForTrackingQueue()
         XCTAssertEqual(amplitude.sessionId, -1)
 
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 2000, eventType: "test event 2"))
+        amplitude.waitForTrackingQueue()
         XCTAssertEqual(amplitude.sessionId, 2000)
 
         let collectedEvents = eventCollector.events
@@ -609,12 +630,15 @@ final class AmplitudeSessionTests: XCTestCase {
 
         amplitude.onEnterForeground(timestamp: 1000)
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 1500, eventType: "test event 1"))
+        amplitude.waitForTrackingQueue()
         XCTAssertEqual(amplitude.sessionId, 1000)
 
         amplitude.setSessionId(timestamp: -1)
+        amplitude.waitForTrackingQueue()
         XCTAssertEqual(amplitude.sessionId, -1)
 
         amplitude.track(event: BaseEvent(userId: "user", timestamp: 2000, eventType: "test event 2"))
+        amplitude.waitForTrackingQueue()
         XCTAssertEqual(amplitude.sessionId, 2000)
 
         let collectedEvents = eventCollector.events

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -173,7 +173,6 @@ final class PersistentStorageTests: XCTestCase {
         let partial = "{\"event_type\":\"test1\",\"user_id\":\"159995596214061\",\"device_id\":\"9b935bb3cd75\","
         let malformedContent = "\(event1.toString())\(PersistentStorage.DELMITER)\(partial)\(PersistentStorage.DELMITER)"
         writeContent(file: currentFile, content: malformedContent)
-        let rawFiles = try? FileManager.default.contentsOfDirectory(at: storeDirectory, includingPropertiesForKeys: nil)
         let eventFiles: [URL]? = persistentStorage.read(key: StorageKey.EVENTS)
         XCTAssertEqual(eventFiles?.count, 1)
 

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -306,7 +306,7 @@ final class MockPathCreation: PathCreationProtocol {
     var networkPathPublisher: AnyPublisher<NetworkPath, Never>?
     private let subject = PassthroughSubject<NetworkPath, Never>()
 
-    func start() {
+    func start(queue: DispatchQueue) {
         networkPathPublisher = subject.eraseToAnyPublisher()
     }
 

--- a/Tests/AmplitudeTests/TimelineTests.swift
+++ b/Tests/AmplitudeTests/TimelineTests.swift
@@ -17,7 +17,7 @@ final class TimelineTests: XCTestCase {
         amplitude.add(plugin: testPlugin)
         amplitude.track(event: BaseEvent(eventType: "testEvent"))
 
-        wait(for: [expectation], timeout: 1.0)
+        wait(for: [expectation], timeout: 10.0)
     }
 
     func testTimelineWithTwoPlugin() {
@@ -38,6 +38,6 @@ final class TimelineTests: XCTestCase {
         amplitude.add(plugin: testPlugin2)
         amplitude.track(event: BaseEvent(eventType: "testEvent"))
 
-        wait(for: [expectation, expectation2], timeout: 1.0)
+        wait(for: [expectation, expectation2], timeout: 10.0)
     }
 }

--- a/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
+++ b/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
@@ -135,9 +135,8 @@ final class IdentifyInterceptorTests: XCTestCase {
             destination: ["key-1": nil, "key-2": "value-2", "key-3": nil, "key-4": nil],
             source: ["key-1": "value-1", "key-2": nil, "key-3": nil, "key-5": nil]
         )
-        XCTAssertTrue(getDictionary(merged).isEqual(
-            to: ["key-1": "value-1", "key-2": "value-2", "key-3": nil, "key-4": nil, "key-5": nil])
-        )
+        XCTAssertEqual(getDictionary(merged),
+                       ["key-1": "value-1", "key-2": "value-2", "key-3": nil, "key-4": nil, "key-5": nil] as NSDictionary)
 
         merged = interceptor.mergeUserProperties(
             destination: ["key-1": NSNull(), "key-2": "value-2", "key-3": NSNull(), "key-4": NSNull()],


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Dispatch most public APIs and callbacks for timers and network calls to an internal queue to improve consistency. This also allows us to move work from the calling thread which is expected to be main for many view interactions. 

This comes with 2 behavioral changes:
- Any api call which generates an event no longer guarantees that the event would be recorded to disk when the call returns
- setSessionId no longer immediately sets the sessionId, and subsequent calls to getSessionId may return the previous sessionId until this completes.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
