### PR TITLE
fix: xcode 26.2 bug causes crash on iOS 15

### DIFF
--- a/Sources/Amplitude/Migration/RemnantDataMigration.swift
+++ b/Sources/Amplitude/Migration/RemnantDataMigration.swift
@@ -19,7 +19,8 @@ class RemnantDataMigration {
     }
 
     func execute() {
-        let firstRunSinceUpgrade = storage.read(key: StorageKey.LAST_EVENT_TIME) == nil
+        let lastEventTime: Int64? = storage.read(key: StorageKey.LAST_EVENT_TIME)
+        let firstRunSinceUpgrade = lastEventTime == nil
 
         moveDeviceAndUserId()
         moveSessionData()

--- a/Sources/Amplitude/Migration/StoragePrefixMigration.swift
+++ b/Sources/Amplitude/Migration/StoragePrefixMigration.swift
@@ -63,7 +63,8 @@ class StoragePrefixMigration {
             return
         }
 
-        if destination.read(key: key) == nil {
+        let destinationValue: String? = destination.read(key: key)
+        if destinationValue == nil {
             do {
                 try destination.write(key: key, value: sourceValue)
             } catch {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

fix https://github.com/amplitude/Amplitude-Swift/issues/348

When compiling optional generics, Xcode 26.2 can emit code incompatible with iOS 15 if it cannot infer the generic type — for example, in expressions like `T? == nil` — leading to runtime EXC_BAD_ACCESS crashes. Change the code style to work around this bug.



### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Work around Xcode 26.2 optional-generic inference crash on iOS 15 by avoiding inline nil comparisons on generic reads.
> 
> - In `RemnantDataMigration.execute`, read `StorageKey.LAST_EVENT_TIME` into typed local `lastEventTime: Int64?` before computing `firstRunSinceUpgrade`
> - In `StoragePrefixMigration.moveStringProperty`, read destination value into typed local `destinationValue: String?` before nil check
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 609e6f23d46e4e4de84a88c4fa737ac08f23e857. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->