### PR TITLE
fix: centralize autocapture logic

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -70,6 +70,8 @@
 		EA28FDA42DED997900848BBB /* InteractionsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA28FDA32DED997900848BBB /* InteractionsOptions.swift */; };
 		EA2FD8862EE8A0E4002AB27E /* AmplitudeCoreFramework in Frameworks */ = {isa = PBXBuildFile; productRef = EA2FD8852EE8A0E4002AB27E /* AmplitudeCoreFramework */; };
 		EA2FD8882EE8A0EB002AB27E /* AmplitudeCoreNoUIKitFramework in Frameworks */ = {isa = PBXBuildFile; productRef = EA2FD8872EE8A0EB002AB27E /* AmplitudeCoreNoUIKitFramework */; };
+		EA2FD8932EECDD6F002AB27E /* AutocaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2FD8922EECDD6F002AB27E /* AutocaptureManager.swift */; };
+		EA2FD8942EECDD6F002AB27E /* AutocaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA2FD8922EECDD6F002AB27E /* AutocaptureManager.swift */; };
 		EA5C95942D7A76B900DC8B3B /* NetworkSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5C95932D7A76B000DC8B3B /* NetworkSwizzler.swift */; };
 		EA5C95962D7A776D00DC8B3B /* MethodSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA5C95952D7A776200DC8B3B /* MethodSwizzler.swift */; };
 		EA84CF0B2DF8D8E400CD1CAD /* MiscellaneousExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA84CF0A2DF8D8E400CD1CAD /* MiscellaneousExtension.swift */; };
@@ -296,6 +298,7 @@
 		D01043602B6C5A8500F8173C /* SandboxHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxHelperTests.swift; sourceTree = "<group>"; };
 		EA1F2CD82D8781950096A576 /* MethodSwizzlerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzlerTest.swift; sourceTree = "<group>"; };
 		EA28FDA32DED997900848BBB /* InteractionsOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractionsOptions.swift; sourceTree = "<group>"; };
+		EA2FD8922EECDD6F002AB27E /* AutocaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocaptureManager.swift; sourceTree = "<group>"; };
 		EA5C95932D7A76B000DC8B3B /* NetworkSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSwizzler.swift; sourceTree = "<group>"; };
 		EA5C95952D7A776200DC8B3B /* MethodSwizzler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MethodSwizzler.swift; sourceTree = "<group>"; };
 		EA84CF0A2DF8D8E400CD1CAD /* MiscellaneousExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiscellaneousExtension.swift; sourceTree = "<group>"; };
@@ -556,6 +559,7 @@
 		OBJ_43 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				EA2FD8922EECDD6F002AB27E /* AutocaptureManager.swift */,
 				EAE4C5F92E5F769D00FCD6E4 /* ObjectFilter.swift */,
 				EA84CF0A2DF8D8E400CD1CAD /* MiscellaneousExtension.swift */,
 				EA5C95952D7A776200DC8B3B /* MethodSwizzler.swift */,
@@ -901,6 +905,7 @@
 				EAED9A002EE7B47E00A5FC08 /* Constants.swift in Sources */,
 				EAED9A012EE7B47E00A5FC08 /* ObjectFilter.swift in Sources */,
 				EAED9A022EE7B47E00A5FC08 /* BaseEvent.swift in Sources */,
+				EA2FD8942EECDD6F002AB27E /* AutocaptureManager.swift in Sources */,
 				EAED9A032EE7B47E00A5FC08 /* EventOptions.swift in Sources */,
 				EAED9A042EE7B47E00A5FC08 /* GroupIdentifyEvent.swift in Sources */,
 				EAED9A052EE7B47E00A5FC08 /* Identify.swift in Sources */,
@@ -1037,6 +1042,7 @@
 				OBJ_91 /* Constants.swift in Sources */,
 				EAE4C5FA2E5F76A400FCD6E4 /* ObjectFilter.swift in Sources */,
 				OBJ_93 /* BaseEvent.swift in Sources */,
