### PR TITLE
fix: port Configuration.flushMaxRetries as pipeline retry cap

### DIFF
--- a/Sources/Amplitude/Constants.swift
+++ b/Sources/Amplitude/Constants.swift
@@ -108,7 +108,7 @@ public struct Constants {
         public static let FLUSH_QUEUE_SIZE = 30
         public static let FLUSH_INTERVAL_MILLIS = 30 * 1000  // 30s
         public static let DEFAULT_INSTANCE = "$default_instance"
-        public static let FLUSH_MAX_RETRIES = 5
+        public static let FLUSH_MAX_RETRIES = 6
         public static let MIN_TIME_BETWEEN_SESSIONS_MILLIS = 300000
         public static let IDENTIFY_BATCH_INTERVAL_MILLIS = 30 * 1000  // 30s
     }

--- a/Sources/Amplitude/Utilities/PersistentStorageResponseHandler.swift
+++ b/Sources/Amplitude/Utilities/PersistentStorageResponseHandler.swift
@@ -49,7 +49,7 @@ class PersistentStorageResponseHandler: ResponseHandler {
         let error = data["error"] as? String ?? ""
 
         let isInvalidApiKey = error == "Invalid API key: \(configuration.apiKey)"
-        if events.count == 1 || isInvalidApiKey {
+        if isInvalidApiKey {
             triggerEventsCallback(
                 events: events,
                 code: HttpClient.HttpStatus.BAD_REQUEST.rawValue,
@@ -84,12 +84,6 @@ class PersistentStorageResponseHandler: ResponseHandler {
             }
         }
 
-        // if nothing should be drop, drop all to prevent MITM
-        if eventsToDrop.isEmpty {
-            eventsToDrop = events
-            eventsToRetry.removeAll()
-        }
-
         triggerEventsCallback(events: eventsToDrop, code: HttpClient.HttpStatus.BAD_REQUEST.rawValue, message: error)
 
         eventsToRetry.forEach { event in
@@ -97,7 +91,7 @@ class PersistentStorageResponseHandler: ResponseHandler {
         }
 
         storage.remove(eventBlock: eventBlock)
-        return true
+        return !eventsToDrop.isEmpty
     }
 
     func handlePayloadTooLargeResponse(data: [String: Any]) -> Bool {

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -43,6 +43,11 @@ final class AmplitudeTests: XCTestCase {
         )
     }
 
+    override func tearDown() {
+        super.tearDown()
+        storage.reset()
+    }
+
     func testInit_defaultInstanceName() {
         let configuration = Configuration(apiKey: "api-key")
         XCTAssertEqual(

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -39,7 +39,6 @@ final class EventPipelineTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        configuration.flushMaxRetries = Constants.Configuration.FLUSH_MAX_RETRIES
         storage.reset()
     }
 

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -243,8 +243,9 @@ final class EventPipelineTests: XCTestCase {
         let uploadExpectations = (0..<3).map { i in expectation(description: "httpresponse-\(i)") }
         httpClient.uploadExpectations = uploadExpectations
 
+        let invalidResponseData = "{\"events_with_invalid_fields\": {\"user_id\": [0]}}".data(using: .utf8)!
         httpClient.uploadResults = [
-            .failure(HttpClient.Exception.httpError(code: HttpClient.HttpStatus.BAD_REQUEST.rawValue, data: nil)),
+            .failure(HttpClient.Exception.httpError(code: HttpClient.HttpStatus.BAD_REQUEST.rawValue, data: invalidResponseData)),
             .failure(HttpClient.Exception.httpError(code: HttpClient.HttpStatus.PAYLOAD_TOO_LARGE.rawValue, data: nil)),
             .success(200),
         ]

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -39,6 +39,7 @@ final class EventPipelineTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
+        configuration.flushMaxRetries = Constants.Configuration.FLUSH_MAX_RETRIES
         storage.reset()
     }
 
@@ -187,7 +188,7 @@ final class EventPipelineTests: XCTestCase {
     // test continues to fail until the event is uploaded
     func testContinuousFailure() {
         pipeline.configuration.offline = false
-        pipeline.maxRetryCount = 2
+        pipeline.configuration.flushMaxRetries = 2
 
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
@@ -225,7 +226,7 @@ final class EventPipelineTests: XCTestCase {
 
     func testContinuesHandledFailure() {
         pipeline.configuration.offline = false
-        pipeline.maxRetryCount = 1
+        pipeline.configuration.flushMaxRetries = 1
 
         let testEvent1 = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent1)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

1. Found an unused `flushMaxRetries` parameter in Configuration, which is suitable as a retry cap for EventPipeline.
2. The previous PR’s handling of 400 errors by dropping events was based on the idea that the user manually set the 400, which can be considered an unrecoverable error. In such cases, dropping events is acceptable. However, the customer pointed out another scenario where a 400 error is returned due to VPN configuration region issues, which may be corrected at some point. Based on this assumption, it is best not to discard the events.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
