### PR TITLE
fix: delay app start / end events when starting amplitude in foreground

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -114,6 +114,7 @@ public class Amplitude {
     public init(
         configuration: Configuration
     ) {
+        trackingQueue.suspend()
         self.configuration = configuration
 
         let serverZone: AmplitudeCore.ServerZone
@@ -173,6 +174,7 @@ public class Amplitude {
         trackingQueue.async { [self] in
             self.trimQueuedEvents()
         }
+        trackingQueue.resume()
     }
 
     convenience init(apiKey: String, configuration: Configuration) {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

When Amplitude is initialized after the app is in the foreground, we will immediately try to fire app opened/ app installed / session start events as we will not get a subsequent onEnterForeground. We recently enhanced the consistency of the user/device id set on an event, so that these automatically tracked events will no longer pick up changes from userid/deviceId set immediately after Amplitude initialization.

To restore this ability, we now fire the events on the tracking queue. This effectively adds enough of a delay that identity can be set immediately after init and be picked up by the events.

During testing, I found that the tracking queue could actually start while still in init - we also now pause the queue to ensure we are fully set up.

In the tests:
The previous tests that overrode various UIApplication apis were not actually working. I've added some more sane apis to `iOSLifecycleManager` to expose just the properties we are actually using, and to allow overrides in tests.

### Checklist

* [ ] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->
