### PR TITLE
fix: expose trackAppOpenedEvent for Flutter SDK

### DIFF
--- a/Sources/Amplitude/Utilities/DefaultEventUtils.swift
+++ b/Sources/Amplitude/Utilities/DefaultEventUtils.swift
@@ -63,7 +63,7 @@ public class DefaultEventUtils {
         }
     }
 
-    func trackAppOpenedEvent(fromBackground: Bool = false) {
+    public func trackAppOpenedEvent(fromBackground: Bool = false) {
         guard let amplitude = amplitude,
               amplitude.configuration.autocapture.contains(.appLifecycles) else {
             return


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Exposes `trackAppOpenedEvent` as a public function rather than internal so that the Flutter SDK can call on it. In Flutter, iOS lifecycle tracking is not reliable on cold starts, so to have consistent lifecycle tracking, we need to call lifecycle events and handle potential deduping on Flutter.

See https://github.com/amplitude/Amplitude-Flutter/pull/280

### Checklist

* [y] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
