### PR TITLE
chore: add a dependency version check workflow to keep consistancy

### DIFF
--- a/.github/workflows/dependency-version-check.yml
+++ b/.github/workflows/dependency-version-check.yml
@@ -99,11 +99,11 @@ jobs:
             # Compare all versions
             if [ -z "$reference_version" ] || [ -z "$carthage_version" ] || [ -z "$pod_version" ]; then
               echo "  ⚠ Warning: Could not find version in all files"
-            elif [ "$reference_version" = "$carthage_version" ] && [ "$carthage_version" = "$pod_version" ]; then
-              echo "  ✓ All versions match: $reference_version"
-            else
-              echo "  ✗ Version mismatch detected!"
+            elif [ "$reference_version" != "$carthage_version" ] || [ "$carthage_version" != "$pod_version" ]; then
+              echo "  ✗ Version mismatch between Package.swift, Cartfile, and Podspec!"
               dep_errors=1
+            elif [ $dep_errors -eq 0 ]; then
+              echo "  ✓ All versions match: $reference_version"
             fi
             echo ""
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

use workflow to check the dependency version consistency across Package.swift files, Podspec, and Cartfile

Example Output:
```
Checking dependency version consistency across Package.swift files, Podspec, and Cartfile...

Found Package manifest files:
  - ./Package.swift
  - ./Package@swift-5.9.swift

================================================================
Dependency Version Report
================================================================

Checking: AnalyticsConnector
----------------------------------------
  Cartfile:      1.3.0
  Podspec:       1.3.0
  Package.swift: 1.3.0
  Package@swift-5.9.swift: 1.3.0
  ✓ All versions match: 1.3.0

Checking: AmplitudeCore
----------------------------------------
  Cartfile:      1.3.1
  Podspec:       1.3.1
  Package.swift: 1.3.2
  Package@swift-5.9.swift: 1.3.1
  ✗ Version mismatch between Package.swift files!
  ✗ Version mismatch detected!

================================================================
FAILED: Found 1 dependency version mismatch(es)

Please ensure the minimum version requirements match across:
  - All Package*.swift files (from: "x.y.z")
  - Cartfile (~> x.y.z)
  - AmplitudeSwift.podspec (~> x.y.z or >=x.y.z)
```

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces automated CI to enforce dependency version alignment across package managers.
> 
> - New workflow `.github/workflows/dependency-version-check.yml` runs on PRs and `main` pushes
> - Bash script scans `Package*.swift`, `Cartfile`, and `AmplitudeSwift.podspec` to extract versions for `AnalyticsConnector` and `AmplitudeCore`
> - Reports mismatches between SPM/Carthage/CocoaPods and exits non‑zero to block merges when inconsistent
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1ff8e4523ce0c8d8b528974acc2ce19be22e1f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->