### PR TITLE
fix: disable swiftui support for autocapture

### DIFF
--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -93,7 +93,7 @@ class UIKitElementInteractions {
 extension UIApplication {
     @objc func amp_sendAction(_ action: Selector, to target: Any?, from sender: Any?, for event: UIEvent?) -> Bool {
         let sendActionResult = amp_sendAction(action, to: target, from: sender, for: event)
-        
+
         // TODO: Reduce SwiftUI noise by finding the unique view that the action method is attached to.
         // Currently, the action methods pointing to a SwiftUI target are blocked.
         let targetClass = NSStringFromClass(type(of: target as AnyObject))
@@ -122,11 +122,11 @@ extension UIGestureRecognizer {
         amp_setState(state)
 
         guard state == .ended, let view else { return }
-        
+
         // TODO: Reduce SwiftUI noise by filtering out system gesture recognizers.
         // Currently, the gesture recognizers with a SwiftUI view are blocked.
-        let targetClass = NSStringFromClass(type(of: view as AnyObject))
-        if targetClass.contains("SwiftUI") {
+        let viewClass = NSStringFromClass(type(of: view as AnyObject))
+        if viewClass.contains("SwiftUI") {
             return
         }
 

--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -63,6 +63,7 @@ class UIKitElementInteractions {
 
     @objc static func didEndEditing(_ notification: NSNotification) {
         guard let view = notification.object as? UIView else { return }
+        // Text fields in SwiftUI are identifiable only after the text field is edited.
         let elementInteractionEvent = view.eventData.elementInteractionEvent(for: "didEndEditing")
         amplitudeInstances.allObjects.forEach {
             $0.track(event: elementInteractionEvent)
@@ -121,6 +122,13 @@ extension UIGestureRecognizer {
         amp_setState(state)
 
         guard state == .ended, let view else { return }
+        
+        // TODO: Reduce SwiftUI noise by filtering out system gesture recognizers.
+        // Currently, the gesture recognizers with a SwiftUI view are blocked.
+        let targetClass = NSStringFromClass(type(of: view as AnyObject))
+        if targetClass.contains("SwiftUI") {
+            return
+        }
 
         let gestureAction: String? = switch self {
         case is UITapGestureRecognizer: "tap"

--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -123,10 +123,8 @@ extension UIGestureRecognizer {
 
         guard state == .ended, let view else { return }
 
-        // TODO: Reduce SwiftUI noise by filtering out system gesture recognizers.
-        // Currently, the gesture recognizers with a SwiftUI view are blocked.
-        let viewClass = NSStringFromClass(type(of: view as AnyObject))
-        if viewClass.contains("SwiftUI") {
+        // Block scroll events for `UIScrollView`.
+        if view is UIScrollView && self is UIPanGestureRecognizer {
             return
         }
 

--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -92,6 +92,13 @@ class UIKitElementInteractions {
 extension UIApplication {
     @objc func amp_sendAction(_ action: Selector, to target: Any?, from sender: Any?, for event: UIEvent?) -> Bool {
         let sendActionResult = amp_sendAction(action, to: target, from: sender, for: event)
+        
+        // TODO: Reduce SwiftUI noise by finding the unique view that the action method is attached to.
+        // Currently, the action methods pointing to a SwiftUI target are blocked.
+        let targetClass = NSStringFromClass(type(of: target as AnyObject))
+        if targetClass.contains("SwiftUI") {
+            return sendActionResult
+        }
 
         guard sendActionResult,
               let control = sender as? UIControl,

--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -96,7 +96,7 @@ extension UIApplication {
 
         // TODO: Reduce SwiftUI noise by finding the unique view that the action method is attached to.
         // Currently, the action methods pointing to a SwiftUI target are blocked.
-        let targetClass = NSStringFromClass(type(of: target as AnyObject))
+        let targetClass = String(cString: object_getClassName(target))
         if targetClass.contains("SwiftUI") {
             return sendActionResult
         }
@@ -123,8 +123,8 @@ extension UIGestureRecognizer {
 
         guard state == .ended, let view else { return }
 
-        // Block scroll events for `UIScrollView`.
-        if view is UIScrollView && self is UIPanGestureRecognizer {
+        // Block scroll and zoom events for `UIScrollView`.
+        if let scrollView = view as? UIScrollView, self === scrollView.panGestureRecognizer || self === scrollView.pinchGestureRecognizer {
             return
         }
 


### PR DESCRIPTION
### Summary

This PR disables support for SwiftUI autocapture.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
