### PR TITLE
fix: set offline when receiving certain error responses

### DIFF
--- a/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
+++ b/Tests/AmplitudeTests/Utilities/HttpClientTests.swift
@@ -86,4 +86,25 @@ final class HttpClientTests: XCTestCase {
         }
         _ = XCTWaiter.wait(for: [asyncExpectation], timeout: 5)
     }
+
+    func testUploadWithCannotConnectToHostError() {
+        let config = Configuration(apiKey: "fake", serverUrl: "http://localhost:3000", offline: false)
+        let httpClient = HttpClient(configuration: config, diagnostics: diagonostics)
+        let uploadExpectation = expectation(description: "Did Call Upload")
+        let event = BaseEvent(userId: "unit-test user", eventType: "unit-test event")
+
+        _ = httpClient.upload(events: "[\(event.toString())]") { result in
+            switch result {
+            case .success:
+                XCTFail("Expected failure")
+            case .failure(let error):
+                XCTAssertEqual((error as NSError).code, NSURLErrorCannotConnectToHost)
+            }
+
+            uploadExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+        XCTAssertEqual(config.offline, true)
+    }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

When receiving certain connection related failures after a failed url request, set the SDK to offline mode. Any successful NWPathMonitor updates will allow us to reconnect.  This prevents us from going in a retry loop.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No
