### PR TITLE
fix: enhance thread safety of properties

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -10,6 +10,7 @@ public class Amplitude {
 
     var state: State = State()
     var contextPlugin: ContextPlugin
+    let timeline = Timeline()
 
     lazy var storage: any Storage = {
         return self.configuration.storageProvider
@@ -18,14 +19,6 @@ public class Amplitude {
     lazy var identifyStorage: any Storage = {
         return self.configuration.identifyStorageProvider
     }()
-
-    private let timelineLock = NSLock()
-    private var _timeline: Timeline?
-    var timeline: Timeline {
-        timelineLock.synchronizedLazy(&_timeline) {
-            Timeline()
-        }
-    }
 
     private var sessionsLock = NSLock()
     private var _sessions: Sessions?

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -19,13 +19,28 @@ public class Amplitude {
         return self.configuration.identifyStorageProvider
     }()
 
-    lazy var timeline: Timeline = {
-        return Timeline()
-    }()
+    private let timelineLock = NSLock()
+    private var _timeline: Timeline?
+    var timeline: Timeline {
+        timelineLock.synchronizedLazy(&_timeline) {
+            Timeline()
+        }
+    }
 
-    lazy var sessions: Sessions = {
-        return Sessions(amplitude: self)
-    }()
+    private var sessionsLock = NSLock()
+    private var _sessions: Sessions?
+    var sessions: Sessions {
+        get {
+            sessionsLock.synchronizedLazy(&_sessions) {
+                Sessions(amplitude: self)
+            }
+        }
+        set {
+            sessionsLock.withLock {
+                _sessions = newValue
+            }
+        }
+    }
 
     public lazy var logger: (any Logger)? = {
         return self.configuration.loggerProvider

--- a/Sources/Amplitude/Utilities/Atomic.swift
+++ b/Sources/Amplitude/Utilities/Atomic.swift
@@ -33,3 +33,16 @@ public struct Atomic<T> {
         value = newValue
     }
 }
+
+extension NSLock {
+    func synchronizedLazy<T>(_ storage: inout T?, initializer: () -> T) -> T {
+        lock()
+        defer { unlock() }
+        if let existing = storage {
+            return existing
+        }
+        let newValue = initializer()
+        storage = newValue
+        return newValue
+    }
+}

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -121,13 +121,10 @@ class HttpClient {
                 ,"options":{"min_id_length":\(minIdLength)}
                 """
         }
-        if diagnostics.hasDiagnostics() {
-            let diagnosticsInfo = diagnostics.extractDiagonosticsToString()
-            if !diagnosticsInfo.isEmpty {
-                requestPayload += """
+        if let diagnosticsInfo = diagnostics.extractDiagnosticsToString(), !diagnosticsInfo.isEmpty {
+            requestPayload += """
                 ,"request_metadata":{"sdk":\(diagnosticsInfo)}
                 """
-            }
         }
         requestPayload += "}"
         return requestPayload.data(using: .utf8)

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -183,8 +183,7 @@ final class PersistentStorageTests: XCTestCase {
         let data = try? JSONSerialization.data(withJSONObject: malformedArr, options: [])
         let expectedPartial = String(data: data!, encoding: .utf8) ?? ""
         XCTAssertEqual(decodedEvents!.count, 1)
-        XCTAssertTrue(self.diagonostics.hasDiagnostics() == true)
-        XCTAssertEqual(self.diagonostics.extractDiagonosticsToString(), "{\"malformed_events\":\(expectedPartial)}")
+        XCTAssertEqual(self.diagonostics.extractDiagnosticsToString(), "{\"malformed_events\":\(expectedPartial)}")
         persistentStorage.reset()
    }
 

--- a/Tests/AmplitudeTests/Utilities/DiagnosticsTests.swift
+++ b/Tests/AmplitudeTests/Utilities/DiagnosticsTests.swift
@@ -14,41 +14,40 @@ final class DiagnosticsTests: XCTestCase {
     func testAddMalformedEvent() {
         let diagnostics = Diagnostics()
         diagnostics.addMalformedEvent("event")
-        XCTAssertTrue(diagnostics.hasDiagnostics())
-        XCTAssertEqual(diagnostics.extractDiagonosticsToString(), "{\"malformed_events\":[\"event\"]}")
+        XCTAssertEqual(diagnostics.extractDiagnosticsToString(), "{\"malformed_events\":[\"event\"]}")
     }
 
     func testAddErrorLog() {
         let diagnostics = Diagnostics()
         diagnostics.addErrorLog("log")
-        XCTAssertTrue(diagnostics.hasDiagnostics())
-        XCTAssertEqual(diagnostics.extractDiagonosticsToString(), "{\"error_logs\":[\"log\"]}")
+        XCTAssertEqual(diagnostics.extractDiagnosticsToString(), "{\"error_logs\":[\"log\"]}")
     }
 
     func testHasDiagonostics() {
         let diagnostics = Diagnostics()
-        XCTAssertFalse(diagnostics.hasDiagnostics())
+        XCTAssertNil(diagnostics.extractDiagnosticsToString())
         diagnostics.addMalformedEvent("event")
-        XCTAssertTrue(diagnostics.hasDiagnostics())
+        XCTAssertNotNil(diagnostics.extractDiagnosticsToString())
         diagnostics.addErrorLog("log")
-        XCTAssertTrue(diagnostics.hasDiagnostics())
+        XCTAssertNotNil(diagnostics.extractDiagnosticsToString())
     }
 
     func testExtractDiagnostic() {
         let diagnostics = Diagnostics()
-        XCTAssertEqual(diagnostics.extractDiagonosticsToString(), "")
+        XCTAssertNil(diagnostics.extractDiagnosticsToString())
         diagnostics.addMalformedEvent("event")
         diagnostics.addErrorLog("log")
-        let result = convertToDictionary(text: diagnostics.extractDiagonosticsToString())
+        let result = convertToDictionary(text: diagnostics.extractDiagnosticsToString()!)
         XCTAssertEqual((result?["malformed_events"] as? [String]) ?? [], ["event"])
         XCTAssertEqual((result?["error_logs"] as? [String]) ?? [], ["log"])
+        XCTAssertNil(diagnostics.extractDiagnosticsToString())
     }
 
     func testDedupsErrorLogs() {
         let diagnostics = Diagnostics()
         diagnostics.addErrorLog("dup")
         diagnostics.addErrorLog("dup")
-        let result = convertToDictionary(text: diagnostics.extractDiagonosticsToString())
+        let result = convertToDictionary(text: diagnostics.extractDiagnosticsToString()!)
         XCTAssertEqual(result?["error_logs"] as? [String], ["dup"])
     }
 
@@ -58,7 +57,7 @@ final class DiagnosticsTests: XCTestCase {
         (0..<maxErrorLogs + 1).forEach {
             diagnostics.addErrorLog("\($0)")
         }
-        let result = convertToDictionary(text: diagnostics.extractDiagonosticsToString())
+        let result = convertToDictionary(text: diagnostics.extractDiagnosticsToString()!)
         guard let errorLogs = result?["error_logs"] as? [String] else {
             XCTFail("Unable to extract error logs")
             return


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Enhance thread safety
- Add locks to lazy vars in Amplitude
  Lazy variables are not thread-safe. They may be initialized multiple times if accessed in multiple threads.
- Add a lock to protect Diagnostics collection properties
  They are accessed on multiple threads. Considering the low access frequency, use one lock to keep it simple.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
