### PR TITLE
fix: gzip upload bodies

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -14,9 +14,13 @@
 		4E27E4162DC1443F00799F24 /* AutocaptureRemoteConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E27E4152DC1443800799F24 /* AutocaptureRemoteConfigTests.swift */; };
 		4E2B646B2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */; };
 		4E3871622BB34DBC002890AB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = B6DF481F2B5B45BE00B3E6AA /* PrivacyInfo.xcprivacy */; };
+		4E5F89452F2AB9B60015FBC6 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E5F89442F2AB9A60015FBC6 /* Data+Gzip.swift */; };
 		4E654D682D97454900BCAA85 /* Identity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E654D672D97454900BCAA85 /* Identity.swift */; };
 		4E654DE12D9B60E700BCAA85 /* IdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E654DE02D9B60E300BCAA85 /* IdentityTests.swift */; };
 		4EB530752CD2E46A00E961F4 /* AnalyticsConnectorFramework in Frameworks */ = {isa = PBXBuildFile; productRef = 4EB530742CD2E46A00E961F4 /* AnalyticsConnectorFramework */; };
+		4ED02BB82F299298001AE863 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED02BB72F299280001AE863 /* Data+Gzip.swift */; };
+		4ED02BB92F299298001AE863 /* Data+Gzip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED02BB72F299280001AE863 /* Data+Gzip.swift */; };
+		4ED02BBB2F29958D001AE863 /* GzipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED02BBA2F299583001AE863 /* GzipTests.swift */; };
 		6C04FC3F2C58973C00EA8667 /* ElementInteractionEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C04FC3E2C58973C00EA8667 /* ElementInteractionEvent.swift */; };
 		6C04FC412C58974A00EA8667 /* UIKitElementInteractions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C04FC402C58974A00EA8667 /* UIKitElementInteractions.swift */; };
 		6C04FC432C58976800EA8667 /* ObjCAutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C04FC422C58976800EA8667 /* ObjCAutocaptureOptions.swift */; };
@@ -244,8 +248,11 @@
 		4E27E4152DC1443800799F24 /* AutocaptureRemoteConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutocaptureRemoteConfigTests.swift; sourceTree = "<group>"; };
 		4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitScreenViewsPluginTests.swift; sourceTree = "<group>"; };
 		4E44BA012DB06D200048796B /* Package@swift-5.9.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Package@swift-5.9.swift"; sourceTree = "<group>"; };
+		4E5F89442F2AB9A60015FBC6 /* Data+Gzip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
 		4E654D672D97454900BCAA85 /* Identity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identity.swift; sourceTree = "<group>"; };
 		4E654DE02D9B60E300BCAA85 /* IdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityTests.swift; sourceTree = "<group>"; };
+		4ED02BB72F299280001AE863 /* Data+Gzip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Gzip.swift"; sourceTree = "<group>"; };
+		4ED02BBA2F299583001AE863 /* GzipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GzipTests.swift; sourceTree = "<group>"; };
 		6C04FC3E2C58973C00EA8667 /* ElementInteractionEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ElementInteractionEvent.swift; sourceTree = "<group>"; };
 		6C04FC402C58974A00EA8667 /* UIKitElementInteractions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitElementInteractions.swift; sourceTree = "<group>"; };
 		6C04FC422C58976800EA8667 /* ObjCAutocaptureOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCAutocaptureOptions.swift; sourceTree = "<group>"; };
@@ -559,6 +566,7 @@
 		OBJ_43 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				4ED02BB72F299280001AE863 /* Data+Gzip.swift */,
 				EA2FD8922EECDD6F002AB27E /* AutocaptureManager.swift */,
 				EAE4C5F92E5F769D00FCD6E4 /* ObjectFilter.swift */,
 				EA84CF0A2DF8D8E400CD1CAD /* MiscellaneousExtension.swift */,
@@ -685,6 +693,8 @@
 		OBJ_70 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				4ED02BBA2F299583001AE863 /* GzipTests.swift */,
+				4E5F89442F2AB9A60015FBC6 /* Data+Gzip.swift */,
 				EAE4C5FB2E5FA0C100FCD6E4 /* ObjectFilterTests.swift */,
 				OBJ_71 /* EventPipelineTests.swift */,
 				OBJ_72 /* HttpClientTests.swift */,
@@ -926,6 +936,7 @@
 				EAED9A142EE7B47E00A5FC08 /* InMemoryStorage.swift in Sources */,
 				EAED9A152EE7B47E00A5FC08 /* DispatchQueueHolder.swift in Sources */,
 				EAED9A162EE7B47E00A5FC08 /* DefaultEventUtils.swift in Sources */,
