### PR TITLE
fix: Add maxQueuedEventCount parameter to trim events in storage if over a limit

### DIFF
--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -48,6 +48,7 @@ public class Configuration {
     public internal(set) var autocapture: AutocaptureOptions
     public var offline: Bool?
     internal let diagonostics: Diagnostics
+    public var maxQueuedEventCount = -1
     var optOutChanged: ((Bool) -> Void)?
 
     @available(*, deprecated, message: "Please use the `autocapture` parameter instead.")
@@ -135,6 +136,7 @@ public class Configuration {
         // `trackingSessionEvents` has been replaced by `defaultTracking.sessions`
         autocapture: AutocaptureOptions = .sessions,
         identifyBatchIntervalMillis: Int = Constants.Configuration.IDENTIFY_BATCH_INTERVAL_MILLIS,
+        maxQueuedEventCount: Int = -1,
         migrateLegacyData: Bool = true,
         offline: Bool? = false
     ) {
@@ -167,6 +169,7 @@ public class Configuration {
         self.minTimeBetweenSessionsMillis = minTimeBetweenSessionsMillis
         self.autocapture = autocapture
         self.identifyBatchIntervalMillis = identifyBatchIntervalMillis
+        self.maxQueuedEventCount = maxQueuedEventCount
         self.migrateLegacyData = migrateLegacyData
         // Logging is OFF by default
         self.loggerProvider.logLevel = logLevel.rawValue

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -122,7 +122,7 @@ final class EventPipelineTests: XCTestCase {
         pipeline?.storage?.rollover()
 
         let testEvent2 = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent2")
-        try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
+        try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent2)
         pipeline.storage?.rollover()
 
         let httpResponseExpectation1 = expectation(description: "httpresponse1")


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds a configuration parameter, `maxQueuedEventCount`, intended to control the maximum number of events we store on device. Set to a negative value to have no max count.

Every time we initialize Amplitude, we check `maxQueuedEventCount`. If set to a value greater than zero, we will delete all but the most recent maxQueuedEventCount events. Note that we will never attempt to split or otherwise rewrite a block during this process, so we may store an actual max event count of `maxQueuedEventCount + flushQueueSize - 1`. We also never will clear storage during the lifetime of the Amplitude instance, so more than maxQueuedEventCount events may be queued on the device until the next time Amplitude is run.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
