### PR TITLE
fix: track changes to defaultTracking after initialization

### DIFF
--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -38,7 +38,7 @@ public class Configuration {
     }() {
         didSet {
             defaultTracking.delegate = self
-            autocapture = defaultTracking.toAutocaptureOptions
+            autocapture = defaultTracking.autocaptureOptions
         }
     }
     public internal(set) var autocapture: AutocaptureOptions
@@ -97,7 +97,7 @@ public class Configuration {
             enableCoppaControl: enableCoppaControl,
             flushEventsOnClose: flushEventsOnClose,
             minTimeBetweenSessionsMillis: minTimeBetweenSessionsMillis,
-            autocapture: defaultTracking.toAutocaptureOptions,
+            autocapture: defaultTracking.autocaptureOptions,
             identifyBatchIntervalMillis: identifyBatchIntervalMillis,
             migrateLegacyData: migrateLegacyData,
             offline: offline)
@@ -180,5 +180,12 @@ public class Configuration {
 
     internal func getNormalizeInstanceName() -> String {
         return Configuration.getNormalizeInstanceName(self.instanceName)
+    }
+}
+
+extension Configuration: DefaultTrackingOptionsDelegate {
+    @available(*, deprecated)
+    func didChangeOptions(options: DefaultTrackingOptions) {
+        autocapture = options.autocaptureOptions
     }
 }

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -33,9 +33,13 @@ public class Configuration {
     public var identifyBatchIntervalMillis: Int
     public internal(set) var migrateLegacyData: Bool
     @available(*, deprecated, renamed: "autocapture", message: "Please use `autocapture` instead.")
-    /// The SDK no longer tracks changes to the defaultTracking options after initialization.
-    public var defaultTracking: DefaultTrackingOptions = DefaultTrackingOptions() {
-        didSet { autocapture = defaultTracking.autocaptureOptions }
+    public lazy var defaultTracking: DefaultTrackingOptions = {
+        DefaultTrackingOptions(with: self)
+    }() {
+        didSet {
+            defaultTracking.delegate = self
+            autocapture = defaultTracking.toAutocaptureOptions
+        }
     }
     public internal(set) var autocapture: AutocaptureOptions
     public var offline: Bool?
@@ -93,7 +97,7 @@ public class Configuration {
             enableCoppaControl: enableCoppaControl,
             flushEventsOnClose: flushEventsOnClose,
             minTimeBetweenSessionsMillis: minTimeBetweenSessionsMillis,
-            autocapture: defaultTracking.autocaptureOptions,
+            autocapture: defaultTracking.toAutocaptureOptions,
             identifyBatchIntervalMillis: identifyBatchIntervalMillis,
             migrateLegacyData: migrateLegacyData,
             offline: offline)

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -34,7 +34,7 @@ public class Configuration {
     public internal(set) var migrateLegacyData: Bool
     @available(*, deprecated, renamed: "autocapture", message: "Please use `autocapture` instead.")
     public lazy var defaultTracking: DefaultTrackingOptions = {
-        DefaultTrackingOptions(with: self)
+        DefaultTrackingOptions(delegate: self)
     }() {
         didSet {
             defaultTracking.delegate = self

--- a/Sources/Amplitude/DefaultTrackingOptions.swift
+++ b/Sources/Amplitude/DefaultTrackingOptions.swift
@@ -52,7 +52,7 @@ public class DefaultTrackingOptions {
         self.screenViews = screenViews
     }
 
-    convenience init(with delegate: DefaultTrackingOptionsDelegate) {
+    convenience init(delegate: DefaultTrackingOptionsDelegate) {
         self.init()
         self.delegate = delegate
     }

--- a/Sources/Amplitude/DefaultTrackingOptions.swift
+++ b/Sources/Amplitude/DefaultTrackingOptions.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+protocol DefaultTrackingOptionsDelegate: AnyObject {
+    @available(*, deprecated)
+    func didChangeOptions(options: DefaultTrackingOptions)
+}
+
 @available(*, deprecated, renamed: "AutocaptureOptions", message: "Please use `AutocaptureOptions` instead")
 public class DefaultTrackingOptions {
     public static var ALL: DefaultTrackingOptions {
@@ -29,7 +34,7 @@ public class DefaultTrackingOptions {
 
     weak var delegate: DefaultTrackingOptionsDelegate?
 
-    var toAutocaptureOptions: AutocaptureOptions {
+    var autocaptureOptions: AutocaptureOptions {
         return [
             sessions ? .sessions : [],
             appLifecycles ? .appLifecycles : [],
@@ -50,17 +55,5 @@ public class DefaultTrackingOptions {
     convenience init(with delegate: DefaultTrackingOptionsDelegate) {
         self.init()
         self.delegate = delegate
-    }
-}
-
-protocol DefaultTrackingOptionsDelegate: AnyObject {
-    @available(*, deprecated)
-    func didChangeOptions(options: DefaultTrackingOptions)
-}
-
-extension Configuration: DefaultTrackingOptionsDelegate {
-    @available(*, deprecated)
-    func didChangeOptions(options: DefaultTrackingOptions) {
-        autocapture = options.toAutocaptureOptions
     }
 }

--- a/Sources/Amplitude/DefaultTrackingOptions.swift
+++ b/Sources/Amplitude/DefaultTrackingOptions.swift
@@ -11,19 +11,19 @@ public class DefaultTrackingOptions {
 
     public var sessions: Bool {
         didSet {
-            delegate?.didChangeSessions(to: sessions)
+            delegate?.didChangeOptions(options: self)
         }
     }
 
     public var appLifecycles: Bool {
         didSet {
-            delegate?.didChangeAppLifecycles(to: appLifecycles)
+            delegate?.didChangeOptions(options: self)
         }
     }
 
     public var screenViews: Bool {
         didSet {
-            delegate?.didChangeScreenViews(to: screenViews)
+            delegate?.didChangeOptions(options: self)
         }
     }
 
@@ -54,29 +54,13 @@ public class DefaultTrackingOptions {
 }
 
 protocol DefaultTrackingOptionsDelegate: AnyObject {
-    func didChangeSessions(to newValue: Bool)
-    func didChangeAppLifecycles(to newValue: Bool)
-    func didChangeScreenViews(to newValue: Bool)
+    @available(*, deprecated)
+    func didChangeOptions(options: DefaultTrackingOptions)
 }
 
 extension Configuration: DefaultTrackingOptionsDelegate {
-    func didChangeSessions(to newValue: Bool) {
-        updateAutocapture(option: .sessions, enabled: newValue)
-    }
-
-    func didChangeAppLifecycles(to newValue: Bool) {
-        updateAutocapture(option: .appLifecycles, enabled: newValue)
-    }
-
-    func didChangeScreenViews(to newValue: Bool) {
-        updateAutocapture(option: .screenViews, enabled: newValue)
-    }
-
-    private func updateAutocapture(option: AutocaptureOptions, enabled: Bool) {
-        if enabled {
-            autocapture.insert(option)
-        } else {
-            autocapture.remove(option)
-        }
+    @available(*, deprecated)
+    func didChangeOptions(options: DefaultTrackingOptions) {
+        autocapture = options.toAutocaptureOptions
     }
 }

--- a/Tests/AmplitudeTests/AutocaptureOptionsTests.swift
+++ b/Tests/AmplitudeTests/AutocaptureOptionsTests.swift
@@ -18,4 +18,49 @@ final class AutocaptureOptionsTests: XCTestCase {
         XCTAssertFalse(options.contains(.sessions))
         XCTAssertTrue(options.contains(.elementInteractions))
     }
+
+    func testDefaultTrackingOptionChangesReflectInAutocapture() {
+        let configuration = Configuration(
+            apiKey: "test-api-key"
+        )
+
+        XCTAssertTrue(configuration.autocapture.contains(.sessions))
+
+        (configuration as DeprecationWarningDiscardable).setDefaultTrackingOptions(sessions: false, appLifecycles: true, screenViews: true)
+
+        XCTAssertFalse(configuration.autocapture.contains(.sessions))
+        XCTAssertTrue(configuration.autocapture.contains(.appLifecycles))
+        XCTAssertTrue(configuration.autocapture.contains(.screenViews))
+    }
+
+    func testDefaultTrackingInstanceChangeReflectInAutocapture() {
+        let configuration = Configuration(
+            apiKey: "test-api-key"
+        )
+
+        (configuration as DeprecationWarningDiscardable).setDefaultTracking(sessions: false, appLifecycles: true, screenViews: true)
+
+        XCTAssertFalse(configuration.autocapture.contains(.sessions))
+        XCTAssertTrue(configuration.autocapture.contains(.appLifecycles))
+        XCTAssertTrue(configuration.autocapture.contains(.screenViews))
+    }
+}
+
+private protocol DeprecationWarningDiscardable {
+    func setDefaultTracking(sessions: Bool, appLifecycles: Bool, screenViews: Bool)
+    func setDefaultTrackingOptions(sessions: Bool, appLifecycles: Bool, screenViews: Bool)
+}
+
+extension Configuration: DeprecationWarningDiscardable {
+    @available(*, deprecated)
+    func setDefaultTracking(sessions: Bool, appLifecycles: Bool, screenViews: Bool) {
+        defaultTracking = DefaultTrackingOptions(sessions: sessions, appLifecycles: appLifecycles, screenViews: screenViews)
+    }
+
+    @available(*, deprecated)
+    func setDefaultTrackingOptions(sessions: Bool, appLifecycles: Bool, screenViews: Bool) {
+        defaultTracking.sessions = sessions
+        defaultTracking.appLifecycles = appLifecycles
+        defaultTracking.screenViews = screenViews
+    }
 }

--- a/Tests/AmplitudeTests/ConfigurationTests.swift
+++ b/Tests/AmplitudeTests/ConfigurationTests.swift
@@ -88,49 +88,4 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertTrue(eventStorageUrl?.contains(expectedStoragePostfix) ?? false)
         XCTAssertTrue(identifyStorageUrl?.contains(expectedStoragePostfix) ?? false)
     }
-
-    func testDefaultTrackingOptionChangesReflectInAutocapture() {
-        let configuration = Configuration(
-            apiKey: "test-api-key"
-        )
-
-        XCTAssertTrue(configuration.autocapture.contains(.sessions))
-
-        (configuration as DeprecationWarningDiscardable).setDefaulTrackingOptions(sessions: false, appLifecycles: true, screenViews: true)
-
-        XCTAssertFalse(configuration.autocapture.contains(.sessions))
-        XCTAssertTrue(configuration.autocapture.contains(.appLifecycles))
-        XCTAssertTrue(configuration.autocapture.contains(.screenViews))
-    }
-
-    func testDefaultTrackingInstanceChangeReflectInAutocapture() {
-        let configuration = Configuration(
-            apiKey: "test-api-key"
-        )
-
-        (configuration as DeprecationWarningDiscardable).setDefaulTracking(sessions: false, appLifecycles: true, screenViews: true)
-
-        XCTAssertFalse(configuration.autocapture.contains(.sessions))
-        XCTAssertTrue(configuration.autocapture.contains(.appLifecycles))
-        XCTAssertTrue(configuration.autocapture.contains(.screenViews))
-    }
-}
-
-private protocol DeprecationWarningDiscardable {
-    func setDefaulTracking(sessions: Bool, appLifecycles: Bool, screenViews: Bool)
-    func setDefaulTrackingOptions(sessions: Bool, appLifecycles: Bool, screenViews: Bool)
-}
-
-extension Configuration: DeprecationWarningDiscardable {
-    @available(*, deprecated)
-    func setDefaulTracking(sessions: Bool, appLifecycles: Bool, screenViews: Bool) {
-        defaultTracking = DefaultTrackingOptions(sessions: sessions, appLifecycles: appLifecycles, screenViews: screenViews)
-    }
-
-    @available(*, deprecated)
-    func setDefaulTrackingOptions(sessions: Bool, appLifecycles: Bool, screenViews: Bool) {
-        defaultTracking.sessions = sessions
-        defaultTracking.appLifecycles = appLifecycles
-        defaultTracking.screenViews = screenViews
-    }
 }

--- a/Tests/AmplitudeTests/ConfigurationTests.swift
+++ b/Tests/AmplitudeTests/ConfigurationTests.swift
@@ -88,4 +88,49 @@ final class ConfigurationTests: XCTestCase {
         XCTAssertTrue(eventStorageUrl?.contains(expectedStoragePostfix) ?? false)
         XCTAssertTrue(identifyStorageUrl?.contains(expectedStoragePostfix) ?? false)
     }
+
+    func testDefaultTrackingOptionChangesReflectInAutocapture() {
+        let configuration = Configuration(
+            apiKey: "test-api-key"
+        )
+
+        XCTAssertTrue(configuration.autocapture.contains(.sessions))
+
+        (configuration as DeprecationWarningDiscardable).setDefaulTracking(sessions: false, appLifecycles: true, screenViews: true)
+
+        XCTAssertFalse(configuration.autocapture.contains(.sessions))
+        XCTAssertTrue(configuration.autocapture.contains(.appLifecycles))
+        XCTAssertTrue(configuration.autocapture.contains(.screenViews))
+    }
+
+    func testDefaultTrackingInstanceChangeReflectInAutocapture() {
+        let configuration = Configuration(
+            apiKey: "test-api-key"
+        )
+
+        (configuration as DeprecationWarningDiscardable).setDefaulTracking(sessions: false, appLifecycles: true, screenViews: true)
+
+        XCTAssertFalse(configuration.autocapture.contains(.sessions))
+        XCTAssertTrue(configuration.autocapture.contains(.appLifecycles))
+        XCTAssertTrue(configuration.autocapture.contains(.screenViews))
+    }
+}
+
+private protocol DeprecationWarningDiscardable {
+    func setDefaulTracking(sessions: Bool, appLifecycles: Bool, screenViews: Bool)
+    func setDefaulTrackingOptions(sessions: Bool, appLifecycles: Bool, screenViews: Bool)
+}
+
+extension Configuration: DeprecationWarningDiscardable {
+    @available(*, deprecated)
+    func setDefaulTracking(sessions: Bool, appLifecycles: Bool, screenViews: Bool) {
+        defaultTracking = DefaultTrackingOptions(sessions: sessions, appLifecycles: appLifecycles, screenViews: screenViews)
+    }
+
+    @available(*, deprecated)
+    func setDefaulTrackingOptions(sessions: Bool, appLifecycles: Bool, screenViews: Bool) {
+        defaultTracking.sessions = sessions
+        defaultTracking.appLifecycles = appLifecycles
+        defaultTracking.screenViews = screenViews
+    }
 }

--- a/Tests/AmplitudeTests/ConfigurationTests.swift
+++ b/Tests/AmplitudeTests/ConfigurationTests.swift
@@ -96,7 +96,7 @@ final class ConfigurationTests: XCTestCase {
 
         XCTAssertTrue(configuration.autocapture.contains(.sessions))
 
-        (configuration as DeprecationWarningDiscardable).setDefaulTracking(sessions: false, appLifecycles: true, screenViews: true)
+        (configuration as DeprecationWarningDiscardable).setDefaulTrackingOptions(sessions: false, appLifecycles: true, screenViews: true)
 
         XCTAssertFalse(configuration.autocapture.contains(.sessions))
         XCTAssertTrue(configuration.autocapture.contains(.appLifecycles))


### PR DESCRIPTION
### Summary

This PR adds support back for tracking changes to `defaultTracking` options after `Configurations` initialization.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
