### PR TITLE
fix: support onReset plugin lifecycle event

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -1321,7 +1321,7 @@
 			repositoryURL = "https://github.com/amplitude/AmplitudeCore-Swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.0;
+				minimumVersion = 1.2.4;
 			};
 		};
 		4EB530762CD2EB9700E961F4 /* XCRemoteSwiftPackageReference "analytics-connector-ios" */ = {

--- a/Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amplitude/AmplitudeCore-Swift",
       "state" : {
-        "revision" : "ce504eddff3597f88b23af640200d59841dc4907",
-        "version" : "1.2.2"
+        "revision" : "1d9b590e202c3e2abb27ccb6b5b5ae62145406f0",
+        "version" : "1.2.4"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amplitude/analytics-connector-ios",
       "state" : {
-        "revision" : "decb203b5ce0e06091bbc5040acbf24fa85ebdce",
-        "version" : "1.3.0"
+        "revision" : "4adbfe85486e6dcdcdca5fa9362097ffe5ec712b",
+        "version" : "1.3.1"
       }
     }
   ],

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.visionos.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   s.dependency 'AnalyticsConnector', '~> 1.3.0'
-  s.dependency 'AmplitudeCore', '>=1.1.0', '<2.0.0'
+  s.dependency 'AmplitudeCore', '>=1.2.4', '<2.0.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "amplitude/analytics-connector-ios" ~> 1.2.3
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.1.0
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.2.4

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.1.0"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.2.4"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.1.0"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.2.4"),
     ],
     targets: [
         .target(

--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -433,6 +433,7 @@ public class Amplitude {
         setUserId(userId: nil)
         identity.userProperties.removeAll()
         contextPlugin.initializeDeviceId(forceReset: true)
+        timeline.apply { $0.onReset() }
         return self
     }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds support for onReset plugin lifecycle handler to analytics SDK

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
