### PR TITLE
test: fix warnings in tests

### DIFF
--- a/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
+++ b/Examples/AmplitudeSwiftUIExample/AmplitudeSwiftUIExample/AmplitudeSwiftUIExampleApp.swift
@@ -74,7 +74,7 @@ extension Amplitude {
     static var testInstance = Amplitude(
         configuration: Configuration(
             apiKey: "TEST-API-KEY",
-            logLevel: LogLevelEnum.DEBUG,
+            logLevel: LogLevelEnum.debug,
             callback: { (event: BaseEvent, code: Int, message: String) -> Void in
                 print("eventcallback: \(event), code: \(code), message: \(message)")
             },

--- a/Examples/AmplitudeSwiftUIExample/iOSAppClip/iOSAppClipApp.swift
+++ b/Examples/AmplitudeSwiftUIExample/iOSAppClip/iOSAppClipApp.swift
@@ -21,7 +21,7 @@ extension Amplitude {
     static var testInstance = Amplitude(
         configuration: Configuration(
             apiKey: "TEST-API-KEY",
-            logLevel: LogLevelEnum.DEBUG,
+            logLevel: LogLevelEnum.debug,
             callback: { (event: BaseEvent, code: Int, message: String) -> Void in
                 print("eventcallback: \(event), code: \(code), message: \(message)")
             },

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -573,7 +573,7 @@ final class AmplitudeTests: XCTestCase {
             // don't transfer any events
             flushQueueSize: 1000,
             flushIntervalMillis: 99999,
-            logLevel: LogLevelEnum.DEBUG,
+            logLevel: LogLevelEnum.debug,
             autocapture: [],
             enableAutoCaptureRemoteConfig: false
         )
@@ -658,7 +658,7 @@ final class AmplitudeTests: XCTestCase {
                 // don't transfer any events
                 flushQueueSize: 1000,
                 flushIntervalMillis: 99999,
-                logLevel: LogLevelEnum.DEBUG,
+                logLevel: LogLevelEnum.debug,
                 autocapture: [],
                 enableAutoCaptureRemoteConfig: false
             )

--- a/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
+++ b/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
@@ -117,10 +117,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 iosLifecycleMonitor = monitor
             }
         }
-        guard let iosLifecycleMonitor else {
-            XCTFail("iOS lifecycle monitor not installed")
-            return
-        }
+        XCTAssertNotNil(iosLifecycleMonitor, "iOS lifecycle monitor not installed")
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be off by default")
 
@@ -150,10 +147,8 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 iosLifecycleMonitor = monitor
             }
         }
-        guard let iosLifecycleMonitor else {
-            XCTFail("iOS lifecycle monitor not installed")
-            return
-        }
+
+        XCTAssertNotNil(iosLifecycleMonitor, "iOS lifecycle monitor not installed")
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be on by default")
 
@@ -183,10 +178,8 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 iosLifecycleMonitor = monitor
             }
         }
-        guard let iosLifecycleMonitor else {
-            XCTFail("iOS lifecycle monitor not installed")
-            return
-        }
+
+        XCTAssertNotNil(iosLifecycleMonitor, "iOS lifecycle monitor not installed")
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be off by default")
 
@@ -216,10 +209,8 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 iosLifecycleMonitor = monitor
             }
         }
-        guard let iosLifecycleMonitor else {
-            XCTFail("iOS lifecycle monitor not installed")
-            return
-        }
+
+        XCTAssertNotNil(iosLifecycleMonitor, "iOS lifecycle monitor not installed")
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be on by default")
 
@@ -265,10 +256,8 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 iosLifecycleMonitor = monitor
             }
         }
-        guard let iosLifecycleMonitor else {
-            XCTFail("iOS lifecycle monitor not installed")
-            return
-        }
+
+        XCTAssertNotNil(iosLifecycleMonitor, "iOS lifecycle monitor not installed")
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be off by default")
         XCTAssertFalse(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be off by default")
@@ -312,10 +301,8 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 iosLifecycleMonitor = monitor
             }
         }
-        guard let iosLifecycleMonitor else {
-            XCTFail("iOS lifecycle monitor not installed")
-            return
-        }
+
+        XCTAssertNotNil(iosLifecycleMonitor, "iOS lifecycle monitor not installed")
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on by default")
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")
@@ -364,10 +351,8 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 iosLifecycleMonitor = monitor
             }
         }
-        guard let iosLifecycleMonitor else {
-            XCTFail("iOS lifecycle monitor not installed")
-            return
-        }
+
+        XCTAssertNotNil(iosLifecycleMonitor, "iOS lifecycle monitor not installed")
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on by default")
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")

--- a/Tests/AmplitudeTests/ConsoleLoggerTests.swift
+++ b/Tests/AmplitudeTests/ConsoleLoggerTests.swift
@@ -14,21 +14,21 @@ final class ConsoleLoggerTests: XCTestCase {
         let consoleLogger = ConsoleLogger()
         XCTAssertEqual(
             consoleLogger.logLevel,
-            LogLevelEnum.OFF.rawValue
+            LogLevelEnum.off.rawValue
         )
     }
 
     func testUpdateLogLevel() {
-        let consoleLogger = ConsoleLogger(logLevel: LogLevelEnum.LOG.rawValue)
+        let consoleLogger = ConsoleLogger(logLevel: LogLevelEnum.log.rawValue)
         XCTAssertEqual(
             consoleLogger.logLevel,
-            LogLevelEnum.LOG.rawValue
+            LogLevelEnum.log.rawValue
         )
 
-        consoleLogger.logLevel = LogLevelEnum.ERROR.rawValue
+        consoleLogger.logLevel = LogLevelEnum.error.rawValue
         XCTAssertEqual(
             consoleLogger.logLevel,
-            LogLevelEnum.ERROR.rawValue
+            LogLevelEnum.error.rawValue
         )
     }
 }

--- a/Tests/AmplitudeTests/Migration/LegacyDatabaseStorageTests.swift
+++ b/Tests/AmplitudeTests/Migration/LegacyDatabaseStorageTests.swift
@@ -24,7 +24,7 @@ final class LegacyDatabaseStorageTests: XCTestCase {
             }
         }
 
-        storage = LegacyDatabaseStorage(tempDbUrl.path, ConsoleLogger(logLevel: LogLevelEnum.WARN.rawValue))
+        storage = LegacyDatabaseStorage(tempDbUrl.path, ConsoleLogger(logLevel: LogLevelEnum.warn.rawValue))
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

fixes warnings in tests

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/example-only updates that mainly address naming/deprecation and warning cleanup, with no impact to runtime SDK behavior.
> 
> **Overview**
> Updates example apps and multiple tests to use the new lowercased `LogLevelEnum` cases (e.g. `.debug`, `.warn`, `.off`, `.log`, `.error`) instead of the deprecated uppercase variants.
> 
> Cleans up `AutocaptureRemoteConfigTests` by replacing `guard let ... else { XCTFail(); return }` patterns with `XCTAssertNotNil(...)` to eliminate optional-binding warnings while keeping the same assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ae9e7977e633f44c3d49bdc76b4eab4b4f4f370. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->