### PR TITLE
fix: improvements to app lifecycle monitoring

### DIFF
--- a/Sources/Amplitude/Utilities/DefaultEventUtils.swift
+++ b/Sources/Amplitude/Utilities/DefaultEventUtils.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 public class DefaultEventUtils {
+
+    private static var instanceNamesThatSentAppUpdatedInstalled: Set<String> = []
+
     private weak var amplitude: Amplitude?
 
     public init(amplitude: Amplitude) {
@@ -8,35 +11,59 @@ public class DefaultEventUtils {
     }
 
     public func trackAppUpdatedInstalledEvent() {
+        guard let amplitude = amplitude else {
+            return
+        }
+
         let info = Bundle.main.infoDictionary
         let currentBuild = info?["CFBundleVersion"] as? String
         let currentVersion = info?["CFBundleShortVersionString"] as? String
-        let previousBuild: String? = amplitude?.storage.read(key: StorageKey.APP_BUILD)
-        let previousVersion: String? = amplitude?.storage.read(key: StorageKey.APP_VERSION)
-
-        if amplitude?.configuration.autocapture.contains(.appLifecycles) ?? false {
-            let lastEventTime: Int64? = amplitude?.storage.read(key: StorageKey.LAST_EVENT_TIME)
-            if lastEventTime == nil {
-                self.amplitude?.track(eventType: Constants.AMP_APPLICATION_INSTALLED_EVENT, eventProperties: [
-                    Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
-                    Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
-                ])
-            } else if currentBuild != previousBuild {
-                self.amplitude?.track(eventType: Constants.AMP_APPLICATION_UPDATED_EVENT, eventProperties: [
-                    Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
-                    Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
-                    Constants.AMP_APP_PREVIOUS_BUILD_PROPERTY: previousBuild ?? "",
-                    Constants.AMP_APP_PREVIOUS_VERSION_PROPERTY: previousVersion ?? "",
-                ])
-            }
-        }
+        let previousBuild: String? = amplitude.storage.read(key: StorageKey.APP_BUILD)
+        let previousVersion: String? = amplitude.storage.read(key: StorageKey.APP_VERSION)
 
         if currentBuild != previousBuild {
-            try? amplitude?.storage.write(key: StorageKey.APP_BUILD, value: currentBuild)
+            try? amplitude.storage.write(key: StorageKey.APP_BUILD, value: currentBuild)
         }
         if currentVersion != previousVersion {
-            try? amplitude?.storage.write(key: StorageKey.APP_VERSION, value: currentVersion)
+            try? amplitude.storage.write(key: StorageKey.APP_VERSION, value: currentVersion)
+        }
+
+        guard amplitude.configuration.autocapture.contains(.appLifecycles),
+              !Self.instanceNamesThatSentAppUpdatedInstalled.contains(amplitude.configuration.instanceName) else {
+            return
+        }
+        // Only send one app installed / updated event per instance name, no matter how many times we are
+        // reinitialized
+        Self.instanceNamesThatSentAppUpdatedInstalled.insert(amplitude.configuration.instanceName)
+
+        if previousBuild == nil || previousVersion == nil {
+            amplitude.track(eventType: Constants.AMP_APPLICATION_INSTALLED_EVENT, eventProperties: [
+                Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
+                Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
+            ])
+        } else if currentBuild != previousBuild || currentVersion != previousVersion {
+            amplitude.track(eventType: Constants.AMP_APPLICATION_UPDATED_EVENT, eventProperties: [
+                Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
+                Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
+                Constants.AMP_APP_PREVIOUS_BUILD_PROPERTY: previousBuild ?? "",
+                Constants.AMP_APP_PREVIOUS_VERSION_PROPERTY: previousVersion ?? "",
+            ])
         }
     }
 
+    func trackAppOpenedEvent(fromBackground: Bool = false) {
+        guard let amplitude = amplitude,
+              amplitude.configuration.autocapture.contains(.appLifecycles) else {
+            return
+        }
+
+        let info = Bundle.main.infoDictionary
+        let currentBuild = info?["CFBundleVersion"] as? String
+        let currentVersion = info?["CFBundleShortVersionString"] as? String
+        self.amplitude?.track(eventType: Constants.AMP_APPLICATION_OPENED_EVENT, eventProperties: [
+            Constants.AMP_APP_BUILD_PROPERTY: currentBuild ?? "",
+            Constants.AMP_APP_VERSION_PROPERTY: currentVersion ?? "",
+            Constants.AMP_APP_FROM_BACKGROUND_PROPERTY: fromBackground,
+        ])
+    }
 }

--- a/Tests/AmplitudeTests/AmplitudeIOSTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeIOSTests.swift
@@ -19,14 +19,17 @@ final class AmplitudeIOSTests: XCTestCase {
         window.addSubview(rootViewController.view)
     }
 
-    func testDidFinishLaunching_ApplicationInstalled() {
+    func testDidFinishLaunching_ApplicationInstalled() throws {
         let configuration = Configuration(
             apiKey: "api-key",
+            instanceName: #function,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             autocapture: .appLifecycles
         )
         let amplitude = Amplitude(configuration: configuration)
+        try storageMem.write(key: StorageKey.APP_BUILD, value: nil)
+        try storageMem.write(key: StorageKey.APP_VERSION, value: nil)
         NotificationCenter.default.post(name: UIApplication.didFinishLaunchingNotification, object: nil)
 
         amplitude.waitForTrackingQueue()
@@ -47,11 +50,11 @@ final class AmplitudeIOSTests: XCTestCase {
     func testDidFinishLaunching_ApplicationUpdated() throws {
         let configuration = Configuration(
             apiKey: "api-key",
+            instanceName: #function,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             autocapture: .appLifecycles
         )
-        try storageMem.write(key: StorageKey.LAST_EVENT_TIME, value: 123 as Int64)
         try storageMem.write(key: StorageKey.APP_BUILD, value: "abc")
         try storageMem.write(key: StorageKey.APP_VERSION, value: "xyz")
         let amplitude = Amplitude(configuration: configuration)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fixes logic around app lifecycle tracking, to improve reliability of session, app opened, and app installed / updated events.
- If the app is already in the active state when the SDK is initialized, we will automatically fire app installed events and start a new session. This seems to be much closer to the expected behavior.
- App installed / updated events now only work with version numbers, not last event time, which may already be set by an event.
- Only send app install events once per instance name, in case we are re-initialized.
- Capture app delegate at time of use, not initialization, as it may not be set at the time we are initialized.
- Detects implicit scene configurations from info.plist, which will also opt in to willEnterForeground vs didBecomeActive for initial launch detection.
- misc cleanup

With this change, we do expect that applications that re-initialize the SDK during the app lifecycle may receive spurious app opened events if they re-initialize the SDK while in the foreground. We could add a flag to revert to the previous behavior or try to be smarter about session tracking (and try to guarantee one app open per foreground, though I'm not sure how much we can do if we aren't initialized).

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
