### PR TITLE
fix: also include NSURLErrorNotConnectedToInternet when setting configuration to offline

### DIFF
--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -45,7 +45,7 @@ class HttpClient {
                         let nsError = error as NSError
                         if nsError.domain == NSURLErrorDomain {
                             switch nsError.code {
-                            case NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost, NSURLErrorCannotFindHost, NSURLErrorAppTransportSecurityRequiresSecureConnection:
+                            case NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost, NSURLErrorCannotFindHost, NSURLErrorAppTransportSecurityRequiresSecureConnection, NSURLErrorNotConnectedToInternet:
                                 logger?.error(message: "Conection failed with error: \(error.localizedDescription), marking offline")
                                 configuration.offline = true
                             default:


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Considers NSURLErrorNotConnectedToInternet as another case to set the SDK into offline mode. We were seeing a lot of errors of this type retried. Would have expected NWPathMonitor to pick this up but seems there's some other case where this can still happen, and it probably belongs in this list too.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No  <!-- Yes or no -->
