### PR TITLE
fix: treat non-op user properties as sets

### DIFF
--- a/Sources/Amplitude/Identity.swift
+++ b/Sources/Amplitude/Identity.swift
@@ -38,6 +38,12 @@ extension Identity {
             }
         }
 
+        // Transfer properties that are not explicit operations as SETs
+        let allOpStrings = Set(Identify.Operation.orderedCases.map(\.rawValue))
+        for (key, value) in identify where !allOpStrings.contains(key) {
+            updatedProperties[key] = value
+        }
+
         userProperties = updatedProperties
     }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

treat non-op user properties as sets

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
