### PR TITLE
chore: fix flaky UT

### DIFF
--- a/Tests/AmplitudeTests/AmplitudeIOSTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeIOSTests.swift
@@ -174,8 +174,9 @@ final class AmplitudeIOSTests: XCTestCase {
 
         let events = storageMem.events()
         XCTAssertEqual(events.count, 2)
-        XCTAssertEqual(events[0].eventType, Constants.AMP_APPLICATION_OPENED_EVENT)
-        XCTAssertEqual(getDictionary(events[0].eventProperties!), [
+        let event = events.first(where: { $0.eventType == Constants.AMP_APPLICATION_OPENED_EVENT })
+        XCTAssertNotNil(event)
+        XCTAssertEqual(getDictionary(event!.eventProperties!), [
             Constants.AMP_APP_BUILD_PROPERTY: currentBuild,
             Constants.AMP_APP_VERSION_PROPERTY: currentVersion,
             Constants.AMP_APP_FROM_BACKGROUND_PROPERTY: false


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

The order of event triggering cannot be guaranteed because the app open trigger was placed into a queue. Espically on slower UT testing machines.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