+				EA2FD8932EECDD6F002AB27E /* AutocaptureManager.swift in Sources */,
 				OBJ_94 /* EventOptions.swift in Sources */,
 				OBJ_95 /* GroupIdentifyEvent.swift in Sources */,
 				OBJ_96 /* Identify.swift in Sources */,

--- a/Sources/Amplitude/Utilities/AutocaptureManager.swift
+++ b/Sources/Amplitude/Utilities/AutocaptureManager.swift
@@ -1,0 +1,164 @@
+#if AMPLITUDE_DISABLE_UIKIT
+@_spi(Internal) import AmplitudeCoreNoUIKit
+#else
+@_spi(Internal) import AmplitudeCore
+#endif
+import Foundation
+
+class AutocaptureManager {
+
+    typealias ChangeCallback = ([String: Any]?) -> Void
+
+    private let context: AmplitudeContext
+    private let trackingQueue: DispatchQueue
+    private var remoteConfigSubscription: Any?
+    private let lock = NSLock()
+
+    private var _enabledOptions: AutocaptureOptions = .init(rawValue: 0)
+    private var enabledOptions: AutocaptureOptions {
+        get { lock.withLock { _enabledOptions } }
+        set { lock.withLock { _enabledOptions = newValue } }
+    }
+
+    private var _rageClickEnabled: Bool = false
+    private var _deadClickEnabled: Bool = false
+
+    var rageClickEnabled: Bool {
+        lock.withLock { _rageClickEnabled }
+    }
+
+    var deadClickEnabled: Bool {
+        lock.withLock { _deadClickEnabled }
+    }
+
+    private var changeCallbacks: [ChangeCallback] = []
+
+    init(context: AmplitudeContext,
+         trackingQueue: DispatchQueue,
+         autocapture: AutocaptureOptions,
+         rageClickEnabled: Bool,
+         deadClickEnabled: Bool,
+         enableRemoteConfig: Bool) {
+        self.context = context
+        self.trackingQueue = trackingQueue
+        self._enabledOptions = autocapture
+        self._rageClickEnabled = rageClickEnabled
+        self._deadClickEnabled = deadClickEnabled
+
+        if enableRemoteConfig {
+            subscribeToRemoteConfig()
+        }
+    }
+
+    func isEnabled(_ option: AutocaptureOptions) -> Bool {
+        return enabledOptions.contains(option)
+    }
+
+    func onChange(_ callback: @escaping ChangeCallback) {
+        lock.withLock {
+            changeCallbacks.append(callback)
+        }
+    }
+
+    func updateDiagnostics() {
+        context.diagnosticsClient.setTag(
+            name: "autocapture.enabled",
+            value: enabledOptions.stringRepresentation()
+        )
+    }
+
+    // MARK: - Remote Config
+
+    private func subscribeToRemoteConfig() {
+        remoteConfigSubscription = context.remoteConfigClient
+            .subscribe(key: Constants.RemoteConfig.Key.autocapture) { [weak self] config, _, _ in
+                self?.handleRemoteConfig(config)
+            }
+    }
+
+    private func handleRemoteConfig(_ config: [String: Any]?) {
+        guard let config else { return }
+
+        // Update enabled options from config
+        lock.withLock {
+            if let sessions = config["sessions"] as? Bool {
+                if sessions {
+                    _enabledOptions.formUnion(.sessions)
+                } else {
+                    _enabledOptions.subtract(.sessions)
+                }
+            }
+
+            if let appLifecycles = config["appLifecycles"] as? Bool {
+                if appLifecycles {
+                    _enabledOptions.formUnion(.appLifecycles)
+                } else {
+                    _enabledOptions.subtract(.appLifecycles)
+                }
+            }
+
+            if let pageViews = config["pageViews"] as? Bool {
+                if pageViews {
+                    _enabledOptions.formUnion(.screenViews)
+                } else {
+                    _enabledOptions.subtract(.screenViews)
+                }
+            }
+
+            if let elementInteractions = config["elementInteractions"] as? Bool {
+                if elementInteractions {
+                    _enabledOptions.formUnion(.elementInteractions)
+                } else {
+                    _enabledOptions.subtract(.elementInteractions)
+                }
+            }
+
+            if let frustrationInteractions = config["frustrationInteractions"] as? [String: Any] {
+                if let enabled = frustrationInteractions["enabled"] as? Bool {
+                    if enabled {
+                        _enabledOptions.formUnion(.frustrationInteractions)
+                    } else {
+                        _enabledOptions.subtract(.frustrationInteractions)
+                    }
+                }
+
+                if let rageClick = frustrationInteractions["rageClick"] as? [String: Any],
+                   let enabled = rageClick["enabled"] as? Bool {
+                    _rageClickEnabled = enabled
+                }
+
+                if let deadClick = frustrationInteractions["deadClick"] as? [String: Any],
+                   let enabled = deadClick["enabled"] as? Bool {
+                    _deadClickEnabled = enabled
+                }
+            }
+
+            if let networkTracking = config["networkTracking"] as? [String: Any],
+               let enabled = networkTracking["enabled"] as? Bool {
+                if enabled {
+                    _enabledOptions.formUnion(.networkTracking)
+                } else {
+                    _enabledOptions.subtract(.networkTracking)
+                }
+            }
+        }
+
+        // Notify callbacks with raw config
+        let callbacks = lock.withLock { changeCallbacks }
+        for callback in callbacks {
+            callback(config)
+        }
+
+        // Update diagnostics
+        trackingQueue.async { [weak self] in
+            self?.updateDiagnostics()
+        }
+    }
+
+    deinit {
+        if let remoteConfigSubscription {
+            context.remoteConfigClient.unsubscribe(remoteConfigSubscription)
+        }
+        remoteConfigSubscription = nil
+    }
+}

