### PR TITLE
fix: potential priority inversion for storagequeue access

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -39,7 +39,7 @@ public class Amplitude {
         return self.configuration.loggerProvider
     }()
 
-    let trackingQueue = DispatchQueue(label: "com.amplitude.analytics", target: .global(qos: .utility))
+    let trackingQueue = DispatchQueue(label: "com.amplitude.analytics")
 
     public init(
         configuration: Configuration


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Removes targetQueue/qos specifier from trackingQueue.

I've set up the following test harness to run multiple amplitude instances at once:
```
let amplitude1 = Amplitude(configuration: Configuration(apiKey: "aaa", instanceName: "instance-1"))
let amplitude2 = Amplitude(configuration: Configuration(apiKey: "aaa", instanceName: "instance-2"))
let trackingQueue = DispatchQueue(label: "App Tracking Queue", attributes: .concurrent)

func sendIdentify(amplitude: Amplitude) {
    trackingQueue.async {
        amplitude.identify(userProperties: ["a": "b"])
        sendIdentify(amplitude: amplitude)
    }
}

func sendEvent(amplitude: Amplitude) {
    trackingQueue.async {
        amplitude.track(eventType: "aaa")
        sendEvent(amplitude: amplitude)
    }
}

sendIdentify(amplitude: amplitude1)
sendEvent(amplitude: amplitude1)
sendIdentify(amplitude: amplitude2)
sendEvent(amplitude: amplitude2)
```

With the current SDK, I get a hang when Xcode's thread performance checker is enabled. This points to a potential priority inversion issue that seems to be resolved by using default priorities for the tracking queue. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
