### PR TITLE
fix: properly decode embedded arrays

### DIFF
--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -27,7 +27,9 @@ final class BaseEventTests: XCTestCase {
             "dict": ["a": 1, "b": 2, "c": "d"],
             "embeddedArray": ["a": [1, 2, 3]],
             "embeddedDict": [1, 2, ["a": 3]],
-            "array2": ["a", 1, 2, "b"]
+            "array2": ["a", 1, 2, "b"],
+            "nestedarray": [[["a": ["b": 1]]]],
+            "nesteddictionary": ["a": ["b": [[1]]]],
         ]
         let baseEvent = BaseEvent(
             plan: Plan(
@@ -111,6 +113,10 @@ final class BaseEventTests: XCTestCase {
             baseEventDict!["ingestion_metadata"]!["source_version" as NSString] as! String,
             "test-source-version"
         )
+        XCTAssertEqual((baseEventDict!["event_properties"]!["nestedarray" as NSString] as! NSArray),
+                       [[["a": ["b": 1]]]])
+        XCTAssertEqual((baseEventDict!["event_properties"]!["nesteddictionary" as NSString] as! NSDictionary),
+                       ["a": ["b": [[1]]]])
     }
 
     func testToString_withNilValues() {
@@ -159,7 +165,9 @@ final class BaseEventTests: XCTestCase {
                 "event_properties": {
                     "integer": 1,
                     "string": "stringValue",
-                    "array": [1, 2, 3]
+                    "array": [1, 2, 3],
+                    "nestedarray": [[{"a": {"b": 1}}]],
+                    "nesteddictionary": {"a": {"b": [[1]]}},
                 },
                 "plan": {
                     "branch": "test-branch",
@@ -191,6 +199,15 @@ final class BaseEventTests: XCTestCase {
             event?.eventProperties!["array"] as! [Double],
             [1, 2, 3]
         )
+        XCTAssertEqual(
+            event?.eventProperties!["nestedarray"] as! NSArray,
+            [[["a": ["b": 1]]]]
+        )
+        XCTAssertEqual(
+            event?.eventProperties!["nesteddictionary"] as! NSDictionary,
+            ["a": ["b": [[1]]]]
+        )
+
         XCTAssertEqual(
             event?.plan?.branch,
             "test-branch"


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fix for https://github.com/amplitude/Amplitude-Swift/issues/239.
Also attempts to clarify some of the logic by renaming some decode functions (which would usually operate on some nested container) to `asTypedFoo`, as they operate on the current container.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