--- a/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
+++ b/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
@@ -66,12 +66,11 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         ], forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: []))
-        let sessions = amplitude.sessions
-        XCTAssertFalse(sessions.trackSessionEvents, "Sessions should be off by default")
+        XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be off by default")
 
         wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
 
-        XCTAssertTrue(sessions.trackSessionEvents, "Sessions should be on from remote config")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be on from remote config")
     }
 
     func testSessionsTurnsOffFromRemoteConfig() {
@@ -88,12 +87,11 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         ], forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: [.sessions]))
-        let sessions = amplitude.sessions
-        XCTAssertTrue(sessions.trackSessionEvents, "Sessions should be on by default")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be on by default")
 
         wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
 
-        XCTAssertFalse(sessions.trackSessionEvents, "Sessions should be off from remote config")
+        XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be off from remote config")
     }
 
 #if os(iOS)
@@ -124,11 +122,11 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.screenViews, "Screen views should be off by default")
+        XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be off by default")
 
         wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
 
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.screenViews, "Screen views should be on from remote config")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be on from remote config")
     }
 
     func testScreenViewsTurnsOffFromRemoteConfig() {
@@ -157,11 +155,11 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.screenViews, "Screen views should be on by default")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be on by default")
 
         wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
 
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.screenViews, "Screen views should be off from remote config")
+        XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be off from remote config")
     }
 
     func testElementInteractionsTurnsOnFromRemoteConfig() {
@@ -190,11 +188,11 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.elementInteractions, "Element interactions should be off by default")
+        XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be off by default")
 
         wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
 
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.elementInteractions, "Element interactions should be on from remote config")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be on from remote config")
     }
 
     func testElementInteractionsTurnsOffFromRemoteConfig() {
@@ -223,11 +221,11 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.elementInteractions, "Element interactions should be on by default")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be on by default")
 
         wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
 
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.elementInteractions, "Element interactions should be off from remote config")
+        XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be off from remote config")
     }
 
     func testFrustrationInteractionsTurnsOnFromRemoteConfig() {
@@ -272,15 +270,15 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.frustrationInteractions, "Frustration interactions should be off by default")
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.rageClick, "Rage click should be off by default")
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.deadClick, "Dead click should be off by default")
+        XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be off by default")
+        XCTAssertFalse(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be off by default")
+        XCTAssertFalse(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be off by default")
 
         wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
 
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.frustrationInteractions, "Frustration interactions should be on from remote config")
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.rageClick, "Rage click should be on from remote config")
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.deadClick, "Dead click should be off from remote config")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on from remote config")
+        XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on from remote config")
+        XCTAssertFalse(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be off from remote config")
     }
 
     func testFrustrationInteractionsTurnsOffFromRemoteConfig() {
@@ -319,15 +317,15 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.frustrationInteractions, "Frustration interactions should be on by default")
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.rageClick, "Rage click should be on by default")
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.deadClick, "Dead click should be on by default")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on by default")
+        XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")
+        XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be on by default")
 
         wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
 
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.frustrationInteractions, "Frustration interactions should be off from remote config")
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.rageClick, "Rage click should still be on from local config")
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.deadClick, "Dead click should still be on from local config")
+        XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be off from remote config")
+        XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should still be on from local config")
+        XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should still be on from local config")
     }
 
     func testFrustrationInteractionsPartialRemoteConfig() {
@@ -371,15 +369,15 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.frustrationInteractions, "Frustration interactions should be on by default")
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.rageClick, "Rage click should be on by default")
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.deadClick, "Dead click should be on by default")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on by default")
+        XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")
+        XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be on by default")
 
         wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
 
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.frustrationInteractions, "Frustration interactions should be on by default")
-        XCTAssertFalse(iosLifecycleMonitor.trackingState.rageClick, "Rage click should be off from remote config")
-        XCTAssertTrue(iosLifecycleMonitor.trackingState.deadClick, "Dead click should be on from local config")
+        XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on by default")
+        XCTAssertFalse(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be off from remote config")
+        XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be on from local config")
     }
 #endif
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Centralize autocapture remote config handling to make the logic clearer

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce AutocaptureManager to own autocapture state/remote-config and refactor plugins (sessions, lifecycle, UI interactions, network) to consume it; add diagnostics tagging and tests.
> 
> - **Core**:
>   - Add `Utilities/AutocaptureManager.swift` to manage `autocapture` state, frustration toggles, remote-config subscription, change callbacks, and diagnostics tag (`autocapture.enabled`).
>   - Wire `Amplitude` to expose `autocaptureManager` and initialize early; remove previous autocapture/diagnostics fields.
> - **Plugins (iOS)**:
>   - `IOSLifecycleMonitor`: replace inline tracking state/remote-config with `autocaptureManager` and react via `onChange`; gate app lifecycle/backgrounded events via manager.
>   - `UIKitElementInteractions`: source frustration feature toggles and `.elementInteractions` checks from `autocaptureManager`; simplify registration.
> - **Network**:
>   - `NetworkTrackingPlugin`: opt-out and option updates now driven by `autocaptureManager.onChange`; remove direct remote-config subscription.
> - **Sessions**:
>   - Drive `trackSessionEvents` from `autocaptureManager` (remove per-class subscription/flag).
> - **Utilities**:
>   - `DefaultEventUtils`: gate lifecycle events via `autocaptureManager` (remove subscription/flag).
> - **Tests**:
>   - Overhaul `AutocaptureRemoteConfigTests` to assert behavior through `autocaptureManager` and network tracking config schema/partials.
> - **Project**:
>   - Add `AutocaptureManager.swift` to build targets; update project references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c6e4e2b58cb0df4fe8a015cbe641b472d5bd41e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->