### PR TITLE
fix: user properties can be updated by any event with user properties

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -481,7 +481,7 @@ public class Amplitude {
             return
         }
 
-        if event.eventType == Constants.IDENTIFY_EVENT, let userProperties = event.userProperties {
+        if let userProperties = event.userProperties, !userProperties.isEmpty {
             var updatedIdentity = identity
             updatedIdentity.apply(identify: userProperties as [String: Any])
             applyIdentityUpdate(updatedIdentity, sendIdentifyIfNeeded: false)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Any event, not just `eventType == $Identify`, can set user props.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to identity update conditions; main risk is unintended identity mutation for event types that include user properties.
> 
> **Overview**
> Updates `Amplitude.process(event:)` to apply `event.userProperties` to the in-memory `identity` for **any** event that carries non-empty user properties, instead of limiting this to `$identify` events.
> 
> This prevents sending an empty user-properties payload from mutating identity and keeps the identity update local (`sendIdentifyIfNeeded: false`) while the event is processed normally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56669295965d1188bf88e7f81c2cabe1d209ba3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->