### PR TITLE
fix: TimeInterval helpers

### DIFF
--- a/Sources/Amplitude/Utilities/QueueTimer.swift
+++ b/Sources/Amplitude/Utilities/QueueTimer.swift
@@ -68,18 +68,11 @@ internal class QueueTimer {
 
 extension TimeInterval {
     static func milliseconds(_ value: Int) -> TimeInterval {
-        return TimeInterval(value / 1000)
+        return TimeInterval(Double(value) / 1000.0)
     }
 
     static func seconds(_ value: Int) -> TimeInterval {
         return TimeInterval(value)
     }
 
-    static func hours(_ value: Int) -> TimeInterval {
-        return TimeInterval(60 * value)
-    }
-
-    static func days(_ value: Int) -> TimeInterval {
-        return TimeInterval((60 * value) * 24)
-    }
 }

--- a/Tests/AmplitudeTests/Utilities/TimeIntervalExtensionsTests.swift
+++ b/Tests/AmplitudeTests/Utilities/TimeIntervalExtensionsTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import AmplitudeSwift
+
+final class TimeIntervalExtensionsTests: XCTestCase {
+    func testMilliseconds() {
+        XCTAssertEqual(TimeInterval.milliseconds(1500), 1.5)
+        XCTAssertEqual(TimeInterval.milliseconds(250), 0.25)
+    }
+
+}


### PR DESCRIPTION
## Summary
- fix `TimeInterval` unit conversion helpers
- add unit tests for `TimeInterval` helpers
- remove unused `hours` and `days` helpers

## Testing
- `swift test` *(fails: Failed to clone repository https://github.com/amplitude/AmplitudeCore-Swift.git: Failed to connect to proxy port 8080)*