### PR TITLE
fix: Improve application opened event reliability

### DIFF
--- a/Sources/Amplitude/Utilities/DefaultEventUtils.swift
+++ b/Sources/Amplitude/Utilities/DefaultEventUtils.swift
@@ -29,11 +29,6 @@ public class DefaultEventUtils {
                     Constants.AMP_APP_PREVIOUS_VERSION_PROPERTY: previousVersion ?? "",
                 ])
             }
-            self.amplitude?.track(eventType: Constants.AMP_APPLICATION_OPENED_EVENT, eventProperties: [
-                Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
-                Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
-                Constants.AMP_APP_FROM_BACKGROUND_PROPERTY: false,
-            ])
         }
 
         if currentBuild != previousBuild {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Background tasks can launch an app without it ever being foregrounded, meaning our application opened event is not accurately being recorded. This mirrors changes in [Amplitude-iOS](https://github.com/amplitude/Amplitude-iOS/blob/bfdec453a31fd35942a619ef472fcf2f09e2313a/Sources/Amplitude/Amplitude.m#L458) that use application state to detect whether an app launch was from the background vs tracking didEnterForeground and didFinishLaunching notifications to infer background state.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