+				4ED02BB92F299298001AE863 /* Data+Gzip.swift in Sources */,
 				EAED9A172EE7B47E00A5FC08 /* PersistentStorage.swift in Sources */,
 				EAED9A182EE7B47E00A5FC08 /* NetworkSwizzler.swift in Sources */,
 				EAED9A192EE7B47E00A5FC08 /* IdentifyInterceptor.swift in Sources */,
@@ -1007,6 +1018,7 @@
 				6C23EF162C38AD31000DC8C8 /* UIKitUserInteractionPluginTest.swift in Sources */,
 				OBJ_153 /* TimelineTests.swift in Sources */,
 				OBJ_154 /* TypesTests.swift in Sources */,
+				4ED02BBB2F29958D001AE863 /* GzipTests.swift in Sources */,
 				OBJ_155 /* EventPipelineTests.swift in Sources */,
 				3E281B8E2B96833D009D913B /* DiagnosticsTests.swift in Sources */,
 				4E27E4162DC1443F00799F24 /* AutocaptureRemoteConfigTests.swift in Sources */,
@@ -1021,6 +1033,7 @@
 				EAE989292DA831F200835345 /* NetworkTrackingPluginTest.swift in Sources */,
 				8EDEC4EE0DE1C89889F451B5 /* QueueTimeTests.swift in Sources */,
 				BA1EC0F62A9F63FD00C2D547 /* AmplitudeIOSTests.swift in Sources */,
+				4E5F89452F2AB9B60015FBC6 /* Data+Gzip.swift in Sources */,
 				8EDEC14255F82E24CEE00B36 /* AmplitudeSessionTests.swift in Sources */,
 				8EDEC972AEB33E4528F7FEEB /* StoragePrefixMigrationTests.swift in Sources */,
 				4E2B646B2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift in Sources */,
@@ -1063,6 +1076,7 @@
 				OBJ_111 /* InMemoryStorage.swift in Sources */,
 				3E281B912B9BCC14009D913B /* DispatchQueueHolder.swift in Sources */,
 				B605396A2BB767390027FC24 /* DefaultEventUtils.swift in Sources */,
+				4ED02BB82F299298001AE863 /* Data+Gzip.swift in Sources */,
 				OBJ_112 /* PersistentStorage.swift in Sources */,
 				EA5C95942D7A76B900DC8B3B /* NetworkSwizzler.swift in Sources */,
 				BA9BEA4B299FB43B00BC0F7C /* IdentifyInterceptor.swift in Sources */,

--- a/Sources/Amplitude/Utilities/Data+Gzip.swift
+++ b/Sources/Amplitude/Utilities/Data+Gzip.swift
@@ -1,0 +1,91 @@
+//
+//  Data+Gzip.swift
+//  Amplitude-Swift
+//
+//  Created by Chris Leonavicius on 1/27/26.
+//
+
+import Foundation
+import zlib
+
+extension Data {
+
+    enum CompressionError: Error {
+        case memoryAccessFailed
+        case zlibFailure
+    }
+
+    /// Returns a gzip-compressed copy of this data.
+    /// - Throws: `CompressionError` on zlib failure or memory access issues.
+    func gzipped() throws -> Data {
+        guard !isEmpty else {
+            return Data()
+        }
+
+        var stream = z_stream()
+        var status: Int32 = Z_OK
+
+        return try withUnsafeBytes { (src: UnsafeRawBufferPointer) throws -> Data in
+            guard let srcBase = src.baseAddress else {
+                throw CompressionError.memoryAccessFailed
+            }
+
+            stream.next_in = UnsafeMutablePointer<Bytef>(mutating: srcBase.assumingMemoryBound(to: Bytef.self))
+            stream.avail_in = uInt(count)
+
+            // 15 = max window bits, +16 = gzip wrapper
+            status = deflateInit2_(
+                &stream,
+                Z_DEFAULT_COMPRESSION,
+                Z_DEFLATED,
+                15 + 16,
+                8,
+                Z_DEFAULT_STRATEGY,
+                ZLIB_VERSION,
+                Int32(MemoryLayout<z_stream>.size)
+            )
+            guard status == Z_OK else {
+                throw CompressionError.zlibFailure
+            }
+            defer {
+                deflateEnd(&stream)
+            }
+
+            let chunkSize = 64 * 1024
+            var output = Data()
+            output.reserveCapacity(Swift.min(count / 2, 1_048_576)) // heuristic; avoids huge over-reserve
+
+            var buffer = Data(count: chunkSize)
+
+            while true {
+                let produced: Int = try buffer.withUnsafeMutableBytes { dst -> Int in
+                    guard let dstBase = dst.baseAddress else {
+                        throw CompressionError.memoryAccessFailed
+                    }
+
+                    stream.next_out = dstBase.assumingMemoryBound(to: Bytef.self)
+                    stream.avail_out = uInt(dst.count)
+
+                    status = deflate(&stream, Z_FINISH)
+
+                    return dst.count - Int(stream.avail_out)
+                }
+
+                if produced > 0 {
+                    output.append(buffer.prefix(produced))
+                }
+
+                if status == Z_STREAM_END {
+                    return output
+                }
+
+                // `deflate(..., Z_FINISH)` should return Z_OK until it ends, otherwise it's an error.
+                guard status == Z_OK else {
+                    throw CompressionError.zlibFailure
+                }
+
+                // If nothing was produced but we're not done, keep looping; zlib may need more iterations.
+            }
+        }
+    }
+}

