### PR TITLE
fix: `Library not loaded: @rpath/AmplitudeCore.framework/AmplitudeCore` when using SPM

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "amplitudecore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/AmplitudeCore-Swift.git",
+      "state" : {
+        "revision" : "5500bb6dbc8c7ea5b70c7f4758e340d08a1047fb",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "analytics-connector-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/amplitude/analytics-connector-ios.git",
+      "state" : {
+        "revision" : "4adbfe85486e6dcdcdca5fa9362097ffe5ec712b",
+        "version" : "1.3.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .target(
             name: "AmplitudeSwift",
             dependencies: [
-                .product(name: "AmplitudeCoreFramework", package: "AmplitudeCore-Swift"),
+                .product(name: "AmplitudeCore", package: "AmplitudeCore-Swift"),
                 .product(name: "AnalyticsConnector", package: "analytics-connector-ios"),
             ],
             path: "Sources/Amplitude",

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -27,7 +27,7 @@ let package = Package(
         .target(
             name: "AmplitudeSwift",
             dependencies: [
-                .product(name: "AmplitudeCoreFramework", package: "AmplitudeCore-Swift"),
+                .product(name: "AmplitudeCore", package: "AmplitudeCore-Swift"),
                 .product(name: "AnalyticsConnector", package: "analytics-connector-ios"),
             ],
             path: "Sources/Amplitude",


### PR DESCRIPTION
### Summary

This PR fixes a crash when the library is linked using Swift Package Manager:

`Library not loaded: @rpath/AmplitudeCore.framework/AmplitudeCore`

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  - *No*
