### PR TITLE
fix: restore Analytics-Connector to built from source version when distributing as a swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.2.3")
+        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.0.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -27,7 +27,7 @@ let package = Package(
         .target(
             name: "AmplitudeSwift",
             dependencies: [
-                .product(name: "AnalyticsConnectorFramework", package: "analytics-connector-ios")
+                .product(name: "AnalyticsConnector", package: "analytics-connector-ios")
             ],
             path: "Sources/Amplitude",
             exclude: ["../../Examples/", "../../Tests/"],


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Reverts changes to Package.swift that opt into the new prepackaged framework based builds, meaning SPM customers will now build analytics-connector from source. The internal Xcode project will still point to the precompiled framework as it is used in Carthage builds. This should help customers with experiencing issues with https://github.com/amplitude/Amplitude-Swift/issues/238.

Note that the version rollback for analytics-connector is intentional, [the only changes we've made are related to packaging](https://github.com/amplitude/analytics-connector-ios/blob/main/CHANGELOG.md).

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
