### PR TITLE
feat: Fix retain cycles in Amplitude so instance will not leak memory

### DIFF
--- a/Sources/Amplitude/Plugins/AnalyticsConnectorPlugin.swift
+++ b/Sources/Amplitude/Plugins/AnalyticsConnectorPlugin.swift
@@ -8,12 +8,17 @@ class AnalyticsConnectorPlugin: BeforePlugin {
     override func setup(amplitude: Amplitude) {
         super.setup(amplitude: amplitude)
         connector = AnalyticsConnector.getInstance(amplitude.configuration.instanceName)
-        connector!.eventBridge.setEventReceiver { event in
-            amplitude.track(event: BaseEvent(
-                eventType: event.eventType,
-                eventProperties: event.eventProperties as? [String: Any],
-                userProperties: event.userProperties as? [String: Any]
-            ))
+        let logger = amplitude.logger
+        connector!.eventBridge.setEventReceiver { [weak amplitude, logger] event in
+            if let amplitude = amplitude {
+                amplitude.track(event: BaseEvent(
+                    eventType: event.eventType,
+                    eventProperties: event.eventProperties as? [String: Any],
+                    userProperties: event.userProperties as? [String: Any]
+                ))
+            } else {
+                logger?.error(message: "Amplitude instance has been deallocated, please maintain a strong reference to track events from Experiment")
+            }
         }
     }
 

--- a/Sources/Amplitude/Utilities/DefaultEventUtils.swift
+++ b/Sources/Amplitude/Utilities/DefaultEventUtils.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public class DefaultEventUtils {
-    private var amplitude: Amplitude?
+    private weak var amplitude: Amplitude?
 
     public init(amplitude: Amplitude) {
         self.amplitude = amplitude

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -43,7 +43,7 @@ final class EventPipelineTests: XCTestCase {
     }
 
     func testInit() {
-        XCTAssertEqual(pipeline.amplitude.configuration.apiKey, configuration.apiKey)
+        XCTAssertEqual(pipeline.configuration.apiKey, configuration.apiKey)
     }
 
     func testPutEvent() {
@@ -77,18 +77,18 @@ final class EventPipelineTests: XCTestCase {
     }
 
     func testFlushWhenOffline() {
-        pipeline.amplitude.configuration.offline = false
+        pipeline.configuration.offline = false
 
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
 
         XCTAssertEqual(httpClient.uploadCount, 0)
-        XCTAssertEqual(pipeline.amplitude.configuration.offline, false)
+        XCTAssertEqual(pipeline.configuration.offline, false)
 
-        pipeline.amplitude.configuration.offline = true
+        pipeline.configuration.offline = true
         pipeline.flush()
 
-        XCTAssertEqual(pipeline.amplitude.configuration.offline, true)
+        XCTAssertEqual(pipeline.configuration.offline, true)
         XCTAssertEqual(httpClient.uploadCount, 0, "There should be no uploads when offline")
     }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fixes retain cycles internal to the Amplitude object, allowing it to correctly deallocate. (see https://github.com/amplitude/Amplitude-Swift/issues/44).

We also add a test ensuring that Amplitude will correctly deallocate to prevent this from happening in the future.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
