### PR TITLE
fix: Don't use idfv for deviceId if invalid

### DIFF
--- a/Sources/Amplitude/Plugins/ContextPlugin.swift
+++ b/Sources/Amplitude/Plugins/ContextPlugin.swift
@@ -161,7 +161,9 @@ class ContextPlugin: BeforePlugin {
             return
         }
         if deviceId == nil, amplitude?.configuration.trackingOptions.shouldTrackIDFV() ?? false {
-            deviceId = staticContext["idfv"] as? String
+            if let idfv = staticContext["idfv"] as? String, idfv != "00000000-0000-0000-0000-000000000000" {
+                deviceId = idfv
+            }
         }
         if deviceId == nil {
             deviceId = NSUUID().uuidString


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fix for https://github.com/amplitude/Amplitude-Swift/issues/182

If we cannot retrieve a valid device id from the IDFV, fall back to using a generic uuid. This mirrors logic from the legacy SDK where the vendor id getter considers '00000000-0000-0000-0000-000000000000' as nil, but doesn't block an explicitly set id with the same value.

Note that clients who have already persisted an invalid deviceId will not be updated, and will need to either reset their amplitude instance, or set a new deviceId.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No