### PR TITLE
fix: allow adding Swift Plugins to ObjC Amplitude

### DIFF
--- a/Sources/Amplitude/ObjC/ObjCAmplitude.swift
+++ b/Sources/Amplitude/ObjC/ObjCAmplitude.swift
@@ -147,10 +147,17 @@ public class ObjCAmplitude: NSObject {
 
     @objc(add:)
     @discardableResult
-    public func add(plugin: ObjCPlugin) -> ObjCAmplitude {
-        let wrapper = ObjCPluginWrapper(amplitude: self, wrapped: plugin)
-        plugins.append(wrapper)
-        amplitude.add(plugin: wrapper)
+    public func add(plugin: AnyObject) -> ObjCAmplitude {
+        switch plugin {
+        case let swiftPlugin as Plugin:
+            amplitude.add(plugin: swiftPlugin)
+        case let objcPlugin as ObjCPlugin:
+            let wrapper = ObjCPluginWrapper(amplitude: self, wrapped: objcPlugin)
+            plugins.append(wrapper)
+            amplitude.add(plugin: wrapper)
+        default:
+            fatalError("Attempted to add a plugin that is not an instance of Plugin or ObjCPlugin")
+        }
         return self
     }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Allow Swift Plugins to be added to the objc version of the SDK. We relax the types here and throw a runtime error as Plugin is currently unrepresentable in ObjC.

Alternatively, we could create some sort of wrapper object, basically the inverse of `ObjCPluginWrapper`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
