### PR TITLE
fix: Incorrect implementation of the atomic wrapper

### DIFF
--- a/Sources/Amplitude/Utilities/AutocaptureManager.swift
+++ b/Sources/Amplitude/Utilities/AutocaptureManager.swift
@@ -77,68 +77,68 @@ class AutocaptureManager {
     }
 
     private func handleRemoteConfig(_ config: [String: Any]?) {
-        guard let config else { return }
-
-        // Update enabled options from config
-        lock.withLock {
-            if let sessions = config["sessions"] as? Bool {
-                if sessions {
-                    _enabledOptions.formUnion(.sessions)
-                } else {
-                    _enabledOptions.subtract(.sessions)
-                }
-            }
-
-            if let appLifecycles = config["appLifecycles"] as? Bool {
-                if appLifecycles {
-                    _enabledOptions.formUnion(.appLifecycles)
-                } else {
-                    _enabledOptions.subtract(.appLifecycles)
-                }
-            }
-
-            if let pageViews = config["pageViews"] as? Bool {
-                if pageViews {
-                    _enabledOptions.formUnion(.screenViews)
-                } else {
-                    _enabledOptions.subtract(.screenViews)
-                }
-            }
-
-            if let elementInteractions = config["elementInteractions"] as? Bool {
-                if elementInteractions {
-                    _enabledOptions.formUnion(.elementInteractions)
-                } else {
-                    _enabledOptions.subtract(.elementInteractions)
-                }
-            }
-
-            if let frustrationInteractions = config["frustrationInteractions"] as? [String: Any] {
-                if let enabled = frustrationInteractions["enabled"] as? Bool {
-                    if enabled {
-                        _enabledOptions.formUnion(.frustrationInteractions)
+        if let config {
+            // Update enabled options from config
+            lock.withLock {
+                if let sessions = config["sessions"] as? Bool {
+                    if sessions {
+                        _enabledOptions.formUnion(.sessions)
                     } else {
-                        _enabledOptions.subtract(.frustrationInteractions)
+                        _enabledOptions.subtract(.sessions)
                     }
                 }
 
-                if let rageClick = frustrationInteractions["rageClick"] as? [String: Any],
-                   let enabled = rageClick["enabled"] as? Bool {
-                    _rageClickEnabled = enabled
+                if let appLifecycles = config["appLifecycles"] as? Bool {
+                    if appLifecycles {
+                        _enabledOptions.formUnion(.appLifecycles)
+                    } else {
+                        _enabledOptions.subtract(.appLifecycles)
+                    }
                 }
 
-                if let deadClick = frustrationInteractions["deadClick"] as? [String: Any],
-                   let enabled = deadClick["enabled"] as? Bool {
-                    _deadClickEnabled = enabled
+                if let pageViews = config["pageViews"] as? Bool {
+                    if pageViews {
+                        _enabledOptions.formUnion(.screenViews)
+                    } else {
+                        _enabledOptions.subtract(.screenViews)
+                    }
                 }
-            }
 
-            if let networkTracking = config["networkTracking"] as? [String: Any],
-               let enabled = networkTracking["enabled"] as? Bool {
-                if enabled {
-                    _enabledOptions.formUnion(.networkTracking)
-                } else {
-                    _enabledOptions.subtract(.networkTracking)
+                if let elementInteractions = config["elementInteractions"] as? Bool {
+                    if elementInteractions {
+                        _enabledOptions.formUnion(.elementInteractions)
+                    } else {
+                        _enabledOptions.subtract(.elementInteractions)
+                    }
+                }
+
+                if let frustrationInteractions = config["frustrationInteractions"] as? [String: Any] {
+                    if let enabled = frustrationInteractions["enabled"] as? Bool {
+                        if enabled {
+                            _enabledOptions.formUnion(.frustrationInteractions)
+                        } else {
+                            _enabledOptions.subtract(.frustrationInteractions)
+                        }
+                    }
+
+                    if let rageClick = frustrationInteractions["rageClick"] as? [String: Any],
+                       let enabled = rageClick["enabled"] as? Bool {
+                        _rageClickEnabled = enabled
+                    }
+
+                    if let deadClick = frustrationInteractions["deadClick"] as? [String: Any],
+                       let enabled = deadClick["enabled"] as? Bool {
+                        _deadClickEnabled = enabled
+                    }
+                }
+
+                if let networkTracking = config["networkTracking"] as? [String: Any],
+                   let enabled = networkTracking["enabled"] as? Bool {
+                    if enabled {
+                        _enabledOptions.formUnion(.networkTracking)
+                    } else {
+                        _enabledOptions.subtract(.networkTracking)
+                    }
                 }
             }
         }

--- a/Sources/Amplitude/Utilities/EventPipeline.swift
+++ b/Sources/Amplitude/Utilities/EventPipeline.swift
@@ -16,7 +16,7 @@ public class EventPipeline {
     let logger: (any Logger)?
     let configuration: Configuration
 
-    @Atomic internal var eventCount: Int = 0
+    @AtomicRef internal var eventCount: Int = 0
     internal var flushTimer: QueueTimer?
     private let uploadsQueue = DispatchQueue(label: "uploadsQueue.amplitude.com")
 
@@ -40,7 +40,7 @@ public class EventPipeline {
         event.attempts += 1
         do {
             try storage.write(key: StorageKey.EVENTS, value: event)
-            eventCount += 1
+            _eventCount.withLock { $0 += 1 }
             if eventCount >= getFlushCount() {
                 flush()
             }

--- a/Sources/Amplitude/Utilities/QueueTimer.swift
+++ b/Sources/Amplitude/Utilities/QueueTimer.swift
@@ -18,7 +18,7 @@ internal class QueueTimer {
     let queue: DispatchQueue
     let handler: () -> Void
 
-    @Atomic var state: State = .suspended
+    @AtomicRef var state: State = .suspended
 
     init(interval: TimeInterval, once: Bool = false, queue: DispatchQueue = .main, handler: @escaping () -> Void) {
         self.interval = interval

--- a/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
+++ b/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
@@ -611,7 +611,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 extension RemoteConfigClient {
 
     private final class SubscriptionHolder: @unchecked Sendable {
-        @Atomic var subscription: Any?
+        @AtomicRef var subscription: Any?
     }
 
     nonisolated var didFetchRemoteExpectation: XCTestExpectation {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Reason:
Swift's mutating method requires exclusive access to the struct's memory. When Thread A calls store() (mutating) while Thread B calls load() (reading), they race on the struct's memory before either lock is acquired.

Fix:
- create a new class type property wrapper
- mark old struct wrapper deprecated

Related Issue:
https://github.com/amplitude/Amplitude-Swift/issues/342

Other fix:
- AutocaptureManager will trigger onChange at least once, whether or not it obtains a config, to remain consistent with remoteConfigClient subscription behavior.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce thread-safe AtomicRef and migrate call sites; adjust NetworkTrackingPlugin to respect remote-config flag and keep behavior consistent without it.
> 
> - **Concurrency/Utilities**:
>   - Deprecates `Atomic` (struct) and adds new thread-safe `AtomicRef` (class) property wrapper in `Sources/Amplitude/Utilities/Atomic.swift`.
>   - Migrates usages to `AtomicRef`:
>     - `NetworkTrackingPlugin`: `options`, `optOut`, `originalOptions`.
>     - `EventPipeline`: `eventCount`.
>     - `QueueTimer`: `state`.
>     - Tests: `RemoteConfigClient.SubscriptionHolder.subscription`.
> - **Network Tracking**:
>   - `NetworkTrackingPlugin.setup`: now gates remote-config subscriptions on `Configuration.enableAutoCaptureRemoteConfig`; otherwise compiles local `networkTrackingOptions` immediately.
>   - Ensures config updates recompile options and toggle listener; preserves `optOut` based on remote config enablement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b8d9619896e5c528c4c28ef67b61a3fa189b224. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->