### PR TITLE
fix: disable compression on uploads for custom server urls unless opted in.

### DIFF
--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -36,6 +36,7 @@ public class Configuration {
         public static let networkTrackingOptions = NetworkTrackingOptions.default
         public static let interactionsOptions = InteractionsOptions()
         public static let enableDiagnostics = true
+        public static let enableRequestBodyCompression = false
     }
 
     public internal(set) var apiKey: String
@@ -84,6 +85,11 @@ public class Configuration {
     public let enableAutoCaptureRemoteConfig: Bool
     public var interactionsOptions: InteractionsOptions
     public var enableDiagnostics: Bool
+
+    /// Controls request body compression **only** when a custom `serverUrl` is configured.
+    /// When using the SDK's default endpoints, request bodies are always compressed
+    /// regardless of this setting.
+    public var enableRequestBodyCompression: Bool
 
     let remoteConfigClient: RemoteConfigClient
     let diagnosticsClient: CoreDiagnostics
@@ -181,7 +187,8 @@ public class Configuration {
         networkTrackingOptions: NetworkTrackingOptions = Defaults.networkTrackingOptions,
         enableAutoCaptureRemoteConfig: Bool = Defaults.enableAutoCaptureRemoteConfig,
         interactionsOptions: InteractionsOptions = Defaults.interactionsOptions,
-        enableDiagnostics: Bool = Defaults.enableDiagnostics
+        enableDiagnostics: Bool = Defaults.enableDiagnostics,
+        enableRequestBodyCompression: Bool = Defaults.enableRequestBodyCompression,
     ) {
         let normalizedInstanceName = Configuration.getNormalizeInstanceName(instanceName)
 
@@ -231,6 +238,7 @@ public class Configuration {
         self.networkTrackingOptions = networkTrackingOptions
         self.enableAutoCaptureRemoteConfig = enableAutoCaptureRemoteConfig
         self.interactionsOptions = interactionsOptions
+        self.enableRequestBodyCompression = enableRequestBodyCompression
     }
 
     func isValid() -> Bool {

--- a/Sources/Amplitude/ObjC/ObjCConfiguration.swift
+++ b/Sources/Amplitude/ObjC/ObjCConfiguration.swift
@@ -326,4 +326,13 @@ public class ObjCConfiguration: NSObject {
     @objc public var enableAutoCaptureRemoteConfig: Bool {
         return configuration.enableAutoCaptureRemoteConfig
     }
+
+    @objc public var enableRequestBodyCompression: Bool {
+        get {
+            return configuration.enableRequestBodyCompression
+        }
+        set {
+            configuration.enableRequestBodyCompression = newValue
+        }
+    }
 }

--- a/Sources/Amplitude/Utilities/HttpClient.swift
+++ b/Sources/Amplitude/Utilities/HttpClient.swift
@@ -133,11 +133,24 @@ class HttpClient {
             return (nil, false)
         }
 
-        do {
-            return (try data.gzipped(), !data.isEmpty)
-        } catch {
-            logger?.error(message: "Error compressing request body: \(error)")
+        if shouldCompressUploadBody {
+            do {
+                return (try data.gzipped(), !data.isEmpty)
+            } catch {
+                logger?.error(message: "Error compressing request body: \(error)")
+                return (data, false)
+            }
+        } else {
             return (data, false)
+        }
+    }
+
+    var shouldCompressUploadBody: Bool {
+        // Custom servers may not support gzip compression- only enable it if opted in.
+        if let serverUrl = configuration.serverUrl, !serverUrl.isEmpty {
+            return configuration.enableRequestBodyCompression
+        } else {
+            return true
         }
     }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Add setting to toggle gzip compression on for non-Amplitude upload endpoints, defaulted to disabled.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes network payload encoding behavior for customers using custom ingestion endpoints; incorrect configuration could impact request acceptance or payload sizes, but default Amplitude endpoints remain unchanged.
> 
> **Overview**
> Adjusts upload request body compression behavior so that **gzip is only applied for custom `serverUrl` endpoints when explicitly enabled**.
> 
> Introduces `Configuration.enableRequestBodyCompression` (default `false`) and exposes it via `ObjCConfiguration`; `HttpClient` now gates `data.gzipped()` and `Content-Encoding: gzip` via `shouldCompressUploadBody`, and adds tests covering default vs custom URL behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44f50dc65bda3ac058cbc6aa8386f3d3a60e7e39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->