### PR TITLE
feat: wire up remote config for autocapture

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3E281B8E2B96833D009D913B /* DiagnosticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E281B8D2B96833D009D913B /* DiagnosticsTests.swift */; };
 		3E281B912B9BCC14009D913B /* DispatchQueueHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E281B902B9BCC14009D913B /* DispatchQueueHolder.swift */; };
 		4E05BB942BE41AEB009DE475 /* Amplitude+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E05BB932BE41AEB009DE475 /* Amplitude+Extensions.swift */; };
+		4E27E4162DC1443F00799F24 /* AutocaptureRemoteConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E27E4152DC1443800799F24 /* AutocaptureRemoteConfigTests.swift */; };
 		4E2B646B2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */; };
 		4E3871622BB34DBC002890AB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B6DF481F2B5B45BE00B3E6AA /* PrivacyInfo.xcprivacy */; };
 		4E654D682D97454900BCAA85 /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E654D672D97454900BCAA85 /* Identity.swift */; };
@@ -143,6 +144,7 @@
 		3E281B8D2B96833D009D913B /* DiagnosticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiagnosticsTests.swift; sourceTree = "<group>"; };
 		3E281B902B9BCC14009D913B /* DispatchQueueHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueHolder.swift; sourceTree = "<group>"; };
 		4E05BB932BE41AEB009DE475 /* Amplitude+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Amplitude+Extensions.swift"; sourceTree = "<group>"; };
+		4E27E4152DC1443800799F24 /* AutocaptureRemoteConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocaptureRemoteConfigTests.swift; sourceTree = "<group>"; };
 		4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitScreenViewsPluginTests.swift; sourceTree = "<group>"; };
 		4E44BA012DB06D200048796B /* Package@swift-5.9.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Package@swift-5.9.swift"; sourceTree = "<group>"; };
 		4E654D672D97454900BCAA85 /* Identity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identity.swift; sourceTree = "<group>"; };
@@ -477,6 +479,7 @@
 		OBJ_53 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				4E27E4152DC1443800799F24 /* AutocaptureRemoteConfigTests.swift */,
 				4E654DE02D9B60E300BCAA85 /* IdentityTests.swift */,
 				6C04FC462C5897AC00EA8667 /* AutocaptureOptionsTests.swift */,
 				B6F3389F2B6854A8006179E2 /* Plugins */,
@@ -738,6 +741,7 @@
 				OBJ_154 /* TypesTests.swift in Sources */,
 				OBJ_155 /* EventPipelineTests.swift in Sources */,
 				3E281B8E2B96833D009D913B /* DiagnosticsTests.swift in Sources */,
+				4E27E4162DC1443F00799F24 /* AutocaptureRemoteConfigTests.swift in Sources */,
 				B6F338A32B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift in Sources */,
 				6C04FC482C589C8100EA8667 /* AutocaptureOptionsTests.swift in Sources */,
 				OBJ_156 /* HttpClientTests.swift in Sources */,

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -25,6 +25,7 @@ public class Configuration {
         public static let maxQueuedEventCount = -1
         public static let autocaptureOptions: AutocaptureOptions = .sessions
         public static let migrateLegacyData = true
+        public static let enableAutoCaptureRemoteConfig = true
         public static let trackingOptions = TrackingOptions()
         public static let networkTrackingOptions = NetworkTrackingOptions.default
     }
