### PR TITLE
fix: track touchupinside and valuechanged only

### DIFF
--- a/Sources/Amplitude/Plugins/iOS/UIKitUserInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitUserInteractions.swift
@@ -68,7 +68,7 @@ extension UIApplication {
 
         guard sendActionResult,
             let view = sender as? UIView,
-            view.amp_shouldTrack(action, for: event),
+            view.amp_shouldTrack(action, for: target),
             let actionName = NSStringFromSelector(action)
                 .components(separatedBy: ":")
                 .first
@@ -178,41 +178,44 @@ extension NSObject {
 
 protocol ActionTrackable {
     var amp_title: String? { get }
-    func amp_shouldTrack(_ action: Selector, for event: UIEvent?) -> Bool
+    func amp_shouldTrack(_ action: Selector, for target: Any?) -> Bool
 }
 
 extension UIView: ActionTrackable {
     @objc var amp_title: String? { nil }
-    @objc func amp_shouldTrack(_ action: Selector, for event: UIEvent?) -> Bool { true }
+    @objc func amp_shouldTrack(_ action: Selector, for target: Any?) -> Bool { false }
 }
 
 extension UIButton {
     override var amp_title: String? { currentTitle }
+    override func amp_shouldTrack(_ action: Selector, for target: Any?) -> Bool {
+        actions(forTarget: target, forControlEvent: .touchUpInside)?.contains(action.description) ?? false
+    }
 }
 
 extension UISegmentedControl {
     override var amp_title: String? { titleForSegment(at: selectedSegmentIndex) }
-}
-
-extension UITextField {
-    override func amp_shouldTrack(_ action: Selector, for event: UIEvent?) -> Bool { false }
-}
-
-extension UITextView {
-    override func amp_shouldTrack(_ action: Selector, for event: UIEvent?) -> Bool { false }
-}
-
-#if !os(tvOS)
-extension UISlider {
-    override func amp_shouldTrack(_ action: Selector, for event: UIEvent?) -> Bool {
-        event?.allTouches?.contains { $0.phase == .ended && $0.view === self } ?? false
+    override func amp_shouldTrack(_ action: Selector, for target: Any?) -> Bool {
+        actions(forTarget: target, forControlEvent: .valueChanged)?.contains(action.description) ?? false
     }
 }
 
-@available(iOS 14.0, *)
-extension UIColorWell {
-    override var amp_title: String? { title }
+extension UIDatePicker {
+    override func amp_shouldTrack(_ action: Selector, for target: Any?) -> Bool {
+        actions(forTarget: target, forControlEvent: .valueChanged)?.contains(action.description) ?? false
+    }
 }
-#endif
+
+extension UIPageControl {
+    override func amp_shouldTrack(_ action: Selector, for target: Any?) -> Bool {
+        actions(forTarget: target, forControlEvent: .valueChanged)?.contains(action.description) ?? false
+    }
+}
+
+extension UISwitch {
+    override func amp_shouldTrack(_ action: Selector, for target: Any?) -> Bool {
+        actions(forTarget: target, forControlEvent: .valueChanged)?.contains(action.description) ?? false
+    }
+}
 
 #endif

--- a/Sources/Amplitude/Plugins/iOS/UIKitUserInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitUserInteractions.swift
@@ -200,13 +200,14 @@ extension UISegmentedControl {
     }
 }
 
-extension UIDatePicker {
+extension UIPageControl {
     override func amp_shouldTrack(_ action: Selector, for target: Any?) -> Bool {
         actions(forTarget: target, forControlEvent: .valueChanged)?.contains(action.description) ?? false
     }
 }
 
-extension UIPageControl {
+#if !os(tvOS)
+extension UIDatePicker {
     override func amp_shouldTrack(_ action: Selector, for target: Any?) -> Bool {
         actions(forTarget: target, forControlEvent: .valueChanged)?.contains(action.description) ?? false
     }
@@ -217,5 +218,6 @@ extension UISwitch {
         actions(forTarget: target, forControlEvent: .valueChanged)?.contains(action.description) ?? false
     }
 }
+#endif
 
 #endif


### PR DESCRIPTION
### Summary

Support only touchUpInside for UIButtons and valueChange for most.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