--- a/Tests/AmplitudeTests/Utilities/Data+Gzip.swift
+++ b/Tests/AmplitudeTests/Utilities/Data+Gzip.swift
@@ -1,0 +1,67 @@
+//
+//  Data+Gzip.swift
+//  Amplitude-Swift
+//
+//  Created by Chris Leonavicius on 1/28/26.
+//
+
+import Foundation
+import zlib
+
+extension Data {
+
+    /// Gunzips data using zlib (expects gzip wrapper).
+    func gunzipped() -> Data? {
+        guard !isEmpty else { return Data() }
+
+        var stream = z_stream()
+        var status: Int32 = Z_OK
+
+        return withUnsafeBytes { (src: UnsafeRawBufferPointer) -> Data? in
+            guard let srcBase = src.baseAddress else { return nil }
+
+            stream.next_in = UnsafeMutablePointer<Bytef>(mutating: srcBase.assumingMemoryBound(to: Bytef.self))
+            stream.avail_in = uInt(count)
+
+            // 15 = max window bits, +16 = gzip wrapper
+            status = inflateInit2_(
+                &stream,
+                15 + 16,
+                ZLIB_VERSION,
+                Int32(MemoryLayout<z_stream>.size)
+            )
+            guard status == Z_OK else { return nil }
+            defer { inflateEnd(&stream) }
+
+            let chunkSize = 64 * 1024
+            var output = Data()
+            var buffer = Data(count: chunkSize)
+
+            while true {
+                let produced: Int = buffer.withUnsafeMutableBytes { dst -> Int in
+                    guard let dstBase = dst.baseAddress else { return 0 }
+
+                    stream.next_out = dstBase.assumingMemoryBound(to: Bytef.self)
+                    stream.avail_out = uInt(dst.count)
+
+                    status = inflate(&stream, Z_NO_FLUSH)
+
+                    return dst.count - Int(stream.avail_out)
+                }
+
+                if produced > 0 {
+                    output.append(buffer.prefix(produced))
+                }
+
+                if status == Z_STREAM_END {
+                    return output
+                }
+
+                // Inflate returns Z_OK while it needs more input/output space.
+                guard status == Z_OK else { return nil }
+
+                // If we produced nothing and status is OK, loop again; zlib may need more room.
+            }
+        }
+    }
+}

