### PR TITLE
fix: offline directly after receive bad url error

### DIFF
--- a/Sources/Amplitude/Utilities/EventPipeline.swift
+++ b/Sources/Amplitude/Utilities/EventPipeline.swift
@@ -119,7 +119,7 @@ public class EventPipeline {
                         self.currentUpload = nil
                     }
                     self.configuration.offline = true
-                    self.logger?.log(message: "Request failed more than \(self.maxRetryCount) times, marking offline")
+                    self.logger?.error(message: "Request failed more than \(self.maxRetryCount) times, marking offline")
                 } else {
                     // Don't send the next event file if we're being deallocated
                     let nextFileBlock: () -> Void = { [weak self] in
@@ -135,7 +135,7 @@ public class EventPipeline {
                     } else {
                         let sendingInterval = min(self.maxRetryInterval, pow(2, Double(failures - 1)))
                         self.uploadsQueue.asyncAfter(deadline: .now() + sendingInterval, execute: nextFileBlock)
-                        self.logger?.debug(message: "Request failed \(failures) times, send next event file in \(sendingInterval) seconds")
+                        self.logger?.error(message: "Request failed \(failures) times, send next event file in \(sendingInterval) seconds")
                     }
                 }
             }

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -45,7 +45,7 @@ class HttpClient {
                         let nsError = error as NSError
                         if nsError.domain == NSURLErrorDomain {
                             switch nsError.code {
-                            case NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost, NSURLErrorCannotFindHost, NSURLErrorAppTransportSecurityRequiresSecureConnection, NSURLErrorNotConnectedToInternet:
+                            case NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost, NSURLErrorCannotFindHost, NSURLErrorAppTransportSecurityRequiresSecureConnection, NSURLErrorNotConnectedToInternet, NSURLErrorBadURL:
                                 logger?.error(message: "Conection failed with error: \(error.localizedDescription), marking offline")
                                 configuration.offline = true
                             default:


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Offline the SDK directly after receiving a Bad URL error.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
