### PR TITLE
feat: support single-target Watch applications

### DIFF
--- a/Sources/Amplitude/Plugins/watchOS/WatchOSLifecycleMonitor.swift
+++ b/Sources/Amplitude/Plugins/watchOS/WatchOSLifecycleMonitor.swift
@@ -13,14 +13,14 @@
     class WatchOSLifecycleMonitor: UtilityPlugin {
         var wasBackgrounded: Bool = false
 
-        private var watchExtension = WKExtension.shared()
+        private var watchExtension = WKApplication.shared()
         private var appNotifications: [NSNotification.Name] = [
-            WKExtension.applicationWillEnterForegroundNotification,
-            WKExtension.applicationDidEnterBackgroundNotification,
+            WKApplication.willEnterForegroundNotification,
+            WKApplication.didEnterBackgroundNotification,
         ]
 
         override init() {
-            watchExtension = WKExtension.shared()
+            watchExtension = WKApplication.shared()
             super.init()
             setupListeners()
         }
@@ -28,9 +28,9 @@
         @objc
         func notificationResponse(notification: NSNotification) {
             switch notification.name {
-            case WKExtension.applicationWillEnterForegroundNotification:
+            case WKApplication.willEnterForegroundNotification:
                 self.applicationWillEnterForeground(notification: notification)
-            case WKExtension.applicationDidEnterBackgroundNotification:
+            case WKApplication.didEnterBackgroundNotification:
                 self.applicationDidEnterBackground(notification: notification)
             default:
                 break


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Moves WKExtension to WKApplication to allow for compatibility with single-target watchOS applications. Single-target watchOS applications have been the default since Xcode 13.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
