### PR TITLE
Fix TimeInterval helpers

### DIFF
--- a/Sources/Amplitude/Utilities/QueueTimer.swift
+++ b/Sources/Amplitude/Utilities/QueueTimer.swift
@@ -68,7 +68,7 @@ internal class QueueTimer {
 
 extension TimeInterval {
     static func milliseconds(_ value: Int) -> TimeInterval {
-        return TimeInterval(value / 1000)
+        return TimeInterval(Double(value) / 1000.0)
     }
 
     static func seconds(_ value: Int) -> TimeInterval {
@@ -76,10 +76,10 @@ extension TimeInterval {
     }
 
     static func hours(_ value: Int) -> TimeInterval {
-        return TimeInterval(60 * value)
+        return TimeInterval(60 * 60 * value)
     }
 
     static func days(_ value: Int) -> TimeInterval {
-        return TimeInterval((60 * value) * 24)
+        return TimeInterval(60 * 60 * 24 * value)
     }
 }

--- a/Tests/AmplitudeTests/Utilities/TimeIntervalExtensionsTests.swift
+++ b/Tests/AmplitudeTests/Utilities/TimeIntervalExtensionsTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import AmplitudeSwift
+
+final class TimeIntervalExtensionsTests: XCTestCase {
+    func testMilliseconds() {
+        XCTAssertEqual(TimeInterval.milliseconds(1500), 1.5)
+        XCTAssertEqual(TimeInterval.milliseconds(250), 0.25)
+    }
+
+    func testHoursAndDays() {
+        XCTAssertEqual(TimeInterval.hours(1), 3600)
+        XCTAssertEqual(TimeInterval.days(1), 86400)
+    }
+}


### PR DESCRIPTION
## Summary
- fix `TimeInterval` unit conversion helpers
- add unit tests for `TimeInterval` helpers

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/amplitude/AmplitudeCore-Swift.git: Failed to connect to proxy port 8080)*