### PR TITLE
fix: implement plugin lookup by type

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -1289,7 +1289,7 @@
 			repositoryURL = "https://github.com/amplitude/AmplitudeCore-Swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.10;
+				minimumVersion = 1.0.12;
 			};
 		};
 		4EB530762CD2EB9700E961F4 /* XCRemoteSwiftPackageReference "analytics-connector-ios" */ = {

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.visionos.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   s.dependency 'AnalyticsConnector', '~> 1.3.0'
-  s.dependency 'AmplitudeCore', '>=1.0.10', '<2.0.0'
+  s.dependency 'AmplitudeCore', '>=1.0.12', '<2.0.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "amplitude/analytics-connector-ios" ~> 1.2.3
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.0.9
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.0.12

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.10"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.12"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.10"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.12"),
     ],
     targets: [
         .target(

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -1,7 +1,7 @@
 @_exported import AmplitudeCore
 import Foundation
 
-public class Amplitude: PluginHost {
+public class Amplitude {
 
     public private(set) var configuration: Configuration
     private var inForeground = false
@@ -357,10 +357,6 @@ public class Amplitude: PluginHost {
         return self
     }
 
-    public func plugin(name: String) -> UniversalPlugin? {
-        return timeline.plugin(name: name)
-    }
-
     @discardableResult
     public func flush() -> Amplitude {
         trackingQueue.async {
@@ -601,6 +597,23 @@ public class Amplitude: PluginHost {
             }
         }
         logger?.debug(message: "Completed trimming events, kept \(eventCount) most recent events")
+    }
+}
+
+extension Amplitude: PluginHost {
+
+    public func plugin(name: String) -> UniversalPlugin? {
+        return timeline.plugin(name: name)
+    }
+
+    public func plugins<PluginType: UniversalPlugin>(type: PluginType.Type) -> [PluginType] {
+        var typedPlugins: [PluginType] = []
+        timeline.apply { plugin in
+            if let typedPlugin = plugin as? PluginType {
+                typedPlugins.append(typedPlugin)
+            }
+        }
+        return typedPlugins
     }
 }
 

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -940,4 +940,32 @@ final class AmplitudeTests: XCTestCase {
     func getDictionary(_ props: [String: Any?]) -> NSDictionary {
         return NSDictionary(dictionary: props as [AnyHashable: Any])
     }
+
+    func testPluginByType() {
+
+        class PluginA: Plugin {
+            let type: PluginType = .before
+        }
+
+        class PluginB: Plugin {
+            let type: PluginType = .before
+        }
+
+        let pluginAs = (0..<3).map { _ in PluginA() }
+        let pluginBs = (0..<4).map { _ in PluginB() }
+
+        let amplitude = Amplitude(configuration: .init(apiKey: ""))
+        pluginAs.forEach { amplitude.add(plugin: $0) }
+        pluginBs.forEach { amplitude.add(plugin: $0) }
+
+        XCTAssertEqual(amplitude.plugins(type: PluginA.self).count, pluginAs.count)
+        pluginAs.forEach { pluginA in
+            XCTAssert(amplitude.plugins(type: PluginA.self).contains { $0 === pluginA })
+        }
+
+        XCTAssertEqual(amplitude.plugins(type: PluginB.self).count, pluginBs.count)
+        pluginBs.forEach { pluginB in
+            XCTAssert(amplitude.plugins(type: PluginB.self).contains { $0 === pluginB })
+        }
+    }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

adds support for plugin lookup by type, recently added in core.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
