### PR TITLE
fix: dispatch identify interceptor callbacks on correct queue

### DIFF
--- a/Sources/Amplitude/Plugins/AmplitudeDestinationPlugin.swift
+++ b/Sources/Amplitude/Plugins/AmplitudeDestinationPlugin.swift
@@ -52,7 +52,8 @@ public class AmplitudeDestinationPlugin: DestinationPlugin {
         pipeline = EventPipeline(amplitude: amplitude)
         identifyInterceptor = IdentifyInterceptor(
             configuration: amplitude.configuration,
-            pipeline: pipeline!
+            pipeline: pipeline!,
+            queue: amplitude.trackingQueue
         )
         pipeline?.start()
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Dispatches IdentifyInterceptor's callback on the correct queue (vs main). 

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
