### PR TITLE
fix: improve objc interface for Unified SDK

### DIFF
--- a/Sources/Amplitude/ObjC/ObjCAmplitude.swift
+++ b/Sources/Amplitude/ObjC/ObjCAmplitude.swift
@@ -227,4 +227,25 @@ public class ObjCAmplitude: NSObject {
         amplitude.reset()
         return self
     }
+
+    @objc
+    var optOut: Bool {
+        get {
+            return amplitude.optOut
+        }
+        set {
+            amplitude.optOut = newValue
+        }
+    }
+}
+
+extension ObjCAmplitude: PluginHost {
+
+    public func plugin(name: String) -> (any UniversalPlugin)? {
+        return amplitude.plugin(name: name)
+    }
+
+    public func plugins<PluginType: UniversalPlugin>(type: PluginType.Type) -> [PluginType] {
+        return amplitude.plugins(type: type)
+    }
 }

--- a/Sources/Amplitude/ObjC/ObjCAutocaptureOptions.swift
+++ b/Sources/Amplitude/ObjC/ObjCAutocaptureOptions.swift
@@ -49,6 +49,11 @@ public final class ObjCAutocaptureOptions: NSObject, @unchecked Sendable {
     @objc
     public static let all: ObjCAutocaptureOptions = ObjCAutocaptureOptions(options: .all)
 
+    @objc
+    public static var `default`: ObjCAutocaptureOptions {
+        return ObjCAutocaptureOptions(options: Configuration.Defaults.autocaptureOptions)
+    }
+
     // MARK: NSObject
 
     public override var hash: Int {

--- a/Sources/Amplitude/ObjC/ObjCConfiguration.swift
+++ b/Sources/Amplitude/ObjC/ObjCConfiguration.swift
@@ -24,6 +24,13 @@ public class ObjCConfiguration: NSObject {
         self.init(configuration: Configuration(apiKey: apiKey, instanceName: instanceName))
     }
 
+    @objc(initWithApiKey:instanceName:enableAutocaptureRemoteConfig:)
+    public convenience init(apiKey: String, instanceName: String, enableAutoCaptureRemoteConfig: Bool) {
+        self.init(configuration: Configuration(apiKey: apiKey,
+                                               instanceName: instanceName,
+                                               enableAutoCaptureRemoteConfig: enableAutoCaptureRemoteConfig))
+    }
+
     internal init(configuration: Configuration) {
         self.configuration = configuration
     }
@@ -303,5 +310,9 @@ public class ObjCConfiguration: NSObject {
         set(value) {
             configuration.networkTrackingOptions = value.options
         }
+    }
+
+    @objc public var enableAutoCaptureRemoteConfig: Bool {
+        return configuration.enableAutoCaptureRemoteConfig
     }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- exposed optOut directly on ObjCAmplitude
- ObjCAmplitude now conforms to PluginHost (this doesn't pick up the `amplitude.experiment` / `amplitude.sessionReplay` extensions as they won't play nice with ObjC, but should allow us to then re-expose these to objc)
- adds a `default` ObjCAutocaptureOptions
- allows `enableAutoCaptureRemoteConfig` to be set on ObjCConfiguration

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
