### PR TITLE
feat: Add App Group support for App Clips and extensions

### DIFF
--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -88,6 +88,11 @@ public class Configuration {
     let remoteConfigClient: RemoteConfigClient
     let diagnosticsClient: CoreDiagnostics
 
+    /// Custom container URL for file storage (e.g., App Group container for App Clips)
+    public let containerURL: URL?
+    /// Custom UserDefaults suite name (e.g., App Group identifier for App Clips)
+    public let userDefaultsSuiteName: String?
+
     @available(*, deprecated, message: "Please use the `autocapture` parameter instead.")
     public convenience init(
         apiKey: String,
@@ -181,7 +186,9 @@ public class Configuration {
         networkTrackingOptions: NetworkTrackingOptions = Defaults.networkTrackingOptions,
         enableAutoCaptureRemoteConfig: Bool = Defaults.enableAutoCaptureRemoteConfig,
         interactionsOptions: InteractionsOptions = Defaults.interactionsOptions,
-        enableDiagnostics: Bool = Defaults.enableDiagnostics
+        enableDiagnostics: Bool = Defaults.enableDiagnostics,
+        containerURL: URL? = nil,
+        userDefaultsSuiteName: String? = nil
     ) {
         let normalizedInstanceName = Configuration.getNormalizeInstanceName(instanceName)
 
@@ -205,10 +212,26 @@ public class Configuration {
                                                    logger: self.loggerProvider,
                                                    enabled: self.enableDiagnostics,
                                                    remoteConfigClient: self.remoteConfigClient)
+        self.containerURL = containerURL
+        self.userDefaultsSuiteName = userDefaultsSuiteName
         self.storageProvider = storageProvider
-        ?? PersistentStorage(storagePrefix: PersistentStorage.getEventStoragePrefix(apiKey, normalizedInstanceName), logger: self.loggerProvider, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        ?? PersistentStorage(
+            storagePrefix: PersistentStorage.getEventStoragePrefix(apiKey, normalizedInstanceName),
+            logger: self.loggerProvider,
+            diagonostics: self.diagonostics,
+            diagnosticsClient: self.diagnosticsClient,
+            containerURL: containerURL,
+            userDefaultsSuiteName: userDefaultsSuiteName
+        )
         self.identifyStorageProvider = identifyStorageProvider
-        ?? PersistentStorage(storagePrefix: PersistentStorage.getIdentifyStoragePrefix(apiKey, normalizedInstanceName), logger: self.loggerProvider, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        ?? PersistentStorage(
+            storagePrefix: PersistentStorage.getIdentifyStoragePrefix(apiKey, normalizedInstanceName),
+            logger: self.loggerProvider,
+            diagonostics: self.diagonostics,
+            diagnosticsClient: self.diagnosticsClient,
+            containerURL: containerURL,
+            userDefaultsSuiteName: userDefaultsSuiteName
+        )
         self.minIdLength = minIdLength
         self.partnerId = partnerId
         self.callback = callback


### PR DESCRIPTION
## Summary

Add `containerURL` and `userDefaultsSuiteName` parameters to `Configuration` that allow specifying custom storage locations. This enables data sharing between App Clips and main apps, or between an app and its extensions, via App Groups.

## Motivation

Currently, the SDK stores data in app-specific locations that are not accessible by App Clips or app extensions. When a user transitions from an App Clip to the full app, their Amplitude identity and event queue cannot be preserved, leading to fragmented analytics.

This change allows developers to specify an App Group container for both file storage and UserDefaults, enabling seamless identity persistence across App Clip → Main App transitions.

## Changes

- **Configuration.swift**: Add optional `containerURL` and `userDefaultsSuiteName` parameters
- **PersistentStorage.swift**: Use custom paths when provided, with key prefixing for multi-instance isolation

## Key Design Decisions

**UserDefaults key prefixing**: When using a custom suite name (shared App Group), keys are prefixed with `storagePrefix` to maintain isolation between different apiKey/instanceName combinations. This prevents data collision when multiple apps or environments share the same App Group.

**Backwards compatibility**: When no custom suite is provided, behavior is unchanged - each instance gets a unique suite name as before.

## Usage

```swift
let appGroupURL = FileManager.default.containerURL(
    forSecurityApplicationGroupIdentifier: "group.com.example.app"
)

Amplitude(configuration: .init(
    apiKey: "YOUR_API_KEY",
    containerURL: appGroupURL,
    userDefaultsSuiteName: "group.com.example.app"
))
```

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Breaking change: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables shared storage via App Groups for App Clips/extensions while keeping default behavior unchanged.
> 
> - Add `containerURL` and `userDefaultsSuiteName` to `Configuration` and pass them to default `PersistentStorage` instances
> - Update `PersistentStorage` to support custom `UserDefaults` suites with `storagePrefix`-prefixed keys for multi-instance isolation
> - Use custom `containerURL` for events file directory when provided; fall back to existing locations otherwise
> - Adjust `reset()` to remove only namespaced keys plus events index/version
> - Introduce `userDefaultsKey(for:)` helper to centralize key namespacing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75c3a183cd09c28bf8a72ce6ab375ae905a5443e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->