### PR TITLE
fix: Delete events on an invalid api key response.

### DIFF
--- a/Sources/Amplitude/Utilities/PersistentStorageResponseHandler.swift
+++ b/Sources/Amplitude/Utilities/PersistentStorageResponseHandler.swift
@@ -45,8 +45,10 @@ class PersistentStorageResponseHandler: ResponseHandler {
             return
         }
 
-        if events.count == 1 {
-            let error = data["error"] as? String ?? ""
+        let error = data["error"] as? String ?? ""
+
+        let isInvalidApiKey = error == "Invalid API key: \(configuration.apiKey)"
+        if events.count == 1 || isInvalidApiKey {
             triggerEventsCallback(
                 events: events,
                 code: HttpClient.HttpStatus.BAD_REQUEST.rawValue,
@@ -81,7 +83,6 @@ class PersistentStorageResponseHandler: ResponseHandler {
             }
         }
 
-        let error = data["error"] as? String ?? ""
         triggerEventsCallback(events: eventsToDrop, code: HttpClient.HttpStatus.BAD_REQUEST.rawValue, message: error)
 
         eventsToRetry.forEach { event in

--- a/Tests/AmplitudeTests/Utilities/PersistentStorageResponseHandlerTests.swift
+++ b/Tests/AmplitudeTests/Utilities/PersistentStorageResponseHandlerTests.swift
@@ -129,4 +129,31 @@ final class PersistentStorageResponseHandlerTests: XCTestCase {
             "removeEventCallback(insertId: e3e4488d-6877-4775-ae88-344df7ccd5d8)"
         )
     }
+
+    func testInvalidAPIKey() {
+        // 2 valid events
+        let eventsString = """
+            [
+              {"event_type":"valid-event","insert_id":"1621D025-A754-42EB-9305-307F36217C78","user_id":"test-user"},
+              {"event_type":"valid-event","insert_id":"AE7550E1-C8F0-4583-81D3-0561830A09DD","user_id":"test-user"},
+            ]
+            """
+
+        let fakePersistentStorage = FakePersistentStorage(storagePrefix: "storage",
+                                                          logger: logger,
+                                                          diagonostics: diagonostics)
+        let handler = PersistentStorageResponseHandler(
+            configuration: configuration,
+            storage: fakePersistentStorage,
+            eventPipeline: eventPipeline,
+            eventBlock: eventBlock,
+            eventsString: eventsString
+        )
+
+        handler.handleBadRequestResponse(data: ["error": "Invalid API key: \(configuration.apiKey)"])
+        XCTAssertEqual(
+            fakePersistentStorage.haveBeenCalledWith[0],
+            "remove(eventBlock: \(eventBlock.absoluteURL))"
+        )
+    }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Delete events that are uploaded with a bad API key. They would previously be continuously unsuccessfully retried, and left orphaned on the device when the api key is finally changed.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
