### PR TITLE
fix: apply identifies to identity userProperties in correct order

### DIFF
--- a/Sources/Amplitude/Events/Identify.swift
+++ b/Sources/Amplitude/Events/Identify.swift
@@ -21,6 +21,19 @@ open class Identify {
         case PRE_INSERT = "$preInsert"
         case POST_INSERT = "$postInsert"
         case REMOVE = "$remove"
+
+        static let orderedCases: [Operation] = [
+            .CLEAR_ALL,
+            .UNSET,
+            .SET,
+            .SET_ONCE,
+            .ADD,
+            .APPEND,
+            .PREPEND,
+            .PRE_INSERT,
+            .POST_INSERT,
+            .REMOVE,
+        ]
     }
 
     public init() {}

--- a/Sources/Amplitude/Identity.swift
+++ b/Sources/Amplitude/Identity.swift
@@ -16,12 +16,12 @@ extension Identity {
     mutating func apply(identify: [String: Any]) {
         var updatedProperties = userProperties
 
-        for property in identify {
-            guard let op = Identify.Operation(rawValue: property.key) else {
+        for op in Identify.Operation.orderedCases {
+            guard let properties = identify[op.rawValue] else {
                 continue
             }
 
-            let opProperties = property.value as? [String: Any] ?? [:]
+            let opProperties = properties as? [String: Any] ?? [:]
 
             switch op {
             case .SET:


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Applies user properties in the same order as our backend.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
