### PR TITLE
fix: change rage click define to 4 click or more in 1s

### DIFF
--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ContentView.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/ContentView.swift
@@ -156,12 +156,6 @@ struct ContentView: View {
                             }.buttonStyle(AmplitudeButton())
 
                             Toggle("Rage Click", isOn: $rageClickTest)
-
-                            Button("Ignored Button") {
-                                print("Ignored button tapped - this will NOT trigger rage click detection")
-                            }.buttonStyle(AmplitudeButton())
-                            // Mark this button to be ignored for rage click detection
-                            .amp_ignoreInteractionEvent(rageClick: true)
                         }
                     }
                     Button(action: {

--- a/Sources/Amplitude/Plugins/iOS/FrustrationInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/FrustrationInteractions.swift
@@ -141,7 +141,7 @@ class DeadClickDetector: InterfaceSignalReceiver, @unchecked Sendable {
 
 class RageClickDetector {
     private let CLICK_RANGE_THRESHOLD: CGFloat = 50
-    private let CLICK_COUNT_THRESHOLD: Int = 3
+    private let CLICK_COUNT_THRESHOLD: Int = 4
     private let CLICK_TIMEOUT: TimeInterval = 1.0
 
     private var clickQueue: [FrustrationClickData] = []


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

The industry generally uses the definition of “more than 3 clicks in 1 second.” Modify the default config to synchronize with this.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
