### PR TITLE
fix: Fix UIScrollView pinchGestureRecognizer unavailability issue on tvOS

### DIFF
--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -121,8 +121,16 @@ extension UIGestureRecognizer {
         guard state == .ended, let view else { return }
 
         // Block scroll and zoom events for `UIScrollView`.
-        if let scrollView = view as? UIScrollView, self === scrollView.panGestureRecognizer || self === scrollView.pinchGestureRecognizer {
-            return
+        if let scrollView = view as? UIScrollView {
+            if self === scrollView.panGestureRecognizer {
+                return
+            }
+
+#if !os(tvOS)
+            if self === scrollView.pinchGestureRecognizer {
+                return
+            }
+#endif
         }
 
         let gestureAction: String?


### PR DESCRIPTION
### Summary

This PR fixes the `UIScrollView.pinchGestureRecognizer` unavailability issue on tvOS.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
