### PR TITLE
fix: resolve compilation issue with watchOS 8.0

### DIFF
--- a/Sources/Amplitude/Plugins/watchOS/WatchOSLifecycleMonitor.swift
+++ b/Sources/Amplitude/Plugins/watchOS/WatchOSLifecycleMonitor.swift
@@ -13,14 +13,12 @@
     class WatchOSLifecycleMonitor: UtilityPlugin {
         var wasBackgrounded: Bool = false
 
-        private var watchExtension = WKApplication.shared()
         private var appNotifications: [NSNotification.Name] = [
-            WKApplication.willEnterForegroundNotification,
-            WKApplication.didEnterBackgroundNotification,
+            WKExtension.applicationWillEnterForegroundNotification,
+            WKExtension.applicationDidEnterBackgroundNotification,
         ]
 
         override init() {
-            watchExtension = WKApplication.shared()
             super.init()
             setupListeners()
         }
@@ -28,9 +26,9 @@
         @objc
         func notificationResponse(notification: NSNotification) {
             switch notification.name {
-            case WKApplication.willEnterForegroundNotification:
+            case WKExtension.applicationWillEnterForegroundNotification:
                 self.applicationWillEnterForeground(notification: notification)
-            case WKApplication.didEnterBackgroundNotification:
+            case WKExtension.applicationDidEnterBackgroundNotification:
                 self.applicationDidEnterBackground(notification: notification)
             default:
                 break
@@ -51,18 +49,11 @@
         }
 
         func applicationWillEnterForeground(notification: NSNotification) {
-            // watchOS will receive this after didFinishLaunching, which is different
-            // from iOS, so ignore until we've been backgrounded at least once.
-            if wasBackgrounded == false { return }
-
             let timestamp = Int64(NSDate().timeIntervalSince1970 * 1000)
             self.amplitude?.onEnterForeground(timestamp: timestamp)
         }
 
         func applicationDidEnterBackground(notification: NSNotification) {
-            // make sure to denote that we were backgrounded.
-            wasBackgrounded = true
-
             let timestamp = Int64(NSDate().timeIntervalSince1970 * 1000)
             self.amplitude?.onExitForeground(timestamp: timestamp)
         }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- Remove unused WKApplication reference
- Use app lifecycle notifications from WKExtension, not WKApplication, which are supported on WatchOS 18. (These should be equivalent as both notification rawValues are the same).
- Remove wasBackgrounded check, which did not appear to work properly as we were only tracking `didFinishLaunching` in the iOS lifecycle monitor.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
