### PR TITLE
fix: notify plugins of internal sessionId changes

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -304,7 +304,6 @@ public class Amplitude {
             } else {
                 sessionEvents = self.sessions.endCurrentSession()
             }
-            self.timeline.onSessionIdChanged(sessionId)
             self.sessions.assignEventId(events: sessionEvents).forEach { e in
                 self.timeline.processEvent(event: e)
             }

--- a/Sources/Amplitude/Sessions.swift
+++ b/Sources/Amplitude/Sessions.swift
@@ -4,6 +4,7 @@ public class Sessions {
     private let configuration: Configuration
     private let storage: Storage
     private let logger: (any Logger)?
+    private let timeline: Timeline
     private var _sessionId: Int64 = -1
     private(set) var sessionId: Int64 {
         get { _sessionId }
@@ -14,6 +15,7 @@ public class Sessions {
             } catch {
                 logger?.warn(message: "Can't write PREVIOUS_SESSION_ID to storage: \(error)")
             }
+            timeline.onSessionIdChanged(_sessionId)
         }
     }
 
@@ -47,6 +49,7 @@ public class Sessions {
         configuration = amplitude.configuration
         storage = amplitude.storage
         logger = amplitude.logger
+        timeline = amplitude.timeline
         self._sessionId = amplitude.storage.read(key: .PREVIOUS_SESSION_ID) ?? -1
         self._lastEventId = amplitude.storage.read(key: .LAST_EVENT_ID) ?? 0
         self._lastEventTime = amplitude.storage.read(key: .LAST_EVENT_TIME) ?? -1


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

`Amplitude.setSessionId` is not called on internal session id updates. move the observer to the actual backing variable.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
