### PR TITLE
fix: add support for Decimal property values

### DIFF
--- a/Sources/Amplitude/Utilities/CodableExtension.swift
+++ b/Sources/Amplitude/Utilities/CodableExtension.swift
@@ -134,6 +134,8 @@ extension KeyedEncodingContainer {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? CGFloat {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
+            } else if let val = item.value as? Decimal {
+                try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? Bool {
                 try container.encodeIfPresent(val, forKey: JSONCodingKeys(stringValue: item.key)!)
             } else if let val = item.value as? [Any] {

--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -64,8 +64,8 @@ final class BaseEventTests: XCTestCase {
             3.14
         )
         XCTAssertEqual(
-            Decimal(floatLiteral: baseEventDict!["event_properties"]!["decimal" as NSString] as! Double),
-            Decimal(floatLiteral: 3.14)
+            Decimal(baseEventDict!["event_properties"]!["decimal" as NSString] as! Double),
+            Decimal(3.14)
         )
         XCTAssertEqual(
             baseEventDict!["event_properties"]!["string" as NSString] as! String,

--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -31,7 +31,8 @@ final class BaseEventTests: XCTestCase {
                 "int64": 1 as Int64,
                 "int32": 1 as Int32,
                 "cgfloat": 3.14 as CGFloat,
-                "double": 3.14 as Double
+                "double": 3.14 as Double,
+                "decimal": 3.14 as Decimal
             ]
         )
 
@@ -61,6 +62,10 @@ final class BaseEventTests: XCTestCase {
         XCTAssertEqual(
             baseEventDict!["event_properties"]!["double" as NSString] as! Double,
             3.14
+        )
+        XCTAssertEqual(
+            Decimal(floatLiteral: baseEventDict!["event_properties"]!["decimal" as NSString] as! Double),
+            Decimal(floatLiteral: 3.14)
         )
         XCTAssertEqual(
             baseEventDict!["event_properties"]!["string" as NSString] as! String,


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This simple adding fixes converting dictionary which contains decimal value and passing through API.

We've faced with issue that decimal values were ignored on Amplitude console on this framework, but legacy framework works well.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
