### PR TITLE
feat: use LogLevel from Core

### DIFF
--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -20,7 +20,7 @@ public class Configuration {
         public static let flushQueueSize = Constants.Configuration.FLUSH_QUEUE_SIZE
         public static let flushIntervalMillis = Constants.Configuration.FLUSH_INTERVAL_MILLIS
         public static let flushMaxRetries = Constants.Configuration.FLUSH_MAX_RETRIES
-        public static let logLevel = LogLevelEnum.WARN
+        public static let logLevel = LogLevelEnum.warn
         public static let minTimeBetweenSessionsMillis = Constants.Configuration.MIN_TIME_BETWEEN_SESSIONS_MILLIS
         public static let identifyBatchIntervalMillis = Constants.Configuration.IDENTIFY_BATCH_INTERVAL_MILLIS
         public static let serverZone = ServerZone.US

--- a/Sources/Amplitude/ConsoleLogger.swift
+++ b/Sources/Amplitude/ConsoleLogger.swift
@@ -15,31 +15,31 @@ public class ConsoleLogger: Logger, @unchecked Sendable {
     public var logLevel: Int
     private var logger: OSLog
 
-    public init(logLevel: Int = LogLevelEnum.OFF.rawValue) {
+    public init(logLevel: Int = LogLevelEnum.off.rawValue) {
         self.logLevel = logLevel
         self.logger = OSLog(subsystem: "Amplitude", category: "Logging")
     }
 
     public func error(message: String) {
-        if logLevel >= LogLevel.ERROR.rawValue {
+        if logLevel >= LogLevel.error.rawValue {
             os_log("Error: %@", log: logger, type: .error, message)
         }
     }
 
     public func warn(message: String) {
-        if logLevel >= LogLevel.WARN.rawValue {
+        if logLevel >= LogLevel.warn.rawValue {
             os_log("Warn: %@", log: logger, type: .default, message)
         }
     }
 
     public func log(message: String) {
-        if logLevel >= LogLevel.LOG.rawValue {
+        if logLevel >= LogLevel.log.rawValue {
             os_log("Log: %@", log: logger, type: .info, message)
         }
     }
 
     public func debug(message: String) {
-        if logLevel >= LogLevel.DEBUG.rawValue {
+        if logLevel >= LogLevel.debug.rawValue {
             os_log("Debug: %@", log: logger, type: .debug, message)
         }
     }

--- a/Sources/Amplitude/Constants.swift
+++ b/Sources/Amplitude/Constants.swift
@@ -5,15 +5,75 @@
 //  Created by Marvin Liu on 10/27/22.
 //
 
+#if AMPLITUDE_DISABLE_UIKIT
+@_spi(Internal) import AmplitudeCoreNoUIKit
+#else
+@_spi(Internal) import AmplitudeCore
+#endif
+
 import Foundation
 
+public typealias LogLevelEnum = LogLevel
+
+public extension LogLevelEnum {
+
+    @available(*, deprecated, renamed: "LogLevel.off")
+    static let OFF = Self.off
+
+    @available(*, deprecated, renamed: "LogLevel.error")
+    static let ERROR = Self.error
+
+    @available(*, deprecated, renamed: "LogLevel.warn")
+    static let WARN = Self.warn
+
+    @available(*, deprecated, renamed: "LogLevel.log")
+    static let LOG = Self.log
+
+    @available(*, deprecated, renamed: "LogLevel.debug")
+    static let DEBUG = Self.debug
+}
+
 @objc(AMPLogLevel)
-public enum LogLevelEnum: Int, Sendable {
+public enum ObjCLogLevel: Int, Sendable {
     case OFF
     case ERROR
     case WARN
     case LOG
     case DEBUG
+
+    init(_ logLevel: LogLevelEnum) {
+        switch logLevel {
+        case .off:
+            self = .OFF
+        case .error:
+            self = .ERROR
+        case .warn:
+            self = .WARN
+        case .log:
+            self = .LOG
+        case .debug:
+            self = .DEBUG
+        @unknown default:
+            self = .OFF
+        }
+    }
+
+    var logLevel: LogLevel {
+        switch self {
+        case .OFF:
+            return .off
+        case .ERROR:
+            return .error
+        case .WARN:
+            return .warn
+        case .LOG:
+            return .log
+        case .DEBUG:
+            return .debug
+        @unknown default:
+            return .off
+        }
+    }
 }
 
 public struct Constants {

--- a/Sources/Amplitude/Events/Identify.swift
+++ b/Sources/Amplitude/Events/Identify.swift
@@ -40,7 +40,7 @@ open class Identify {
 
     var propertySet = Set<String>()
     var properties = [String: Any]()
-    var logger = ConsoleLogger(logLevel: LogLevelEnum.WARN.rawValue)
+    var logger = ConsoleLogger(logLevel: LogLevelEnum.warn.rawValue)
 
     // $set operation
     @discardableResult

--- a/Sources/Amplitude/ObjC/ObjCConfiguration.swift
+++ b/Sources/Amplitude/ObjC/ObjCConfiguration.swift
@@ -76,13 +76,14 @@ public class ObjCConfiguration: NSObject {
     }
 
     @objc
-    public var logLevel: LogLevelEnum {
+    public var logLevel: ObjCLogLevel {
         get {
-            configuration.logLevel
+            return ObjCLogLevel(configuration.logLevel)
         }
         set(value) {
-            configuration.logLevel = value
-            configuration.loggerProvider.logLevel = value.rawValue
+            let logLevel = value.logLevel
+            configuration.logLevel = logLevel
+            configuration.loggerProvider.logLevel = logLevel.rawValue
         }
     }
 
@@ -91,13 +92,13 @@ public class ObjCConfiguration: NSObject {
         get {
             { (logLevel, message) in
                 switch logLevel {
-                case LogLevelEnum.ERROR.rawValue:
+                case LogLevelEnum.error.rawValue:
                     self.configuration.loggerProvider.error(message: message)
-                case LogLevelEnum.WARN.rawValue:
+                case LogLevelEnum.warn.rawValue:
                     self.configuration.loggerProvider.warn(message: message)
-                case LogLevelEnum.LOG.rawValue:
+                case LogLevelEnum.log.rawValue:
                     self.configuration.loggerProvider.log(message: message)
-                case LogLevelEnum.DEBUG.rawValue:
+                case LogLevelEnum.debug.rawValue:
                     self.configuration.loggerProvider.debug(message: message)
                 default:
                     break

--- a/Sources/Amplitude/ObjC/ObjCLoggerProvider.swift
+++ b/Sources/Amplitude/ObjC/ObjCLoggerProvider.swift
@@ -18,25 +18,25 @@ class ObjCLoggerProviderWrapper: Logger, @unchecked Sendable {
     }
 
     func error(message: String) {
-        if logLevel >= LogLevelEnum.ERROR.rawValue {
+        if logLevel >= LogLevelEnum.error.rawValue {
             logProvider(logLevel, message)
         }
     }
 
     func warn(message: String) {
-        if logLevel >= LogLevelEnum.WARN.rawValue {
+        if logLevel >= LogLevelEnum.warn.rawValue {
             logProvider(logLevel, message)
         }
     }
 
     func log(message: String) {
-        if logLevel >= LogLevelEnum.LOG.rawValue {
+        if logLevel >= LogLevelEnum.log.rawValue {
             logProvider(logLevel, message)
         }
     }
 
     func debug(message: String) {
-        if logLevel >= LogLevelEnum.DEBUG.rawValue {
+        if logLevel >= LogLevelEnum.debug.rawValue {
             logProvider(logLevel, message)
         }
     }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

We have two sources of truth for LogLevel - one here, one in core. This attempts to unite them by typealiasing this version to the version in Core, and adding static variables to match the legacy capitalized cases. 

ObjC is a bit trickier - We effectively cannot rename AMPLogLevel without breaking ObjC compatibility or adding ObjC headers to the project (which is more trouble than its worth). We can export it from another enum, though, which works quite well as we already wrap Configuration for ObjC and we just have to change the type on the accessor for LogLevel.

Optionally, we could remove the deprecation warnings for the legacy capitalized cases to remove the need for any migration - @sojingle thoughts?

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  yes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies logging level across SDKs by adopting Core’s `LogLevel`.
> 
> - Typealiases `LogLevelEnum` to Core `LogLevel` and adds deprecated uppercase shims (`OFF/ERROR/WARN/LOG/DEBUG`) for source compatibility
> - Introduces `@objc(AMPLogLevel) ObjCLogLevel` with mapping to/from `LogLevel` and updates `ObjCConfiguration.logLevel` to use it
> - Updates defaults and checks to lowercase cases (e.g., `LogLevelEnum.warn`) in `Configuration`, `ConsoleLogger`, `Identify`, and ObjC logger wrapper
> 
> - Breaking change (ObjC): `ObjCConfiguration.logLevel` type changes from `LogLevelEnum` to `ObjCLogLevel`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a64ce71fa1e95b0abe195dd7e0f206b5de24560. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->