### PR TITLE
fix: support encoding UInt

### DIFF
--- a/Sources/Amplitude/Utilities/CodableExtension.swift
+++ b/Sources/Amplitude/Utilities/CodableExtension.swift
@@ -124,6 +124,8 @@ extension KeyedEncodingContainer {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? Int64 {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
+            } else if let val = item.value as? UInt {
+                try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? String {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? Double {
@@ -147,6 +149,8 @@ extension KeyedEncodingContainer {
             return
         }
         if let val = safeValue as? [Int] {
+            try self.encodeIfPresent(val, forKey: key)
+        } else if let val = safeValue as? [UInt] {
             try self.encodeIfPresent(val, forKey: key)
         } else if let val = safeValue as? [String] {
             try self.encodeIfPresent(val, forKey: key)
@@ -174,6 +178,8 @@ extension UnkeyedEncodingContainer {
         var container = self.nestedContainer(keyedBy: JSONCodingKeys.self)
         for item in value {
             if let val = item.value as? Int {
+                try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
+            } else if let val = item.value as? UInt {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? String {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Support encoding of `UInt` as a value for event properties.

We, as users of the sdk, noticed our properties with UInt's got dropped. It worked in the old sdk at https://github.com/amplitude/Amplitude-iOS and in our opinion UInts should be supported since we and others use them extensively for IDs, counts, etc...

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