@@ -72,6 +73,7 @@ public class Configuration {
     internal let diagonostics: Diagnostics
     public var maxQueuedEventCount = -1
     var optOutChanged: ((Bool) -> Void)?
+    public let enableAutoCaptureRemoteConfig: Bool
 
     @available(*, deprecated, message: "Please use the `autocapture` parameter instead.")
     public convenience init(
@@ -163,7 +165,8 @@ public class Configuration {
         maxQueuedEventCount: Int = Defaults.maxQueuedEventCount,
         migrateLegacyData: Bool = Defaults.migrateLegacyData,
         offline: Bool? = false,
-        networkTrackingOptions: NetworkTrackingOptions = Defaults.networkTrackingOptions
+        networkTrackingOptions: NetworkTrackingOptions = Defaults.networkTrackingOptions,
+        enableAutoCaptureRemoteConfig: Bool = Defaults.enableAutoCaptureRemoteConfig
     ) {
         let normalizedInstanceName = Configuration.getNormalizeInstanceName(instanceName)
 
@@ -200,6 +203,7 @@ public class Configuration {
         self.loggerProvider.logLevel = logLevel.rawValue
         self.offline = offline
         self.networkTrackingOptions = networkTrackingOptions
+        self.enableAutoCaptureRemoteConfig = enableAutoCaptureRemoteConfig
     }
 
     func isValid() -> Bool {

--- a/Sources/Amplitude/ConsoleLogger.swift
+++ b/Sources/Amplitude/ConsoleLogger.swift
@@ -8,7 +8,8 @@
 import Foundation
 import os.log
 
-public class ConsoleLogger: Logger {
+@preconcurrency
+public class ConsoleLogger: Logger, @unchecked Sendable {
     public typealias LogLevel = LogLevelEnum
 
     public var logLevel: Int

--- a/Sources/Amplitude/Constants.swift
+++ b/Sources/Amplitude/Constants.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 @objc(AMPLogLevel)
-public enum LogLevelEnum: Int {
+public enum LogLevelEnum: Int, Sendable {
     case OFF
     case ERROR
     case WARN
@@ -89,6 +89,12 @@ public struct Constants {
     static let AMP_NETWORK_DURATION_PROPERTY = "\(AMP_AMPLITUDE_PREFIX)Duration"
     static let AMP_NETWORK_REQUEST_BODY_SIZE_PROPERTY = "\(AMP_AMPLITUDE_PREFIX)Request Body Size"
     static let AMP_NETWORK_RESPONSE_BODY_SIZE_PROPERTY = "\(AMP_AMPLITUDE_PREFIX)Response Body Size"
+
+    struct RemoteConfig {
+        struct Key {
+            static let autocapture = "analyticsSDK.iosSDK.autocapture"
+        }
+    }
 
     public struct Configuration {
         public static let FLUSH_QUEUE_SIZE = 30

--- a/Sources/Amplitude/ObjC/ObjCAutocaptureOptions.swift
+++ b/Sources/Amplitude/ObjC/ObjCAutocaptureOptions.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objc(AMPAutocaptureOptions)
-public final class ObjCAutocaptureOptions: NSObject {
+public final class ObjCAutocaptureOptions: NSObject, @unchecked Sendable {
     internal var _options: AutocaptureOptions
 
     public override init() {

--- a/Sources/Amplitude/ObjC/ObjCLoggerProvider.swift
+++ b/Sources/Amplitude/ObjC/ObjCLoggerProvider.swift
@@ -2,7 +2,8 @@ import Foundation
 
 public typealias ObjCLoggerProvider = (Int, String) -> Void
 
-class ObjCLoggerProviderWrapper: Logger {
+@preconcurrency
+class ObjCLoggerProviderWrapper: Logger, @unchecked Sendable {
     public typealias LogLevel = LogLevelEnum
     public var logLevel: Int
 

--- a/Tests/AmplitudeTests/AmplitudeIOSTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeIOSTests.swift
@@ -25,7 +25,8 @@ final class AmplitudeIOSTests: XCTestCase {
             instanceName: #function,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
-            autocapture: .appLifecycles
+            autocapture: .appLifecycles,
+            enableAutoCaptureRemoteConfig: false
         )
         let amplitude = Amplitude(configuration: configuration)
         try storageMem.write(key: StorageKey.APP_BUILD, value: nil)
@@ -53,7 +54,8 @@ final class AmplitudeIOSTests: XCTestCase {
             instanceName: #function,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
-            autocapture: .appLifecycles
+            autocapture: .appLifecycles,
+            enableAutoCaptureRemoteConfig: false
         )
         try storageMem.write(key: StorageKey.APP_BUILD, value: "abc")
         try storageMem.write(key: StorageKey.APP_VERSION, value: "xyz")
@@ -81,7 +83,8 @@ final class AmplitudeIOSTests: XCTestCase {
             apiKey: "api-key",
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
-            autocapture: .appLifecycles
+            autocapture: .appLifecycles,
+            enableAutoCaptureRemoteConfig: false
         )
 
         let info = Bundle.main.infoDictionary
@@ -124,7 +127,8 @@ final class AmplitudeIOSTests: XCTestCase {
             apiKey: "api-key",
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
-            autocapture: .appLifecycles
+            autocapture: .appLifecycles,
+            enableAutoCaptureRemoteConfig: false
         )
 
         let info = Bundle.main.infoDictionary
@@ -190,7 +194,8 @@ final class AmplitudeIOSTests: XCTestCase {
             apiKey: "api-key",
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
-            autocapture: .appLifecycles
+            autocapture: .appLifecycles,
+            enableAutoCaptureRemoteConfig: false
         )
 
         let info = Bundle.main.infoDictionary
@@ -223,7 +228,8 @@ final class AmplitudeIOSTests: XCTestCase {
             apiKey: "api-key",
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
-            autocapture: .appLifecycles
+            autocapture: .appLifecycles,
+            enableAutoCaptureRemoteConfig: false
         )
 
         let amplitude = Amplitude(configuration: configuration)

--- a/Tests/AmplitudeTests/AmplitudeSessionTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeSessionTests.swift
@@ -18,7 +18,8 @@ final class AmplitudeSessionTests: XCTestCase {
             apiKey: apiKey,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
-            minTimeBetweenSessionsMillis: 100
+            minTimeBetweenSessionsMillis: 100,
+            enableAutoCaptureRemoteConfig: false
         )
     }
 
@@ -115,7 +116,8 @@ final class AmplitudeSessionTests: XCTestCase {
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             minTimeBetweenSessionsMillis: 100,
-            autocapture: []
+            autocapture: [],
+            enableAutoCaptureRemoteConfig: false
         )
         let amplitude = Amplitude(configuration: customCongiguration)
         amplitude.setSessionId(timestamp: 800)

--- a/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
+++ b/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
@@ -1,0 +1,309 @@
+//
+//  AutocaptureRemoteConfigTests.swift
+//  Amplitude-Swift
+//
+//  Created by Chris Leonavicius on 4/29/25.
+//
+
+import AmplitudeCore
+@testable import AmplitudeSwift
+import ObjectiveC
+import XCTest
+
+class AutocaptureRemoteConfigTests: XCTestCase {
+
+    private static func swizzleUrlSessionConfiguration() {
+        let originalMethod = class_getInstanceMethod(URLSessionConfiguration.self,
+                                         #selector(getter: URLSessionConfiguration.protocolClasses))
+        let swizzledMethod = class_getInstanceMethod(URLSessionConfiguration.self,
+                                         #selector(getter: URLSessionConfiguration.amp_protocolClasses))
+
+        guard let originalMethod, let swizzledMethod else {
+            XCTFail("Unable to swizzle protocolClasses")
+            return
+        }
+
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    override class func setUp() {
+        super.setUp()
+
+        // Inject url handler for SR client
+        swizzleUrlSessionConfiguration()
+
+    }
+
+    override func setUp() {
+        super.setUp()
+
+        // reset remote config storage
+        RemoteConfigClient.resetStorage()
+    }
+
+    override class func tearDown() {
+        super.tearDown()
+
+        // Swizzle again to restore original behavior
+        swizzleUrlSessionConfiguration()
+    }
+
+    func testSessionsTurnsOnFromRemoteConfig() {
+        RemoteConfigClient.setNextFetchedRemoteConfig([
+            "analyticsSDK": [
+                "iosSDK": [
+                    "autocapture": [
+                        "sessions": true,
+                    ]
+                ]
+            ]
+        ])
+
+        let amplitude = Amplitude(configuration: Configuration(apiKey: "aaa", autocapture: []))
+        let sessions = amplitude.sessions
+        XCTAssertFalse(sessions.trackSessionEvents)
+
+        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 1)
+
+        XCTAssertTrue(sessions.trackSessionEvents)
+    }
+
+    func testSessionsTurnsOffFromRemoteConfig() {
+        RemoteConfigClient.setNextFetchedRemoteConfig([
+            "analyticsSDK": [
+                "iosSDK": [
+                    "autocapture": [
+                        "sessions": false,
+                    ]
+                ]
+            ]
+        ])
+
+        let amplitude = Amplitude(configuration: Configuration(apiKey: "aaa", autocapture: [.sessions]))
+        let sessions = amplitude.sessions
+        XCTAssertTrue(sessions.trackSessionEvents)
+
+        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 1)
+
+        XCTAssertFalse(sessions.trackSessionEvents)
+    }
+
+#if os(iOS)
+
+    func testScreenViewsTurnsOnFromRemoteConfig() {
+        RemoteConfigClient.setNextFetchedRemoteConfig([
+            "analyticsSDK": [
+                "iosSDK": [
+                    "autocapture": [
+                        "pageViews": true,
+                    ]
+                ]
+            ]
+        ])
+
+        let amplitude = Amplitude(configuration: Configuration(apiKey: "aaa", autocapture: []))
+
+        var iosLifecycleMonitor: IOSLifecycleMonitor?
+        amplitude.apply { plugin in
+            if let monitor = plugin as? IOSLifecycleMonitor {
+                iosLifecycleMonitor = monitor
+            }
+        }
+        guard let iosLifecycleMonitor else {
+            XCTFail("iOS lifecycle monitor not installed")
+            return
+        }
+
+        XCTAssertFalse(iosLifecycleMonitor.trackScreenViews)
+
+        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 1)
+
+        XCTAssertTrue(iosLifecycleMonitor.trackScreenViews)
+    }
+
+    func testScreenViewsTurnsOffFromRemoteConfig() {
+        RemoteConfigClient.setNextFetchedRemoteConfig([
+            "analyticsSDK": [
+                "iosSDK": [
+                    "autocapture": [
+                        "pageViews": false,
+                    ]
+                ]
+            ]
+        ])
+
+        let amplitude = Amplitude(configuration: Configuration(apiKey: "aaa", autocapture: [.screenViews]))
+
+        var iosLifecycleMonitor: IOSLifecycleMonitor?
+        amplitude.apply { plugin in
+            if let monitor = plugin as? IOSLifecycleMonitor {
+                iosLifecycleMonitor = monitor
+            }
+        }
+        guard let iosLifecycleMonitor else {
+            XCTFail("iOS lifecycle monitor not installed")
+            return
+        }
+
+        XCTAssertTrue(iosLifecycleMonitor.trackScreenViews)
+
+        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 1)
+
+        XCTAssertFalse(iosLifecycleMonitor.trackScreenViews)
+    }
+
+    func testElementInteractionsTurnsOnFromRemoteConfig() {
+        RemoteConfigClient.setNextFetchedRemoteConfig([
+            "analyticsSDK": [
+                "iosSDK": [
+                    "autocapture": [
+                        "elementInteractions": true,
+                    ]
+                ]
+            ]
+        ])
+
+        let amplitude = Amplitude(configuration: Configuration(apiKey: "aaa", autocapture: []))
+
+        var iosLifecycleMonitor: IOSLifecycleMonitor?
+        amplitude.apply { plugin in
+            if let monitor = plugin as? IOSLifecycleMonitor {
+                iosLifecycleMonitor = monitor
+            }
+        }
+        guard let iosLifecycleMonitor else {
+            XCTFail("iOS lifecycle monitor not installed")
+            return
+        }
+
+        XCTAssertFalse(iosLifecycleMonitor.trackElementInteractions)
+
+        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 1)
+
+        XCTAssertTrue(iosLifecycleMonitor.trackElementInteractions)
+    }
+
+    func testElementInteractionsTurnsOffFromRemoteConfig() {
+        RemoteConfigClient.setNextFetchedRemoteConfig([
+            "analyticsSDK": [
+                "iosSDK": [
+                    "autocapture": [
+                        "elementInteractions": false,
+                    ]
+                ]
+            ]
+        ])
+
+        let amplitude = Amplitude(configuration: Configuration(apiKey: "aaa", autocapture: [.elementInteractions]))
+
+        var iosLifecycleMonitor: IOSLifecycleMonitor?
+        amplitude.apply { plugin in
+            if let monitor = plugin as? IOSLifecycleMonitor {
+                iosLifecycleMonitor = monitor
+            }
+        }
+        guard let iosLifecycleMonitor else {
+            XCTFail("iOS lifecycle monitor not installed")
+            return
+        }
+
+        XCTAssertTrue(iosLifecycleMonitor.trackElementInteractions)
+
+        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 1)
+
+        XCTAssertFalse(iosLifecycleMonitor.trackElementInteractions)
+    }
+
+#endif
+}
+
+extension RemoteConfigClient {
+
+    private final class SubscriptionHolder: @unchecked Sendable {
+        @Atomic var subscription: Any?
+    }
+
+    nonisolated var didFetchRemoteExpectation: XCTestExpectation {
+        let expectation = XCTestExpectation(description: "didFetchRemote")
+
+        let subscriptionHolder = SubscriptionHolder()
+        subscriptionHolder.subscription = subscribe { [weak self] _, source, _ in
+            guard source == .remote else {
+                return
+            }
+            if let subscription = subscriptionHolder.subscription {
+                self?.unsubscribe(subscription)
+            }
+            expectation.fulfill()
+        }
+
+        return expectation
+    }
+
+    static func setNextFetchedRemoteConfig(_ remoteConfig: RemoteConfigClient.RemoteConfig) {
+        RemoteConfigUrlProtocol.nextConfigs.append(remoteConfig)
+    }
+
+    static func resetStorage(instanceName: String? = Constants.Configuration.DEFAULT_INSTANCE) {
+        RemoteConfigClient.setNextFetchedRemoteConfig([
+            "analyticsSDK": [
+                "iosSDK": [
+                    "autocapture": [
+                        "sessions": true,
+                    ]
+                ]
+            ]
+        ])
+        let amplitude = Amplitude(configuration: Configuration(apiKey: "aaa"))
+        XCTWaiter().wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation],
+                         timeout: 1)
+    }
+}
+
+extension URLSessionConfiguration {
+
+    @objc var amp_protocolClasses: [AnyClass]? {
+        // this is swizzled, so it is not recursive
+        return [RemoteConfigUrlProtocol.self] + (self.amp_protocolClasses ?? [])
+    }
+}
+
+class RemoteConfigUrlProtocol: URLProtocol {
+
+    static var nextConfigs: [RemoteConfigClient.RemoteConfig] = []
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return request.url?.absoluteString.hasPrefix("https://sr-client-cfg.") ?? false
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let url = request.url, !Self.nextConfigs.isEmpty else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown))
+            return
+        }
+
+        let config = Self.nextConfigs.removeFirst()
+
+        let response = HTTPURLResponse(url: url,
+                                       statusCode: 200,
+                                       httpVersion: nil,
+                                       headerFields: ["Content-Type": "application/json"])!
+        let data = try? JSONSerialization.data(withJSONObject: ["configs": config])
+
+        DispatchQueue.global().asyncAfter(deadline: .now() + DispatchTimeInterval.milliseconds(200)) { [self] in
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+
+    override func stopLoading() {
+        // no-op
+    }
+}

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -41,7 +41,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
                                           storageProvider: storageMem,
                                           flushMaxRetries: 0,
                                           autocapture: .networkTracking,
-                                          networkTrackingOptions: options)
+                                          networkTrackingOptions: options,
+                                          enableAutoCaptureRemoteConfig: false)
         amplitude = Amplitude(configuration: configuration)
         amplitude.add(plugin: eventCollector)
     }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds auto capture remote config for analyticsSDK.iosSDK namespace. We still need backend APIs to power this.

This changes the behavior of autocapture such that changes committed after amplitude init are ignored.

### Checklist

* [x Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
