### PR TITLE
fix: clean up ios observers on stop

### DIFF
--- a/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
+++ b/Sources/Amplitude/Plugins/iOS/IOSLifecycleMonitor.swift
@@ -124,6 +124,15 @@ class IOSLifecycleMonitor: UtilityPlugin {
     private var currentTimestamp: Int64 {
         return Int64(NSDate().timeIntervalSince1970 * 1000)
     }
+
+    override func teardown() {
+        super.teardown()
+
+        if let amplitude {
+            UIKitScreenViews.unregister(amplitude)
+            UIKitElementInteractions.unregister(amplitude)
+        }
+    }
 }
 
 #endif

--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -58,6 +58,12 @@ class UIKitElementInteractions {
         addNotificationObservers
     }
 
+    static func unregister(_ amplitude: Amplitude) {
+        lock.withLock {
+            amplitudeInstances.remove(amplitude)
+        }
+    }
+
     @objc static func didEndEditing(_ notification: NSNotification) {
         guard let view = notification.object as? UIView else { return }
         // Text fields in SwiftUI are identifiable only after the text field is edited.

--- a/Sources/Amplitude/Plugins/iOS/UIKitScreenViews.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitScreenViews.swift
@@ -15,6 +15,12 @@ class UIKitScreenViews {
         swizzleViewDidAppear
     }
 
+    static func unregister(_ amplitude: Amplitude) {
+        lock.withLock {
+            amplitudes.remove(amplitude)
+        }
+    }
+
     private static let swizzleViewDidAppear: Void = {
         let controllerClass = UIViewController.self
         let originalSelector = #selector(UIViewController.viewDidAppear(_:))


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

explicitly unregisters amplitude as a listener when lifecycle monitor is removed

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
