### PR TITLE
fix: Fail requests when encoding request body fails.

### DIFF
--- a/Examples/AmplitudeObjCExample/AmplitudeObjCExampleTests/TestAmplitude.swift
+++ b/Examples/AmplitudeObjCExample/AmplitudeObjCExampleTests/TestAmplitude.swift
@@ -98,7 +98,8 @@ class TestStorage: Storage {
         configuration: Configuration,
         eventPipeline: EventPipeline,
         eventBlock: URL,
-        eventsString: String
+        eventsString: String,
+        logger: (any Logger)?
     ) -> ResponseHandler {
         class TestResponseHandler: ResponseHandler {
 

--- a/Sources/Amplitude/Storages/InMemoryStorage.swift
+++ b/Sources/Amplitude/Storages/InMemoryStorage.swift
@@ -42,7 +42,8 @@ class InMemoryStorage: Storage {
         configuration: Configuration,
         eventPipeline: EventPipeline,
         eventBlock: EventBlock,
-        eventsString: String
+        eventsString: String,
+        logger: (any Logger)?
     ) -> ResponseHandler {
         abort()
     }

--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -129,14 +129,16 @@ class PersistentStorage: Storage {
         configuration: Configuration,
         eventPipeline: EventPipeline,
         eventBlock: EventBlock,
-        eventsString: String
+        eventsString: String,
+        logger: (any Logger)?
     ) -> ResponseHandler {
         return PersistentStorageResponseHandler(
             configuration: configuration,
             storage: self,
             eventPipeline: eventPipeline,
             eventBlock: eventBlock,
-            eventsString: eventsString
+            eventsString: eventsString,
+            logger: logger
         )
     }
 

--- a/Sources/Amplitude/Types.swift
+++ b/Sources/Amplitude/Types.swift
@@ -60,7 +60,8 @@ public protocol Storage {
         configuration: Configuration,
         eventPipeline: EventPipeline,
         eventBlock: URL,
-        eventsString: String
+        eventsString: String,
+        logger: (any Logger)?
     ) -> ResponseHandler
 }
 

--- a/Sources/Amplitude/Utilities/EventPipeline.swift
+++ b/Sources/Amplitude/Utilities/EventPipeline.swift
@@ -76,7 +76,8 @@ public class EventPipeline {
                         configuration: self.configuration,
                         eventPipeline: self,
                         eventBlock: eventFile,
-                        eventsString: eventsString
+                        eventsString: eventsString,
+                        logger: logger
                     )
                     responseHandler.handle(result: result)
                     self.completeUpload(for: eventFile)

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -122,7 +122,8 @@ class FakeInMemoryStorage: Storage {
         configuration: Configuration,
         eventPipeline: EventPipeline,
         eventBlock: EventBlock,
-        eventsString: String
+        eventsString: String,
+        logger: (any Logger)?
     ) -> ResponseHandler {
         FakeResponseHandler(
             configuration: configuration, storage: self, eventPipeline: eventPipeline, eventBlock: eventBlock,

--- a/Tests/AmplitudeTests/Utilities/PersistentStorageResponseHandlerTests.swift
+++ b/Tests/AmplitudeTests/Utilities/PersistentStorageResponseHandlerTests.swift
@@ -39,7 +39,8 @@ final class PersistentStorageResponseHandlerTests: XCTestCase {
             storage: storage,
             eventPipeline: eventPipeline,
             eventBlock: eventBlock,
-            eventsString: eventsString
+            eventsString: eventsString,
+            logger: nil
         )
 
         XCTAssertEqual(handler.eventsString, eventsString)
@@ -58,7 +59,8 @@ final class PersistentStorageResponseHandlerTests: XCTestCase {
             storage: fakePersistentStorage,
             eventPipeline: eventPipeline,
             eventBlock: eventBlock,
-            eventsString: eventsString
+            eventsString: eventsString,
+            logger: nil
         )
 
         handler.removeEventCallbackByEventsString(eventsString: eventsString)
@@ -91,7 +93,8 @@ final class PersistentStorageResponseHandlerTests: XCTestCase {
             storage: fakePersistentStorage,
             eventPipeline: eventPipeline,
             eventBlock: eventBlock,
-            eventsString: eventsString
+            eventsString: eventsString,
+            logger: nil
         )
 
         handler.removeEventCallbackByEventsString(eventsString: eventsString)
@@ -116,7 +119,8 @@ final class PersistentStorageResponseHandlerTests: XCTestCase {
             storage: fakePersistentStorage,
             eventPipeline: eventPipeline,
             eventBlock: eventBlock,
-            eventsString: eventsString
+            eventsString: eventsString,
+            logger: nil
         )
 
         handler.handleSuccessResponse(code: 200)
@@ -147,7 +151,8 @@ final class PersistentStorageResponseHandlerTests: XCTestCase {
             storage: fakePersistentStorage,
             eventPipeline: eventPipeline,
             eventBlock: eventBlock,
-            eventsString: eventsString
+            eventsString: eventsString,
+            logger: nil
         )
 
         handler.handleBadRequestResponse(data: ["error": "Invalid API key: \(configuration.apiKey)"])


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds a new failure before trying to send a network request if we cannot encode the request body. Defensively, we will try to re-encode the request body without our diagnostic data in case that is the source of the problem. If this also fails, we delete the invalid events.

This also moves the callback handler for failures to the expected callbackQueue.

TODO: add tests

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
