### PR TITLE
fix: disallow setting nulls for various properties dicts, as this is not supported

### DIFF
--- a/Sources/Amplitude/Events/BaseEvent.swift
+++ b/Sources/Amplitude/Events/BaseEvent.swift
@@ -9,10 +9,10 @@ import Foundation
 
 open class BaseEvent: EventOptions, Codable {
     public var eventType: String
-    public var eventProperties: [String: Any?]?
-    public var userProperties: [String: Any?]?
-    public var groups: [String: Any?]?
-    public var groupProperties: [String: Any?]?
+    public var eventProperties: [String: Any]?
+    public var userProperties: [String: Any]?
+    public var groups: [String: Any]?
+    public var groupProperties: [String: Any]?
 
     enum CodingKeys: String, CodingKey {
         case eventType = "event_type"
@@ -98,10 +98,10 @@ open class BaseEvent: EventOptions, Codable {
         callback: EventCallback? = nil,
         partnerId: String? = nil,
         eventType: String,
-        eventProperties: [String: Any?]? = nil,
-        userProperties: [String: Any?]? = nil,
-        groups: [String: Any?]? = nil,
-        groupProperties: [String: Any?]? = nil
+        eventProperties: [String: Any]? = nil,
+        userProperties: [String: Any]? = nil,
+        groups: [String: Any]? = nil,
+        groupProperties: [String: Any]? = nil
     ) {
         self.eventType = eventType
         self.eventProperties = eventProperties

--- a/Sources/Amplitude/Events/ElementInteractionEvent.swift
+++ b/Sources/Amplitude/Events/ElementInteractionEvent.swift
@@ -12,16 +12,17 @@ public class ElementInteractionEvent: BaseEvent {
         actionMethod: String? = nil,
         gestureRecognizer: String? = nil
     ) {
-        self.init(eventType: Constants.AMP_ELEMENT_INTERACTED_EVENT, eventProperties: [
-            Constants.AMP_APP_SCREEN_NAME_PROPERTY: screenName,
-            Constants.AMP_APP_TARGET_AXLABEL_PROPERTY: accessibilityLabel,
-            Constants.AMP_APP_TARGET_AXIDENTIFIER_PROPERTY: accessibilityIdentifier,
-            Constants.AMP_APP_ACTION_PROPERTY: action,
-            Constants.AMP_APP_TARGET_VIEW_CLASS_PROPERTY: targetViewClass,
-            Constants.AMP_APP_TARGET_TEXT_PROPERTY: targetText,
-            Constants.AMP_APP_HIERARCHY_PROPERTY: hierarchy,
-            Constants.AMP_APP_ACTION_METHOD_PROPERTY: actionMethod,
-            Constants.AMP_APP_GESTURE_RECOGNIZER_PROPERTY: gestureRecognizer
-        ])
+        var eventProperties: [String: Any] = [:]
+        eventProperties[Constants.AMP_APP_SCREEN_NAME_PROPERTY] = screenName
+        eventProperties[Constants.AMP_APP_TARGET_AXLABEL_PROPERTY] = accessibilityLabel
+        eventProperties[Constants.AMP_APP_TARGET_AXIDENTIFIER_PROPERTY] = accessibilityIdentifier
+        eventProperties[Constants.AMP_APP_ACTION_PROPERTY] = action
+        eventProperties[Constants.AMP_APP_TARGET_VIEW_CLASS_PROPERTY] = targetViewClass
+        eventProperties[Constants.AMP_APP_TARGET_TEXT_PROPERTY] = targetText
+        eventProperties[Constants.AMP_APP_HIERARCHY_PROPERTY] = hierarchy
+        eventProperties[Constants.AMP_APP_ACTION_METHOD_PROPERTY] = actionMethod
+        eventProperties[Constants.AMP_APP_GESTURE_RECOGNIZER_PROPERTY] = gestureRecognizer
+
+        self.init(eventType: Constants.AMP_ELEMENT_INTERACTED_EVENT, eventProperties: eventProperties)
     }
 }

--- a/Sources/Amplitude/Events/Identify.swift
+++ b/Sources/Amplitude/Events/Identify.swift
@@ -39,7 +39,7 @@ open class Identify {
     public init() {}
 
     var propertySet = Set<String>()
-    var properties = [String: Any?]()
+    var properties = [String: Any]()
     var logger = ConsoleLogger(logLevel: LogLevelEnum.WARN.rawValue)
 
     // $set operation

--- a/Sources/Amplitude/Events/Revenue.swift
+++ b/Sources/Amplitude/Events/Revenue.swift
@@ -77,7 +77,7 @@ public class Revenue {
 
     public var receiptSig: String?
 
-    public var properties: [String: Any?]?
+    public var properties: [String: Any]?
 
     @discardableResult
     public func setReceipt(receipt: String, receiptSignature: String) -> Revenue {
@@ -92,7 +92,7 @@ public class Revenue {
 
     func toRevenueEvent() -> RevenueEvent {
         let event = RevenueEvent()
-        var eventProperties = properties ?? [String: Any?]()
+        var eventProperties = properties ?? [String: Any]()
         if productId != nil {
             eventProperties[Property.REVENUE_PRODUCT_ID.rawValue] = productId
         }

--- a/Tests/AmplitudeTests/Events/BaseEventTests.swift
+++ b/Tests/AmplitudeTests/Events/BaseEventTests.swift
@@ -12,7 +12,7 @@ import XCTest
 // swiftlint:disable force_cast
 final class BaseEventTests: XCTestCase {
     func testToString() {
-        let eventProperties: [String: Any?] = [
+        let eventProperties: [String: Any] = [
             "integer": 1,
             "string": "stringValue",
             "array": [1, 2, 3],
@@ -43,7 +43,7 @@ final class BaseEventTests: XCTestCase {
                 sourceVersion: "test-source-version"
             ),
             eventType: "test",
-            eventProperties: eventProperties)
+            eventProperties: eventProperties as [String: Any])
 
         let baseEventData = baseEvent.toString().data(using: .utf8)!
         let baseEventDict =
@@ -127,7 +127,7 @@ final class BaseEventTests: XCTestCase {
                 "integer": 1,
                 "string": nil,
                 "array": nil,
-            ]
+            ] as [String: Any?] as [String: Any]
         )
 
         let baseEventData = baseEvent.toString().data(using: .utf8)!
@@ -261,11 +261,11 @@ final class BaseEventTests: XCTestCase {
             1
         )
         XCTAssertEqual(
-            event?.eventProperties!["string"] as? String?,
+            event?.eventProperties!["string"] as? String,
             nil
         )
         XCTAssertEqual(
-            event?.eventProperties!["array"] as? [Double]?,
+            event?.eventProperties!["array"] as? [Double],
             nil
         )
     }

--- a/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
+++ b/Tests/AmplitudeTests/Utilities/IdentifyInterceptorTests.swift
@@ -73,31 +73,31 @@ final class IdentifyInterceptorTests: XCTestCase {
             interceptor.isInterceptEvent(BaseEvent(userId: "user-1", eventType: "$identify"))
         )
         XCTAssertFalse(
-            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", groups: [String: Any?]()))
+            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", groups: [String: Any]()))
         )
         XCTAssertFalse(
             interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", groups: ["key-1": "value-1"]))
         )
         XCTAssertFalse(
-            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: [String: Any?]()))
+            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: [String: Any]()))
         )
         XCTAssertTrue(
-            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$set": [String: Any?]()]))
+            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$set": [String: Any]()]))
         )
         XCTAssertFalse(
             interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$clearAll": "-"]))
         )
         XCTAssertFalse(
-            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$add": [String: Any?]()]))
+            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$add": [String: Any]()]))
         )
         XCTAssertFalse(
-            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$set": [String: Any?](), "$add": [String: Any?]()]))
+            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$set": [String: Any](), "$add": [String: Any?]()]))
         )
         XCTAssertFalse(
-            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$clearAll": "-", "$add": [String: Any?]()]))
+            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$clearAll": "-", "$add": [String: Any]()]))
         )
         XCTAssertFalse(
-            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$set": [String: Any?](), "$clearAll": "-", "$add": [String: Any?]()]))
+            interceptor.isInterceptEvent(BaseEvent(eventType: "$identify", userProperties: ["$set": [String: Any](), "$clearAll": "-", "$add": [String: Any]()]))
         )
     }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Removes the ability to store null values in our properties dictionaries, as this does not appear to be supported from wither directly sending events from curl, or round tripping events from storage.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  semi-breaking; this will generate warnings for dict literals passed in as properties that have nullable values (see `ElementInteractionEvent` changes), but conversion between nullable / not nullable values itself seems to be implicit.
