### PR TITLE
fix: optout setting still recording session start/end events

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -439,10 +439,13 @@ public class Amplitude {
             } else {
                 sessionEvents = self.sessions.endCurrentSession()
             }
-            self.sessions.assignEventId(events: sessionEvents).forEach { e in
-                e.userId = e.userId ?? identity.userId
-                e.deviceId = e.deviceId ?? identity.deviceId
-                self.timeline.processEvent(event: e)
+
+            if !configuration.optOut {
+                self.sessions.assignEventId(events: sessionEvents).forEach { e in
+                    e.userId = e.userId ?? identity.userId
+                    e.deviceId = e.deviceId ?? identity.deviceId
+                    self.timeline.processEvent(event: e)
+                }
             }
         }
         return self
@@ -503,10 +506,12 @@ public class Amplitude {
         trackingQueue.async { [self, identity] in
             // set inForeground to false to represent state before event was fired
             let events = self.sessions.processEvent(event: dummySessionStartEvent, inForeground: false)
-            events.forEach { e in
-                e.userId = e.userId ?? identity.userId
-                e.deviceId = e.deviceId ?? identity.deviceId
-                self.timeline.processEvent(event: e)
+            if !configuration.optOut {
+                events.forEach { e in
+                    e.userId = e.userId ?? identity.userId
+                    e.deviceId = e.deviceId ?? identity.deviceId
+                    self.timeline.processEvent(event: e)
+                }
             }
         }
     }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fix still recording session start/end events when optout set to true

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures session lifecycle events respect `optOut`.
> 
> - Gate session event emission in `Amplitude.swift` (`setSessionId` and `onEnterForeground`) behind `!configuration.optOut`
> - Add unit tests in `AmplitudeSessionTests.swift` verifying no events are sent when `optOut` is true (tracking, entering foreground, `setSessionId`), and that events resume after re-enabling tracking
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37f2b5719a73afdca779b1e117a7adf9633e344a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->