### PR TITLE
fix: set application as a computed property

### DIFF
--- a/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
+++ b/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
@@ -7,131 +7,131 @@
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
-    import Foundation
-    import SwiftUI
+import Foundation
+import SwiftUI
 
-    class IOSLifecycleMonitor: UtilityPlugin {
-        private var application: UIApplication?
-        private var appNotifications: [NSNotification.Name] = [
-            UIApplication.didEnterBackgroundNotification,
-            UIApplication.willEnterForegroundNotification,
-            UIApplication.didFinishLaunchingNotification,
-            UIApplication.didBecomeActiveNotification,
-        ]
-        private var utils: DefaultEventUtils?
-        private var sendApplicationOpenedOnDidBecomeActive = false
+class IOSLifecycleMonitor: UtilityPlugin {
+    private var application: UIApplication?
+    private var appNotifications: [NSNotification.Name] = [
+        UIApplication.didEnterBackgroundNotification,
+        UIApplication.willEnterForegroundNotification,
+        UIApplication.didFinishLaunchingNotification,
+        UIApplication.didBecomeActiveNotification,
+    ]
+    private var utils: DefaultEventUtils?
+    private var sendApplicationOpenedOnDidBecomeActive = false
 
-        override init() {
-            // TODO: Check if lifecycle plugin works for app extension
-            // App extensions can't use UIApplication.shared, so
-            // funnel it through something to check; Could be nil.
-            application = UIApplication.value(forKeyPath: "sharedApplication") as? UIApplication
-            super.init()
-            setupListeners()
-        }
+    override init() {
+        // TODO: Check if lifecycle plugin works for app extension
+        // App extensions can't use UIApplication.shared, so
+        // funnel it through something to check; Could be nil.
+        application = UIApplication.value(forKeyPath: "sharedApplication") as? UIApplication
+        super.init()
+        setupListeners()
+    }
 
-        public override func setup(amplitude: Amplitude) {
-            super.setup(amplitude: amplitude)
-            utils = DefaultEventUtils(amplitude: amplitude)
-            if amplitude.configuration.defaultTracking.screenViews {
-                UIKitScreenViews.register(amplitude)
-            }
-        }
-
-        @objc
-        func notificationResponse(notification: Notification) {
-            switch notification.name {
-            case UIApplication.didEnterBackgroundNotification:
-                didEnterBackground(notification: notification)
-            case UIApplication.willEnterForegroundNotification:
-                applicationWillEnterForeground(notification: notification)
-            case UIApplication.didFinishLaunchingNotification:
-                applicationDidFinishLaunchingNotification(notification: notification)
-            case UIApplication.didBecomeActiveNotification:
-                applicationDidBecomeActive(notification: notification)
-            default:
-                break
-            }
-        }
-
-        func setupListeners() {
-            // Configure the current life cycle events
-            let notificationCenter = NotificationCenter.default
-            for notification in appNotifications {
-                notificationCenter.addObserver(
-                    self,
-                    selector: #selector(notificationResponse(notification:)),
-                    name: notification,
-                    object: application
-                )
-            }
-
-        }
-
-        func applicationWillEnterForeground(notification: Notification) {
-            let timestamp = Int64(NSDate().timeIntervalSince1970 * 1000)
-
-            let fromBackground: Bool
-            if let sharedApplication = application {
-                switch sharedApplication.applicationState {
-                case .active, .inactive:
-                    fromBackground = false
-                case .background:
-                    fromBackground = true
-                @unknown default:
-                    fromBackground = false
-                }
-            } else {
-                fromBackground = false
-            }
-
-            amplitude?.onEnterForeground(timestamp: timestamp)
-            sendApplicationOpened(fromBackground: fromBackground)
-        }
-
-        func didEnterBackground(notification: Notification) {
-            let timestamp = Int64(NSDate().timeIntervalSince1970 * 1000)
-            self.amplitude?.onExitForeground(timestamp: timestamp)
-            if self.amplitude?.configuration.defaultTracking.appLifecycles == true {
-                self.amplitude?.track(eventType: Constants.AMP_APPLICATION_BACKGROUNDED_EVENT)
-            }
-        }
-
-        func applicationDidFinishLaunchingNotification(notification: Notification) {
-            utils?.trackAppUpdatedInstalledEvent()
-
-            // Pre SceneDelegate apps wil not fire a willEnterForeground notification on app launch.
-            // Instead, use the initial applicationDidBecomeActive
-            let usesSceneDelegate = application?.delegate?.responds(to: #selector(UIApplicationDelegate.application(_:configurationForConnecting:options:))) ?? false
-            if !usesSceneDelegate {
-                sendApplicationOpenedOnDidBecomeActive = true
-            }
-        }
-
-        func applicationDidBecomeActive(notification: Notification) {
-            guard sendApplicationOpenedOnDidBecomeActive else {
-                return
-            }
-            sendApplicationOpenedOnDidBecomeActive = false
-
-            let timestamp = Int64(NSDate().timeIntervalSince1970 * 1000)
-            amplitude?.onEnterForeground(timestamp: timestamp)
-            sendApplicationOpened(fromBackground: false)
-        }
-
-        private func sendApplicationOpened(fromBackground: Bool) {
-            guard amplitude?.configuration.defaultTracking.appLifecycles ?? false else {
-                return
-            }
-            let info = Bundle.main.infoDictionary
-            let currentBuild = info?["CFBundleVersion"] as? String
-            let currentVersion = info?["CFBundleShortVersionString"] as? String
-            self.amplitude?.track(eventType: Constants.AMP_APPLICATION_OPENED_EVENT, eventProperties: [
-                Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
-                Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
-                Constants.AMP_APP_FROM_BACKGROUND_PROPERTY: fromBackground,
-            ])
+    public override func setup(amplitude: Amplitude) {
+        super.setup(amplitude: amplitude)
+        utils = DefaultEventUtils(amplitude: amplitude)
+        if amplitude.configuration.defaultTracking.screenViews {
+            UIKitScreenViews.register(amplitude)
         }
     }
+
+    @objc
+    func notificationResponse(notification: Notification) {
+        switch notification.name {
+        case UIApplication.didEnterBackgroundNotification:
+            didEnterBackground(notification: notification)
+        case UIApplication.willEnterForegroundNotification:
+            applicationWillEnterForeground(notification: notification)
+        case UIApplication.didFinishLaunchingNotification:
+            applicationDidFinishLaunchingNotification(notification: notification)
+        case UIApplication.didBecomeActiveNotification:
+            applicationDidBecomeActive(notification: notification)
+        default:
+            break
+        }
+    }
+
+    func setupListeners() {
+        // Configure the current life cycle events
+        let notificationCenter = NotificationCenter.default
+        for notification in appNotifications {
+            notificationCenter.addObserver(
+                self,
+                selector: #selector(notificationResponse(notification:)),
+                name: notification,
+                object: application
+            )
+        }
+
+    }
+
+    func applicationWillEnterForeground(notification: Notification) {
+        let timestamp = Int64(NSDate().timeIntervalSince1970 * 1000)
+
+        let fromBackground: Bool
+        if let sharedApplication = application {
+            switch sharedApplication.applicationState {
+            case .active, .inactive:
+                fromBackground = false
+            case .background:
+                fromBackground = true
+            @unknown default:
+                fromBackground = false
+            }
+        } else {
+            fromBackground = false
+        }
+
+        amplitude?.onEnterForeground(timestamp: timestamp)
+        sendApplicationOpened(fromBackground: fromBackground)
+    }
+
+    func didEnterBackground(notification: Notification) {
+        let timestamp = Int64(NSDate().timeIntervalSince1970 * 1000)
+        self.amplitude?.onExitForeground(timestamp: timestamp)
+        if self.amplitude?.configuration.defaultTracking.appLifecycles == true {
+            self.amplitude?.track(eventType: Constants.AMP_APPLICATION_BACKGROUNDED_EVENT)
+        }
+    }
+
+    func applicationDidFinishLaunchingNotification(notification: Notification) {
+        utils?.trackAppUpdatedInstalledEvent()
+
+        // Pre SceneDelegate apps wil not fire a willEnterForeground notification on app launch.
+        // Instead, use the initial applicationDidBecomeActive
+        let usesSceneDelegate = application?.delegate?.responds(to: #selector(UIApplicationDelegate.application(_:configurationForConnecting:options:))) ?? false
+        if !usesSceneDelegate {
+            sendApplicationOpenedOnDidBecomeActive = true
+        }
+    }
+
+    func applicationDidBecomeActive(notification: Notification) {
+        guard sendApplicationOpenedOnDidBecomeActive else {
+            return
+        }
+        sendApplicationOpenedOnDidBecomeActive = false
+
+        let timestamp = Int64(NSDate().timeIntervalSince1970 * 1000)
+        amplitude?.onEnterForeground(timestamp: timestamp)
+        sendApplicationOpened(fromBackground: false)
+    }
+
+    private func sendApplicationOpened(fromBackground: Bool) {
+        guard amplitude?.configuration.defaultTracking.appLifecycles ?? false else {
+            return
+        }
+        let info = Bundle.main.infoDictionary
+        let currentBuild = info?["CFBundleVersion"] as? String
+        let currentVersion = info?["CFBundleShortVersionString"] as? String
+        self.amplitude?.track(eventType: Constants.AMP_APPLICATION_OPENED_EVENT, eventProperties: [
+            Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
+            Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
+            Constants.AMP_APP_FROM_BACKGROUND_PROPERTY: fromBackground,
+        ])
+    }
+}
 
 #endif

--- a/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
+++ b/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
@@ -17,7 +17,7 @@ class IOSLifecycleMonitor: UtilityPlugin {
         // funnel it through something to check; Could be nil.
         UIApplication.value(forKeyPath: "sharedApplication") as? UIApplication
     }
-    
+
     private var appNotifications: [NSNotification.Name] = [
         UIApplication.didEnterBackgroundNotification,
         UIApplication.willEnterForegroundNotification,

--- a/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
+++ b/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
@@ -11,7 +11,13 @@ import Foundation
 import SwiftUI
 
 class IOSLifecycleMonitor: UtilityPlugin {
-    private var application: UIApplication?
+    private var application: UIApplication? {
+        // TODO: Check if lifecycle plugin works for app extension
+        // App extensions can't use UIApplication.shared, so
+        // funnel it through something to check; Could be nil.
+        UIApplication.value(forKeyPath: "sharedApplication") as? UIApplication
+    }
+    
     private var appNotifications: [NSNotification.Name] = [
         UIApplication.didEnterBackgroundNotification,
         UIApplication.willEnterForegroundNotification,
@@ -22,10 +28,6 @@ class IOSLifecycleMonitor: UtilityPlugin {
     private var sendApplicationOpenedOnDidBecomeActive = false
 
     override init() {
-        // TODO: Check if lifecycle plugin works for app extension
-        // App extensions can't use UIApplication.shared, so
-        // funnel it through something to check; Could be nil.
-        application = UIApplication.value(forKeyPath: "sharedApplication") as? UIApplication
         super.init()
         setupListeners()
     }


### PR DESCRIPTION
### Summary

This PR fixes the issue with the `application` instance being `nil` if `Amplitude` is initialized before the app starts. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
