### PR TITLE
chore: fix release script for newly released dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,19 @@ jobs:
         run: |
           sudo xcode-select -switch /Applications/Xcode_16.3.app
 
+      - name: Install Apple platform SDKs
+        run: |
+          # Warm up CoreSimulator to avoid "Unable to connect to simulator":
+          # https://github.com/actions/runner-images/issues/12862#issuecomment-3239326872
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
+          sudo xcodebuild -downloadPlatform tvOS
+          sudo xcodebuild -downloadPlatform watchOS
+          sudo xcodebuild -downloadPlatform visionOS
+
       - name: Validate Podfile
-        run: pod lib lint --allow-warnings
+        run: |
+          pod lib lint --allow-warnings || (echo "Lint failed, updating repo and retrying..." && pod repo update && pod lib lint --allow-warnings)
 
       - name: Build xcframework
         run: scripts/build_framework.sh

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -56,6 +56,25 @@ jobs:
       - name: Set Xcode ${{ matrix.xcode }}
         run: |
           sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Install Apple platform SDKs
+        run: |
+          # Warm up CoreSimulator to avoid "Unable to connect to simulator":
+          # https://github.com/actions/runner-images/issues/12862#issuecomment-3239326872
+          xcrun simctl list > /dev/null
+          case "${{ matrix.platform }}" in
+            iOS)
+              sudo xcodebuild -downloadPlatform iOS
+              ;;
+            tvOS)
+              sudo xcodebuild -downloadPlatform tvOS
+              ;;
+            watchOS)
+              sudo xcodebuild -downloadPlatform watchOS
+              ;;
+            visionOS)
+              sudo xcodebuild -downloadPlatform visionOS
+              ;;
+          esac
       - name: List Simulators
         run: |
           xcrun simctl list
@@ -107,6 +126,12 @@ jobs:
       - name: Set Xcode 16
         run: |
           sudo xcode-select -switch /Applications/Xcode_16.4.app
+      - name: Install Apple platform SDKs
+        run: |
+          # Warm up CoreSimulator to avoid "Unable to connect to simulator":
+          # https://github.com/actions/runner-images/issues/12862#issuecomment-3239326872
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
       - name: Objective-C Example Tests (iOS)
         working-directory: Examples/AmplitudeObjCExample
         run: |


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- retry with `pod repo update` if `pod lib lint` fail
- add install missing platform logic

Test run: https://github.com/amplitude/Amplitude-Swift/actions/runs/21192484869/job/60962959833

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  false

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes CI for Apple platforms and improves release resilience.
> 
> - **Release workflow:** Adds step to install Apple platform SDKs (`iOS`, `tvOS`, `watchOS`, `visionOS`) with CoreSimulator warm-up; updates `pod lib lint` to retry after `pod repo update` on failure.
> - **Unit-test workflow:** Adds platform-specific SDK installation (based on matrix) with CoreSimulator warm-up; installs `iOS` SDK for `objc-example-test`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27404f0adfb13d762925e252b2310cbae31e3409. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->