### PR TITLE
fix: Disable network connectivity check on watchOS as it is not supported on real devices

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -55,7 +55,8 @@ public class Amplitude {
             state.userId = userId
         }
 
-        if self.configuration.offline != NetworkConnectivityCheckerPlugin.Disabled {
+        if configuration.offline != NetworkConnectivityCheckerPlugin.Disabled,
+           VendorSystem.current.networkConnectivityCheckingEnabled {
             _ = add(plugin: NetworkConnectivityCheckerPlugin())
         }
         // required plugin for specific platform, only has lifecyclePlugin now

--- a/Sources/Amplitude/Plugins/Vendors/AppUtil.swift
+++ b/Sources/Amplitude/Plugins/Vendors/AppUtil.swift
@@ -245,6 +245,12 @@ import Foundation
         override var requiredPlugin: Plugin {
             return WatchOSLifecycleMonitor()
         }
+
+        // Per https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos,
+        // NWPathMonitor is not supported on most WatchOS apps when running on a real device.
+        override var networkConnectivityCheckingEnabled: Bool {
+            return false
+        }
     }
 #endif
 

--- a/Sources/Amplitude/Plugins/Vendors/VendorSystem.swift
+++ b/Sources/Amplitude/Plugins/Vendors/VendorSystem.swift
@@ -48,6 +48,10 @@ internal class VendorSystem {
         return nil
     }
 
+    var networkConnectivityCheckingEnabled: Bool {
+        return true
+    }
+
     func beginBackgroundTask() -> BackgroundTaskCompletionCallback? {
         return nil
     }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Per Apple's [docs](https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos) on WatchOS, "... NWPathMonitor will remain in the .unsatisfied state.", meaning we will never attempt a connection once the connectivity checker runs. This is only blocked on a real device, and WatchOS 6-8 may still have inadvertently worked.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
