### PR TITLE
fix: crash when bundleIdentifier is nil

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -1443,7 +1443,7 @@
 			repositoryURL = "https://github.com/amplitude/AmplitudeCore-Swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.3.1;
+				minimumVersion = 1.3.3;
 			};
 		};
 		4EB530762CD2EB9700E961F4 /* XCRemoteSwiftPackageReference "analytics-connector-ios" */ = {

--- a/Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amplitude/AmplitudeCore-Swift",
       "state" : {
-        "revision" : "f08b61731d4912721a4f88923b93a98862e790b6",
-        "version" : "1.3.1"
+        "revision" : "6f52f3c1c3bd09e4d14efe49536ffb581717467e",
+        "version" : "1.3.3"
       }
     },
     {

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.visionos.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   s.dependency 'AnalyticsConnector', '~> 1.3.0'
-  s.dependency 'AmplitudeCore', '>=1.3.1', '<2.0.0'
+  s.dependency 'AmplitudeCore', '>=1.3.3', '<2.0.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "amplitude/analytics-connector-ios" ~> 1.3.0
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.3.1
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.3.3

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.3.1"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.3.3"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.3.1"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.3.3"),
     ],
     targets: [
         .target(

--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -211,22 +211,8 @@ class PersistentStorage: Storage {
         if sandboxed {
             return ""
         }
-        let appIdentifier = Bundle.main.bundleIdentifier ?? hashedExecutablePath()
+        let appIdentifier = Bundle.main.bundleIdentifier ?? (Bundle.main.executablePath ?? ProcessInfo.processInfo.processName).fnv1a64String()
         return "\(appIdentifier)/"
-    }
-
-    private static func hashedExecutablePath() -> String {
-        let path = Bundle.main.executablePath ?? ProcessInfo.processInfo.processName
-        let hash = fnv1a64(path)
-        return String(format: "%016llx", hash)
-    }
-
-    private static func fnv1a64(_ s: String) -> UInt64 {
-        let offsetBasis: UInt64 = 0xcbf29ce484222325
-        let prime: UInt64 = 0x100000001b3
-        return s.utf8.reduce(offsetBasis) { hash, byte in
-            (hash ^ UInt64(byte)) &* prime
-        }
     }
 }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

fix crash when bundle identifier is nil
https://github.com/amplitude/AmplitudeUnified-Swift/issues/7

Storage path fallback chain: bundle identifier -> executablePath -> processName

related pr:
add fnv1a64String helper: https://github.com/amplitude/AmplitudeCore-Swift/pull/53

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves crash when `Bundle.main.bundleIdentifier` is nil and aligns dependencies.
> 
> - In `PersistentStorage`, replace direct bundle identifier usage with `getAppPath(sandboxed:)`, falling back to `executablePath` or `processName` (hashed via `fnv1a64String`) to derive `appPath`.
> - Bump `AmplitudeCore` to `1.3.3` in `Package.swift`, `Package@swift-5.9.swift`, `AmplitudeSwift.podspec`, `Cartfile`, Xcode project settings, and `Package.resolved`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b60c3f3a781c0efcfb7826c0790d3cb568cc6a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->