### PR TITLE
fix: update Cocoapods/Carthage deps

### DIFF
--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.visionos.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   s.dependency 'AnalyticsConnector', '~> 1.3.0'
-  s.dependency 'AmplitudeCore', '>=1.2.4', '<2.0.0'
+  s.dependency 'AmplitudeCore', '>=1.3.1', '<2.0.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "amplitude/analytics-connector-ios" ~> 1.2.3
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.2.4
+github "amplitude/analytics-connector-ios" ~> 1.3.0
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.3.1


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Updates dependencies to match Package.swift

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency versions to align with `Package.swift`.
> 
> - In `AmplitudeSwift.podspec`, raises `AmplitudeCore` to `>=1.3.1 <2.0.0`
> - In `Cartfile`, bumps `amplitude/analytics-connector-ios` to `~> 1.3.0` and `AmplitudeCore` binary to `~> 1.3.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fc1df9972da071697aab2b4577553958008f5ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->