--- a/Tests/AmplitudeTests/Utilities/GzipTests.swift
+++ b/Tests/AmplitudeTests/Utilities/GzipTests.swift
@@ -1,0 +1,149 @@
+//
+//  GzipTests.swift
+//  Amplitude-Swift
+//
+//  Created by Chris Leonavicius on 1/27/26.
+//
+
+@testable import AmplitudeSwift
+import XCTest
+
+final class GzipTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func normalizedGzip(_ data: Data) -> Data {
+        XCTAssertGreaterThan(data.count, 10)
+
+        var result = data
+
+        // gzip header layout:
+        // 0-1: magic
+        // 2: compression method
+        // 3: flags
+        // 4-7: mtime  (variable)
+        // 8: xfl
+        // 9: os      (variable)
+        //
+        // Zero out mtime + os to make output deterministic
+        result.replaceSubrange(4..<8, with: repeatElement(0, count: 4))
+        result[9] = 0
+
+        return result
+    }
+
+    private func assertRoundTrip(_ input: Data, file: StaticString = #filePath, line: UInt = #line) {
+        guard let gz = try? input.gzipped() else {
+            XCTFail("gzipped returned nil", file: file, line: line)
+            return
+        }
+        guard let out = gz.gunzipped() else {
+            XCTFail("gunzip failed", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(out, input, "round-trip mismatch", file: file, line: line)
+    }
+
+    // MARK: - Tests
+
+    func testEmptyDataReturnsEmptyData() {
+        let input = Data()
+        let gz = try? input.gzipped()
+        XCTAssertNotNil(gz)
+        XCTAssertEqual(gz, Data())
+    }
+
+    func testSmallAsciiRoundTrip_DefaultLevel() {
+        let input = Data("hello gzip\n".utf8)
+        assertRoundTrip(input)
+    }
+
+    func testBinaryDataRoundTrip() {
+        let bytes = (0..<256).map { UInt8($0) }
+        let input = Data(bytes + bytes + bytes) // some repetition
+        assertRoundTrip(input)
+    }
+
+    func testLargeDataRoundTrip() {
+        // > 64KB to force multiple chunks and multiple deflate iterations
+        var input = Data(count: 512 * 1024)
+        input.withUnsafeMutableBytes { raw in
+            guard let p = raw.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
+            for i in 0..<raw.count {
+                // deterministic pseudo-pattern (compresses somewhat, but not trivially)
+                p[i] = UInt8((i &* 31 &+ (i >> 3)) & 0xFF)
+            }
+        }
+        assertRoundTrip(input)
+    }
+
+    func testGzipMagicHeader() {
+        let input = Data("header check".utf8)
+        guard let gz = try? input.gzipped() else {
+            return XCTFail("gzipped returned nil")
+        }
+        // gzip magic bytes: 0x1f, 0x8b
+        XCTAssertGreaterThanOrEqual(gz.count, 2)
+        XCTAssertEqual(gz[gz.startIndex], 0x1f)
+        XCTAssertEqual(gz[gz.startIndex + 1], 0x8b)
+    }
+
+    func testCompressedOutputUsuallySmallerForHighlyRedundantData() {
+        // Not a guaranteed property for arbitrary data, so choose a very compressible payload.
+        let input = Data(repeating: 0x41, count: 256 * 1024) // "AAAA..."
+        guard let gz = try? input.gzipped() else {
+            return XCTFail("gzipped returned nil")
+        }
+        XCTAssertLessThan(gz.count, input.count)
+        // Also ensure round-trip correctness
+        XCTAssertEqual(gz.gunzipped(), input)
+    }
+
+    func testFixedVector_hello() {
+        let input = Data("hello".utf8)
+
+        guard let gz = try? input.gzipped() else {
+            return XCTFail("compression failed")
+        }
+
+        let normalized = normalizedGzip(gz)
+
+        let expected: [UInt8] = [
+            0x1f, 0x8b, 0x08, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, // xfl, os (normalized)
+            0xcb, 0x48, 0xcd, 0xc9,
+            0xc9, 0x07, 0x00,
+            0x86, 0xa6, 0x10, 0x36,
+            0x05, 0x00, 0x00, 0x00
+        ]
+
+        XCTAssertEqual(Array(normalized), expected)
+    }
+
+    func testFixedVector_emptyString() throws {
+        let input = Data()
+
+        let gz = try input.gzipped()
+        XCTAssertEqual(gz, Data())
+    }
+
+    func testFixedVector_repeatedA() throws {
+        let input = Data(repeating: 0x41, count: 32)
+
+        let gz = try input.gzipped()
+        let normalized = normalizedGzip(gz)
+
+        let expected: [UInt8] = [
+            0x1f, 0x8b, 0x08, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+            0x73, 0x74, 0xc4, 0x0f,
+            0x00,
+            0x1e, 0x6f, 0x31, 0xad,
+            0x20, 0x00, 0x00, 0x00
+        ]
+
+        XCTAssertEqual(Array(normalized), expected)
+    }
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds Gzip compression for request bodies.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the HTTP request body format for all uploads; any mismatch between `Content-Encoding` and body data could break ingestion or interoperability across environments.
> 
> **Overview**
> Event upload requests are now **gzip-compressed** before being sent, and `HttpClient` conditionally sets `Content-Encoding: gzip` to match the encoded body.
> 
> This adds a `Data.gzipped()` zlib-based utility and updates request construction to fall back to uncompressed JSON (and log) if compression fails. Tests were updated/added to validate gzip round-trips, fixed vectors, and that `HttpClientTests` correctly verifies decompressed payloads and the gzip header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7a0e1d77db4ccc06d22dbddfe90ba0e33d2ade6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->