### PR TITLE
fix: update to xcode 16.1 for prebuilt artifacts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   lint:
-    runs-on: macos-13
+    runs-on: macos-14-large
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set Xcode 15
+      - name: Set Xcode 16
         run: |
-          sudo xcode-select -switch /Applications/Xcode_15.2.app
+          sudo xcode-select -switch /Applications/Xcode_16.1.app
       - name: Lint
         run: swiftlint --strict # force to fix warnings too

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   authorize:
     name: Authorize
-    runs-on: macos-13-xlarge
+    runs-on: macos-14
     steps:
       - name: ${{ github.actor }} permission check to do a release
         uses: octokit/request-action@v2.1.9
@@ -27,14 +27,14 @@ jobs:
 
   release:
     name: Release
-    runs-on: macos-13-xlarge
+    runs-on: macos-14-xlarge
     needs: [authorize, run-tests]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set Xcode 15
+      - name: Set Xcode 16.1
         run: |
-          sudo xcode-select -switch /Applications/Xcode_15.2.app
+          sudo xcode-select -switch /Applications/Xcode_16.1.app
 
       # Install missing sdk for pod lint
       # Remove this step after the runner upgraded to macos-15

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - 1.1.x
   workflow_call:
 
 jobs:
@@ -17,38 +16,38 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: macos-13
+          - runs-on: macos-14
             platform: iOS
-            xcode: 15.2
+            xcode: 16.1
+            device: "iPhone 16"
+            test-destination-os: latest
+
+          - runs-on: macos-14
+            platform: iOS
+            xcode: 16.1
+            test-destination-os: 17.2
             device: "iPhone 15"
-            test-destination-os: latest
-
-          - runs-on: macos-13
-            platform: iOS
-            xcode: 15.0.1
-            test-destination-os: 16.1
-            device: "iPhone 14"
           
-          - runs-on: macos-13
+          - runs-on: macos-14
             platform: macOS
-            xcode: 15.2
+            xcode: 16.1
             test-destination-os: latest
 
-          - runs-on: macos-13
+          - runs-on: macos-14
             platform: tvOS
-            xcode: 15.2
+            xcode: 16.1
             test-destination-os: latest
-            device: "Apple TV"
+            device: "Apple TV 4K (3rd generation)"
 
-          - runs-on: macos-13
+          - runs-on: macos-14
             platform: watchOS
-            xcode: 15.2
+            xcode: 16.1
             test-destination-os: latest
-            device: "Apple Watch Series 8 (41mm)"
+            device: "Apple Watch Series 10 (46mm)"
 
-          - runs-on: macos-13
+          - runs-on: macos-14
             platform: visionOS
-            xcode: 15.2
+            xcode: 16.1
             test-destination-os: latest
             device: "Apple Vision Pro"
     steps:
@@ -76,7 +75,7 @@ jobs:
               xcodebuild test \
                 -scheme Amplitude-Swift-Package \
                 -sdk macosx \
-                -destination 'platform=macosx,OS=${{ matrix.test-destination-os }}'
+                -destination 'platform=macOS'
               ;;
             tvOS)
               xcodebuild \
@@ -101,17 +100,17 @@ jobs:
               ;;
           esac
   objc-example-test:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set Xcode 15
         run: |
-          sudo xcode-select -switch /Applications/Xcode_15.2.app
+          sudo xcode-select -switch /Applications/Xcode_16.1.app
       - name: Objective-C Example Tests (iOS)
         working-directory: Examples/AmplitudeObjCExample
         run: |
           xcodebuild test \
             -scheme AmplitudeObjCExample \
             -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 15'
+            -destination 'platform=iOS Simulator,name=iPhone 16'

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -192,8 +192,8 @@ final class PersistentStorageTests: XCTestCase {
         persistentStorage.reset()
         let dispatchGroup = DispatchGroup()
         for i in 0..<100 {
+            dispatchGroup.enter()
             Thread.detachNewThread {
-                dispatchGroup.enter()
                 for d in 0..<10 {
                     try? persistentStorage.write(
                         key: StorageKey.EVENTS,
@@ -221,8 +221,8 @@ final class PersistentStorageTests: XCTestCase {
     func testConcurrentWriteOnMultipleInsances() {
         let dispatchGroup = DispatchGroup()
         for i in 0..<100 {
+            dispatchGroup.enter()
             Thread.detachNewThread {
-                dispatchGroup.enter()
                 let persistentStorage = PersistentStorage(storagePrefix: "xxx-multiple-instance", logger: self.logger, diagonostics: self.diagonostics)
                 for d in 0..<10 {
                     try? persistentStorage.write(


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Use Xcode 16.1 to generate artifacts as 16 is now min in the App Store (https://developer.apple.com/news/upcoming-requirements/?id=02212025a)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
