### PR TITLE
fix: preserve symlinks when zipping xcframeworks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,11 @@ jobs:
       
       - name: Zip xcframework
         working-directory: .build/artifacts
-        run: zip -r AmplitudeSwift.xcframework.zip AmplitudeSwift.xcframework
+        run: zip -r -y AmplitudeSwift.xcframework.zip AmplitudeSwift.xcframework
 
       - name: Zip xcframework
         working-directory: .build/artifacts
-        run: zip -r AmplitudeSwiftNoUIKit.xcframework.zip AmplitudeSwiftNoUIKit.xcframework
+        run: zip -r -y AmplitudeSwiftNoUIKit.xcframework.zip AmplitudeSwiftNoUIKit.xcframework
 
       - name: Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

preserves symlinks vs copying file contents when zipping xcframeworks

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
