### PR TITLE
test: Stabilize CI-flaky async tests and harden test harness isolation

### DIFF
--- a/Tests/AmplitudeTests/AmplitudeIOSTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeIOSTests.swift
@@ -247,18 +247,20 @@ final class AmplitudeIOSTests: XCTestCase {
     func testSetIdentityForAutoCapturedEvents() throws {
         let configuration = Configuration(
             apiKey: "api-key",
+            instanceName: #function,
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             autocapture: .sessions,
             enableAutoCaptureRemoteConfig: false
         )
 
-        // force new session event to fire immediately
-        IOSVendorSystem.overrideApplicationState(.active)
+        // Start inactive so the session autocapture waits for didBecomeActive.
+        IOSVendorSystem.overrideApplicationState(.inactive)
 
         let identity = Identity(userId: "test-user", deviceId: "test-device")
         let amplitude = Amplitude(configuration: configuration)
         amplitude.identity = identity
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
         amplitude.waitForTrackingQueue()
         // wait twice for async event generate
         amplitude.waitForTrackingQueue()

--- a/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
+++ b/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
@@ -37,6 +37,16 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         super.tearDown()
     }
 
+    override func setUp() {
+        super.setUp()
+        RemoteConfigUrlProtocol.reset()
+    }
+
+    override func tearDown() {
+        RemoteConfigUrlProtocol.reset()
+        super.tearDown()
+    }
+
     private func uniqueApiKey(_ function: String = #function) -> String {
         let cleanName = function.replacingOccurrences(of: "()", with: "")
         return "\(RemoteConfigUrlProtocol.testApiKeyPrefix)\(cleanName)"
@@ -52,6 +62,12 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         RemoteConfigClient.resetStorage(instanceName: instanceName)
     }
 
+    private func waitForRemoteConfigFetch(_ amplitude: Amplitude, apiKey: String, timeout: TimeInterval = 15) {
+        let didFetchRemoteExpectation = amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation
+        RemoteConfigClient.resumeNextFetchedRemoteConfig(forApiKey: apiKey)
+        wait(for: [didFetchRemoteExpectation], timeout: timeout)
+    }
+
     func testSessionsTurnsOnFromRemoteConfig() {
         resetStorage()
         let apiKey = uniqueApiKey()
@@ -64,11 +80,12 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: []))
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be on from remote config")
     }
@@ -85,11 +102,12 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: [.sessions]))
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be off from remote config")
     }
@@ -108,6 +126,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: []))
 
@@ -121,7 +140,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be on from remote config")
     }
@@ -138,6 +157,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: [.screenViews]))
 
@@ -152,7 +172,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be off from remote config")
     }
@@ -169,6 +189,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: []))
 
@@ -183,7 +204,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be on from remote config")
     }
@@ -200,6 +221,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: [.elementInteractions]))
 
@@ -214,7 +236,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be off from remote config")
     }
@@ -239,6 +261,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let interactionsOptions = InteractionsOptions(
             rageClick: .init(enabled: false),
@@ -263,7 +286,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertFalse(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be off by default")
         XCTAssertFalse(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on from remote config")
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on from remote config")
@@ -284,6 +307,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let interactionsOptions = InteractionsOptions(
             rageClick: .init(enabled: true),
@@ -308,7 +332,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")
         XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be off from remote config")
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should still be on from local config")
@@ -334,6 +358,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let interactionsOptions = InteractionsOptions(
             rageClick: .init(enabled: true),
@@ -358,7 +383,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")
         XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on by default")
         XCTAssertFalse(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be off from remote config")
@@ -380,6 +405,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: []))
 
@@ -396,7 +422,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertTrue(networkTrackingPlugin.optOut, "Network tracking should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertFalse(networkTrackingPlugin.optOut, "Network tracking should be on from remote config")
     }
@@ -415,6 +441,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
                 ]
             ]
         ], forApiKey: apiKey)
+        RemoteConfigClient.pauseNextFetchedRemoteConfig(forApiKey: apiKey)
 
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: [.networkTracking]))
 
@@ -431,7 +458,7 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertFalse(networkTrackingPlugin.optOut, "Network tracking should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        waitForRemoteConfigFetch(amplitude, apiKey: apiKey)
 
         XCTAssertTrue(networkTrackingPlugin.optOut, "Network tracking should be on from remote config")
     }
@@ -623,6 +650,14 @@ extension RemoteConfigClient {
         RemoteConfigUrlProtocol.setConfig(remoteConfig, forApiKey: apiKey)
     }
 
+    static func pauseNextFetchedRemoteConfig(forApiKey apiKey: String) {
+        RemoteConfigUrlProtocol.pauseResponses(forApiKey: apiKey)
+    }
+
+    static func resumeNextFetchedRemoteConfig(forApiKey apiKey: String) {
+        RemoteConfigUrlProtocol.resumeResponses(forApiKey: apiKey)
+    }
+
     static func resetStorage(instanceName: String) {
         let suiteName = "com.amplitude.remoteconfig.cache.\(instanceName)"
         UserDefaults.standard.removePersistentDomain(forName: suiteName)
@@ -642,22 +677,55 @@ extension URLSessionConfiguration {
 class RemoteConfigUrlProtocol: URLProtocol {
 
     static let testApiKeyPrefix = "remote-config-test-"
-    // Configs keyed by API key for test isolation
-    static var configsByApiKey: [String: [RemoteConfigClient.RemoteConfig]] = [:]
+    private static let stateQueue = DispatchQueue(label: "RemoteConfigUrlProtocol.stateQueue")
+    private static var configsByApiKey: [String: [RemoteConfigClient.RemoteConfig]] = [:]
+    private static var pausedApiKeys: Set<String> = []
 
-    private static let responseQueue = DispatchQueue(label: "RemoteConfigUrlProtocol.responseQueue")
+    private static let responseQueue = DispatchQueue(label: "RemoteConfigUrlProtocol.responseQueue",
+                                                     attributes: .concurrent)
+    private let lifecycleLock = NSLock()
+    private var stopped = false
+
+    static func reset() {
+        stateQueue.sync {
+            configsByApiKey.removeAll()
+            pausedApiKeys.removeAll()
+        }
+    }
 
     static func setConfig(_ config: RemoteConfigClient.RemoteConfig, forApiKey apiKey: String) {
-        configsByApiKey[apiKey, default: []].append(config)
+        stateQueue.sync {
+            configsByApiKey[apiKey, default: []].append(config)
+        }
+    }
+
+    static func pauseResponses(forApiKey apiKey: String) {
+        stateQueue.sync {
+            _ = pausedApiKeys.insert(apiKey)
+        }
+    }
+
+    static func resumeResponses(forApiKey apiKey: String) {
+        stateQueue.sync {
+            _ = pausedApiKeys.remove(apiKey)
+        }
     }
 
     static func popConfig(forApiKey apiKey: String) -> RemoteConfigClient.RemoteConfig? {
-        guard var configs = configsByApiKey[apiKey], !configs.isEmpty else {
-            return nil
+        stateQueue.sync {
+            guard var configs = configsByApiKey[apiKey], !configs.isEmpty else {
+                return nil
+            }
+            let config = configs.removeFirst()
+            configsByApiKey[apiKey] = configs
+            return config
         }
-        let config = configs.removeFirst()
-        configsByApiKey[apiKey] = configs
-        return config
+    }
+
+    static func isPaused(forApiKey apiKey: String) -> Bool {
+        stateQueue.sync {
+            pausedApiKeys.contains(apiKey)
+        }
     }
 
     private static func extractApiKey(from url: URL) -> String? {
@@ -680,6 +748,10 @@ class RemoteConfigUrlProtocol: URLProtocol {
     }
 
     override func startLoading() {
+        lifecycleLock.lock()
+        stopped = false
+        lifecycleLock.unlock()
+
         guard let url = request.url,
               let apiKey = Self.extractApiKey(from: url),
               let config = Self.popConfig(forApiKey: apiKey) else {
@@ -696,17 +768,42 @@ class RemoteConfigUrlProtocol: URLProtocol {
         let data = try? JSONSerialization.data(withJSONObject: ["configs": config])
 
         Self.responseQueue.asyncAfter(deadline: .now() + DispatchTimeInterval.milliseconds(500)) { [self] in
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            if let data {
-                client?.urlProtocol(self, didLoad: data)
-            }
-            client?.urlProtocolDidFinishLoading(self)
-
-            print("RemoteConfigUrlProtocol: Finished loading \(url): \(config)")
+            deliverResponseWhenResumed(url: url, apiKey: apiKey, response: response, data: data, config: config)
         }
     }
 
     override func stopLoading() {
-        // no-op
+        lifecycleLock.lock()
+        stopped = true
+        lifecycleLock.unlock()
+    }
+
+    private func deliverResponseWhenResumed(url: URL,
+                                            apiKey: String,
+                                            response: HTTPURLResponse,
+                                            data: Data?,
+                                            config: RemoteConfigClient.RemoteConfig) {
+        lifecycleLock.lock()
+        let isStopped = stopped
+        lifecycleLock.unlock()
+
+        guard !isStopped else {
+            return
+        }
+
+        guard !Self.isPaused(forApiKey: apiKey) else {
+            Self.responseQueue.asyncAfter(deadline: .now() + DispatchTimeInterval.milliseconds(10)) { [self] in
+                deliverResponseWhenResumed(url: url, apiKey: apiKey, response: response, data: data, config: config)
+            }
+            return
+        }
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let data {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+
+        print("RemoteConfigUrlProtocol: Finished loading \(url): \(config)")
     }
 }

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -120,14 +120,13 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation], timeout: 2)
 
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 1)
-        XCTAssertTrue(events[0] is NetworkRequestEvent)
-        let event = events[0] as! NetworkRequestEvent
+        guard let events = requireCollectedEvents(1, message: "Should capture one network request") else {
+            return
+        }
+        guard let event = events.first as? NetworkRequestEvent else {
+            XCTFail("Expected the first collected event to be a NetworkRequestEvent")
+            return
+        }
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://example.com")
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_QUERY_PROPERTY] as! String, "test=1")
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_FRAGMENT_PROPERTY] as! String, "hash")
@@ -166,12 +165,9 @@ final class NetworkTrackingPluginTest: XCTestCase {
         amplitude.track(eventType: "Test")
         amplitude.flush()
 
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 1)
+        guard let events = requireCollectedEvents(1, message: "Expected only the tracked event") else {
+            return
+        }
         XCTAssertFalse(events[0] is NetworkRequestEvent)
     }
 
@@ -239,13 +235,14 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: expectations, timeout: 2)
 
-        amplitude.waitForTrackingQueue()
-        wait()
-
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 2, "Should capture two network requests")
-        let event = events[0] as! NetworkRequestEvent
-        let event2 = events[1] as! NetworkRequestEvent
+        guard let events = requireCollectedEvents(2, message: "Should capture two network requests") else {
+            return
+        }
+        guard let event = events[0] as? NetworkRequestEvent,
+              let event2 = events[1] as? NetworkRequestEvent else {
+            XCTFail("Expected both collected events to be NetworkRequestEvent instances")
+            return
+        }
         let urls = [event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String,
                     event2.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String]
         XCTAssertFalse(urls.contains(url3), "Should not capture requests to other hosts")
@@ -273,13 +270,14 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: expectations, timeout: 2)
 
-        amplitude.waitForTrackingQueue()
-        wait()
-
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 2, "Should capture two network requests")
-        let event = events[0] as! NetworkRequestEvent
-        let event2 = events[1] as! NetworkRequestEvent
+        guard let events = requireCollectedEvents(2, message: "Should capture two network requests") else {
+            return
+        }
+        guard let event = events[0] as? NetworkRequestEvent,
+              let event2 = events[1] as? NetworkRequestEvent else {
+            XCTFail("Expected both collected events to be NetworkRequestEvent instances")
+            return
+        }
         let statusCodes = [event.eventProperties?[Constants.AMP_NETWORK_STATUS_CODE_PROPERTY] as! Int,
                            event2.eventProperties?[Constants.AMP_NETWORK_STATUS_CODE_PROPERTY] as! Int]
         XCTAssertFalse(statusCodes.contains(200), "Should not capture requests with status codes outside the specified range")
@@ -300,13 +298,13 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation], timeout: 2)
 
-        amplitude.waitForTrackingQueue()
-        wait()
-
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 1)
-        XCTAssertTrue(events[0] is NetworkRequestEvent)
-        let event = events[0] as! NetworkRequestEvent
+        guard let events = requireCollectedEvents(1, message: "Should capture one timed out network request") else {
+            return
+        }
+        guard let event = events.first as? NetworkRequestEvent else {
+            XCTFail("Expected the first collected event to be a NetworkRequestEvent")
+            return
+        }
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://example.com")
         XCTAssertNil(event.eventProperties?[Constants.AMP_NETWORK_STATUS_CODE_PROPERTY] as Any?)
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_ERROR_CODE_PROPERTY] as! Int, -1001)
@@ -324,15 +322,13 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
-        amplitude.waitForTrackingQueue()
-
-        wait(for: 1)
-
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 1)
-        XCTAssertTrue(events[0] is NetworkRequestEvent)
-        let event = events[0] as! NetworkRequestEvent
+        guard let events = requireCollectedEvents(1, message: "Should capture one async network request") else {
+            return
+        }
+        guard let event = events.first as? NetworkRequestEvent else {
+            XCTFail("Expected the first collected event to be a NetworkRequestEvent")
+            return
+        }
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://example.com")
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_REQUEST_BODY_SIZE_PROPERTY] as! Int64, 0)
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_RESPONSE_BODY_SIZE_PROPERTY] as! Int64, 0)
@@ -355,14 +351,15 @@ final class NetworkTrackingPluginTest: XCTestCase {
         sharedSession.uploadTask(with: request, from: requestBodyData, completionHandler: { _, _, _ in
             expectation.fulfill()
         }).resume()
-        wait(for: [expectation], timeout: 2)
+        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 5), .completed)
 
-        wait() // Wait for Autocapture works
-        amplitude.waitForTrackingQueue()
+        XCTAssertTrue(waitForCollectedEventCount(1, timeout: 5), "Expected a captured upload request event")
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
-        XCTAssertTrue(events[0] is NetworkRequestEvent)
-        let event = events[0] as! NetworkRequestEvent
+        guard let event = events.first as? NetworkRequestEvent else {
+            XCTFail("Expected the first collected event to be a NetworkRequestEvent")
+            return
+        }
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://httpbin.org/status/500")
 
         // This can only pass when sending a real network request becase there is no public api for URLProtocol to mock upload data
@@ -384,14 +381,15 @@ final class NetworkTrackingPluginTest: XCTestCase {
         sharedSession.downloadTask(with: request, completionHandler: { _, _, _ in
             expectation.fulfill()
         }).resume()
-        wait(for: [expectation], timeout: 2)
+        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 5), .completed)
 
-        wait() // Wait for Autocapture works
-        amplitude.waitForTrackingQueue()
+        XCTAssertTrue(waitForCollectedEventCount(1, timeout: 5), "Expected a captured download request event")
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
-        XCTAssertTrue(events[0] is NetworkRequestEvent)
-        let event = events[0] as! NetworkRequestEvent
+        guard let event = events.first as? NetworkRequestEvent else {
+            XCTFail("Expected the first collected event to be a NetworkRequestEvent")
+            return
+        }
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://httpbin.org/status/500")
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_RESPONSE_BODY_SIZE_PROPERTY] as! Int64, Int64(responseBodyData.count))
     }
@@ -445,18 +443,16 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation3], timeout: 2)
 
-        wait()
-        plugin.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 2)
-        XCTAssertTrue(events[0] is NetworkRequestEvent)
-        XCTAssertTrue(events[1] is NetworkRequestEvent)
-        let event = events[0] as! NetworkRequestEvent
+        guard let events = requireCollectedEvents(2, message: "Should capture only requests matching the configured host rules") else {
+            return
+        }
+        guard let event = events[0] as? NetworkRequestEvent,
+              let event2 = events[1] as? NetworkRequestEvent else {
+            XCTFail("Expected both collected events to be NetworkRequestEvent instances")
+            return
+        }
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://api.example.com")
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_STATUS_CODE_PROPERTY] as! Int, 400)
-        let event2 = events[1] as! NetworkRequestEvent
         XCTAssertEqual(event2.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://api2.example.com")
         XCTAssertEqual(event2.eventProperties?[Constants.AMP_NETWORK_STATUS_CODE_PROPERTY] as! Int, 500)
     }
@@ -481,13 +477,13 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 1)
-        XCTAssertTrue(events[0] is NetworkRequestEvent)
-        let event = events[0] as! NetworkRequestEvent
+        guard let events = requireCollectedEvents(1, message: "Should capture the request with filtered headers") else {
+            return
+        }
+        guard let event = events.first as? NetworkRequestEvent else {
+            XCTFail("Expected the first collected event to be a NetworkRequestEvent")
+            return
+        }
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://example.com")
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_QUERY_PROPERTY] as! String, "test=1")
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_FRAGMENT_PROPERTY] as! String, "hash")
@@ -538,12 +534,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-        wait()
 
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 1, "Should capture only matching URLs")
+        guard let events = requireCollectedEvents(1, message: "Should capture only matching URLs") else {
+            return
+        }
 
         // Verify event captured correctly
         for event in events {
@@ -603,12 +597,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-        wait()
 
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 3, "Should capture only regex matching URLs")
+        guard let events = requireCollectedEvents(3, message: "Should capture only regex matching URLs") else {
+            return
+        }
 
         // Verify matched URLs
         let capturedURLs = events.compactMap { event in
@@ -679,12 +671,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-        wait()
 
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 4, "Should capture only URLs matching the anchored regex patterns")
+        guard let events = requireCollectedEvents(4, message: "Should capture only URLs matching the anchored regex patterns") else {
+            return
+        }
 
         // Verify the matched URLs
         let capturedURLs = events.compactMap { event in
@@ -732,14 +722,14 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
 
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 1, "URL patterns should take priority over host patterns")
-
-        let event = events[0] as! NetworkRequestEvent
+        guard let events = requireCollectedEvents(1, message: "URL patterns should take priority over host patterns") else {
+            return
+        }
+        guard let event = events.first as? NetworkRequestEvent else {
+            XCTFail("Expected the first collected event to be a NetworkRequestEvent")
+            return
+        }
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://api.example.com/v1/specific")
     }
 
@@ -786,12 +776,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
 
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 2, "Should capture only GET and POST requests")
+        guard let events = requireCollectedEvents(2, message: "Should capture only GET and POST requests") else {
+            return
+        }
 
         // Verify captured methods
         let capturedMethods = events.compactMap { event in
@@ -834,11 +822,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
 
-        let events = eventCollector.events
+        guard let events = requireCollectedEvents(3, message: "Should capture all HTTP methods with wildcard") else {
+            return
+        }
         XCTAssertEqual(events.count, 3, "Should capture all HTTP methods with wildcard")
     }
 
@@ -875,11 +862,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
 
-        let events = eventCollector.events
+        guard let events = requireCollectedEvents(3, message: "Method matching should be case-insensitive") else {
+            return
+        }
         XCTAssertEqual(events.count, 3, "Method matching should be case-insensitive")
     }
 
@@ -932,12 +918,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
 
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 2, "Should capture only requests matching both URL and method criteria")
+        guard let events = requireCollectedEvents(2, message: "Should capture only requests matching both URL and method criteria") else {
+            return
+        }
 
         // Verify the captured events (order independent)
         let capturedRequests = events.compactMap { event -> (url: String, method: String)? in
@@ -1013,12 +997,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         task.resume()
 
         wait(for: [expectation], timeout: 2.0)
-        wait(for: 0.2)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
 
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 1, "Should capture 1 POST request")
+        guard let events = requireCollectedEvents(1, message: "Should capture 1 POST request") else {
+            return
+        }
 
         let event = events[0]
         XCTAssertEqual(event.eventType, "[Amplitude] Network Request")
@@ -1104,12 +1086,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         task.resume()
 
         wait(for: [expectation], timeout: 2.0)
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
 
-        let events = eventCollector.events
-        XCTAssertEqual(events.count, 1, "Should capture 1 GET request")
+        guard let events = requireCollectedEvents(1, message: "Should capture 1 GET request") else {
+            return
+        }
 
         let event = events[0]
         XCTAssertEqual(event.eventType, "[Amplitude] Network Request")
@@ -1199,11 +1179,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
 
-        let events = eventCollector.events
+        guard let events = requireCollectedEvents(3, message: "Should capture requests matching any of the rules") else {
+            return
+        }
         XCTAssertEqual(events.count, 3, "Should capture requests matching any of the rules")
     }
 #else
@@ -1223,9 +1202,26 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTWaiter().wait(for: [expectation], timeout: interval)
     }
 
+    func requireCollectedEvents(_ expectedCount: Int,
+                                timeout: TimeInterval = 5,
+                                message: String) -> [BaseEvent]? {
+        guard waitForCollectedEventCount(expectedCount, timeout: timeout) else {
+            XCTFail(message)
+            return nil
+        }
+
+        let events = eventCollector.events
+        guard events.count == expectedCount else {
+            XCTFail("\(message). Found \(events.count) event(s) instead of \(expectedCount).")
+            return nil
+        }
+
+        return events
+    }
+
     @discardableResult
     func waitForCollectedEventCount(_ expectedCount: Int,
-                                    timeout: TimeInterval = 2,
+                                    timeout: TimeInterval = 5,
                                     pollInterval: TimeInterval = 0.01) -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
 

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -40,11 +40,13 @@ final class NetworkTrackingPluginTest: XCTestCase {
         configuration.protocolClasses = [FakeURLProtocol.self]
         sharedSession = URLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
         FakeURLProtocol.clearMockResponses()
+        FakeURLProtocol.interceptAmplitudeRequests = false
     }
 
     override func tearDown() {
         eventCollector.events.removeAll()
         FakeURLProtocol.clearMockResponses()
+        FakeURLProtocol.interceptAmplitudeRequests = false
         sharedSession.invalidateAndCancel()
         sharedSession = nil
         // Invalidate any per-test sessions created with non-default timeouts.
@@ -159,6 +161,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
     func testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude() {
         setupAmplitude()
+        FakeURLProtocol.interceptAmplitudeRequests = true
 
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
 
@@ -175,6 +178,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         var options = NetworkTrackingOptions.default
         options.ignoreAmplitudeRequests = false
         setupAmplitude(with: options)
+        FakeURLProtocol.interceptAmplitudeRequests = true
 
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
 

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -17,14 +17,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
     private var amplitude: Amplitude!
     private var storageMem: FakeInMemoryStorage!
     private var eventCollector = EventCollectorPlugin()
-
-    // Shared session for most requests - reused across tests in this class
-    private static var sharedSession: URLSession = {
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = defaultTimeout
-        configuration.protocolClasses = [FakeURLProtocol.self]
-        return URLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
-    }()
+    private var sharedSession: URLSession!
 
     // Track sessions with custom timeouts to invalidate in tearDown
     private var customTimeoutSessions: [URLSession] = []
@@ -35,7 +28,6 @@ final class NetworkTrackingPluginTest: XCTestCase {
     }
 
     static override func tearDown() {
-        sharedSession.invalidateAndCancel()
         URLSessionConfiguration.disableMockDefault()
         super.tearDown()
     }
@@ -43,13 +35,19 @@ final class NetworkTrackingPluginTest: XCTestCase {
     override func setUp() {
         super.setUp()
         storageMem = FakeInMemoryStorage()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = Self.defaultTimeout
+        configuration.protocolClasses = [FakeURLProtocol.self]
+        sharedSession = URLSession(configuration: configuration, delegate: nil, delegateQueue: nil)
         FakeURLProtocol.clearMockResponses()
     }
 
     override func tearDown() {
         eventCollector.events.removeAll()
         FakeURLProtocol.clearMockResponses()
-        // Only invalidate custom timeout sessions - shared session is reused
+        sharedSession.invalidateAndCancel()
+        sharedSession = nil
+        // Invalidate any per-test sessions created with non-default timeouts.
         customTimeoutSessions.forEach { $0.invalidateAndCancel() }
         customTimeoutSessions.removeAll()
         amplitude = nil
@@ -91,7 +89,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         // Use shared session for default timeout, create new one only for custom timeouts
         let session: URLSession
         if timeout == Self.defaultTimeout {
-            session = Self.sharedSession
+            session = sharedSession
         } else {
             let configuration = URLSessionConfiguration.ephemeral
             configuration.timeoutIntervalForRequest = timeout
@@ -108,7 +106,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         var request = URLRequest(url: URL(string: url)!)
         request.httpMethod = method
         // Always use shared session for async requests (default timeout)
-        return try await Self.sharedSession.data(for: request)
+        return try await sharedSession.data(for: request)
     }
 
 #if !os(watchOS)
@@ -354,7 +352,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
 
-        Self.sharedSession.uploadTask(with: request, from: requestBodyData, completionHandler: { _, _, _ in
+        sharedSession.uploadTask(with: request, from: requestBodyData, completionHandler: { _, _, _ in
             expectation.fulfill()
         }).resume()
         wait(for: [expectation], timeout: 2)
@@ -383,7 +381,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
 
-        Self.sharedSession.downloadTask(with: request, completionHandler: { _, _, _ in
+        sharedSession.downloadTask(with: request, completionHandler: { _, _, _ in
             expectation.fulfill()
         }).resume()
         wait(for: [expectation], timeout: 2)
@@ -1008,7 +1006,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         let expectation = XCTestExpectation(description: "Network request finished")
 
         // Create a data task with completion handler using the shared session
-        let task = Self.sharedSession.dataTask(with: request) { _, _, _ in
+        let task = sharedSession.dataTask(with: request) { _, _, _ in
             expectation.fulfill()
         }
 
@@ -1099,7 +1097,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         let expectation = XCTestExpectation(description: "Network request finished")
 
         // Use dataTask with URL directly (not URLRequest) via shared session
-        let task = Self.sharedSession.dataTask(with: url) { _, _, _ in
+        let task = sharedSession.dataTask(with: url) { _, _, _ in
             expectation.fulfill()
         }
 

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -43,14 +43,17 @@ final class NetworkTrackingPluginTest: XCTestCase {
     override func setUp() {
         super.setUp()
         storageMem = FakeInMemoryStorage()
+        FakeURLProtocol.clearMockResponses()
     }
 
     override func tearDown() {
-        super.tearDown()
         eventCollector.events.removeAll()
+        FakeURLProtocol.clearMockResponses()
         // Only invalidate custom timeout sessions - shared session is reused
         customTimeoutSessions.forEach { $0.invalidateAndCancel() }
         customTimeoutSessions.removeAll()
+        amplitude = nil
+        super.tearDown()
     }
 
     func setupAmplitude(with options: NetworkTrackingOptions = NetworkTrackingOptions.default) {
@@ -184,14 +187,14 @@ final class NetworkTrackingPluginTest: XCTestCase {
         amplitude.track(eventType: "Test")
         amplitude.flush()
 
-        wait(for: 0.1)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        XCTAssertTrue(waitForCollectedEventCount(2), "Expected the tracked event and the captured Amplitude upload request")
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2)
-        let event = events[1] as! NetworkRequestEvent
+        guard let event = events.first(where: { $0 is NetworkRequestEvent }) as? NetworkRequestEvent else {
+            XCTFail("Expected a captured Amplitude network request event")
+            return
+        }
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://api2.amplitude.com/2/httpapi")
     }
 
@@ -1220,6 +1223,28 @@ final class NetworkTrackingPluginTest: XCTestCase {
     func wait(for interval: TimeInterval = 0.1) {
         let expectation = XCTestExpectation(description: "Wait for time interval")
         XCTWaiter().wait(for: [expectation], timeout: interval)
+    }
+
+    @discardableResult
+    func waitForCollectedEventCount(_ expectedCount: Int,
+                                    timeout: TimeInterval = 2,
+                                    pollInterval: TimeInterval = 0.01) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        repeat {
+            networkTrackingPlugin?.waitforNetworkTrackingQueue()
+            amplitude.waitForTrackingQueue()
+
+            if eventCollector.events.count >= expectedCount {
+                return true
+            }
+
+            RunLoop.current.run(until: min(deadline, Date().addingTimeInterval(pollInterval)))
+        } while Date() < deadline
+
+        networkTrackingPlugin?.waitforNetworkTrackingQueue()
+        amplitude.waitForTrackingQueue()
+        return eventCollector.events.count >= expectedCount
     }
 }
 // swiftlint:enable force_cast

--- a/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
+++ b/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
@@ -8,7 +8,21 @@
 import Foundation
 
 class FakeURLProtocol: URLProtocol {
-    static var mockResponses: [MockResponse] = []
+    private static let stateQueue = DispatchQueue(label: "FakeURLProtocol.stateQueue")
+    private static var _mockResponses: [MockResponse] = []
+
+    static var mockResponses: [MockResponse] {
+        get {
+            stateQueue.sync {
+                _mockResponses
+            }
+        }
+        set {
+            stateQueue.sync {
+                _mockResponses = newValue
+            }
+        }
+    }
 
     private static let responseQueue = DispatchQueue(label: "FakeURLProtocol.responseQueue")
 
@@ -51,12 +65,18 @@ class FakeURLProtocol: URLProtocol {
 
         print("FakeURLProtocol: Starting to load \(url)")
 
-        guard !Self.mockResponses.isEmpty else {
+        let mockResponse = Self.stateQueue.sync { () -> MockResponse? in
+            guard !Self._mockResponses.isEmpty else {
+                return nil
+            }
+
+            return Self._mockResponses.removeFirst()
+        }
+
+        guard let mockResponse else {
             client?.urlProtocol(self, didFailWithError: NSError(domain: "FakeURLProtocol", code: -2, userInfo: [NSLocalizedDescriptionKey: "No mock responses available"]))
             return
         }
-
-        let mockResponse = Self.mockResponses.removeFirst()
 
         let response = HTTPURLResponse(
             url: url,
@@ -91,7 +111,9 @@ class FakeURLProtocol: URLProtocol {
     }
 
     static func clearMockResponses() {
-        mockResponses.removeAll()
+        stateQueue.sync {
+            _mockResponses.removeAll()
+        }
     }
 }
 

--- a/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
+++ b/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
@@ -25,6 +25,8 @@ class FakeURLProtocol: URLProtocol {
     }
 
     private static let responseQueue = DispatchQueue(label: "FakeURLProtocol.responseQueue")
+    private let lifecycleLock = NSLock()
+    private var stopped = false
 
     struct MockResponse {
         let statusCode: Int
@@ -63,6 +65,10 @@ class FakeURLProtocol: URLProtocol {
             return
         }
 
+        lifecycleLock.withLock {
+            stopped = false
+        }
+
         print("FakeURLProtocol: Starting to load \(url)")
 
         let mockResponse = Self.stateQueue.sync { () -> MockResponse? in
@@ -87,27 +93,30 @@ class FakeURLProtocol: URLProtocol {
 
         let delay = mockResponse.delay
 
-        Self.responseQueue.asyncAfter(deadline: .now() + delay) { [weak self] in
-            guard let self = self else { return }
+        Self.responseQueue.asyncAfter(deadline: .now() + delay) { [self] in
+            let isStopped = lifecycleLock.withLock { stopped }
+            guard !isStopped else { return }
 
-            self.client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
 
             if let data = mockResponse.data {
-                self.client?.urlProtocol(self, didLoad: data)
+                client?.urlProtocol(self, didLoad: data)
             }
 
             if let error = mockResponse.error {
-                self.client?.urlProtocol(self, didFailWithError: error)
+                client?.urlProtocol(self, didFailWithError: error)
             }
 
-            self.client?.urlProtocolDidFinishLoading(self)
+            client?.urlProtocolDidFinishLoading(self)
 
             print("FakeURLProtocol: Finished loading \(url), response: \(mockResponse)")
         }
     }
 
     override func stopLoading() {
-        // Nothing to do here
+        lifecycleLock.withLock {
+            stopped = true
+        }
     }
 
     static func clearMockResponses() {

--- a/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
+++ b/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
@@ -24,7 +24,10 @@ class FakeURLProtocol: URLProtocol {
         }
     }
 
-    private static let responseQueue = DispatchQueue(label: "FakeURLProtocol.responseQueue")
+    // Delivering all fake responses on a single serial queue can backlog unrelated requests
+    // across the test process and trip per-session timeouts on slower CI runners.
+    private static let responseQueue = DispatchQueue(label: "FakeURLProtocol.responseQueue",
+                                                     attributes: .concurrent)
     private let lifecycleLock = NSLock()
     private var stopped = false
 

--- a/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
+++ b/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
@@ -10,6 +10,7 @@ import Foundation
 class FakeURLProtocol: URLProtocol {
     private static let stateQueue = DispatchQueue(label: "FakeURLProtocol.stateQueue")
     private static var _mockResponses: [MockResponse] = []
+    private static var _interceptAmplitudeRequests = false
 
     static var mockResponses: [MockResponse] {
         get {
@@ -20,6 +21,19 @@ class FakeURLProtocol: URLProtocol {
         set {
             stateQueue.sync {
                 _mockResponses = newValue
+            }
+        }
+    }
+
+    static var interceptAmplitudeRequests: Bool {
+        get {
+            stateQueue.sync {
+                _interceptAmplitudeRequests
+            }
+        }
+        set {
+            stateQueue.sync {
+                _interceptAmplitudeRequests = newValue
             }
         }
     }
@@ -55,7 +69,17 @@ class FakeURLProtocol: URLProtocol {
 
     override class func canInit(with request: URLRequest) -> Bool {
         let isRemoteConfig = request.url?.absoluteString.hasPrefix("https://sr-client-cfg.") ?? false
-        return !isRemoteConfig
+        let isAmplitudeRequest = request.url?.host?.contains("amplitude.com") ?? false
+
+        guard !isRemoteConfig else {
+            return false
+        }
+
+        if isAmplitudeRequest && !interceptAmplitudeRequests {
+            return false
+        }
+
+        return true
     }
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
@@ -125,6 +149,7 @@ class FakeURLProtocol: URLProtocol {
     static func clearMockResponses() {
         stateQueue.sync {
             _mockResponses.removeAll()
+            _interceptAmplitudeRequests = false
         }
     }
 }

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -16,18 +16,22 @@ final class EventPipelineTests: XCTestCase {
     private var pipeline: EventPipeline!
     private var httpClient: FakeHttpClient!
     private var storage: PersistentStorage!
+    private var storagePrefix: String!
 
     override func setUp() {
         super.setUp()
+        storagePrefix = "event-pipeline-tests-\(UUID().uuidString)"
         storage = PersistentStorage(
-            storagePrefix: "event-pipeline-tests",
+            storagePrefix: storagePrefix,
             logger: nil,
             diagonostics: Diagnostics(),
             diagnosticsClient: FakeDiagnosticsClient())
         configuration = Configuration(
             apiKey: "testApiKey",
             flushIntervalMillis: Int(Self.FLUSH_INTERVAL_SECONDS * 1000),
+            instanceName: storagePrefix,
             storageProvider: storage,
+            logLevel: .off,
             offline: NetworkConnectivityCheckerPlugin.Disabled
         )
         let amplitude = Amplitude(configuration: configuration)
@@ -39,8 +43,13 @@ final class EventPipelineTests: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         storage.reset()
+        storage = nil
+        storagePrefix = nil
+        httpClient = nil
+        pipeline = nil
+        configuration = nil
+        super.tearDown()
     }
 
     func testInit() {
@@ -193,9 +202,6 @@ final class EventPipelineTests: XCTestCase {
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
 
-        let uploadExpectations = (0..<4).map { i in expectation(description: "httpresponse-\(i)") }
-        httpClient.uploadExpectations = uploadExpectations
-
         httpClient.uploadResults = [
             .failure(NSError(domain: "unknown", code: 0, userInfo: nil)), // instant failure
             .failure(NSError(domain: "unknown", code: 0, userInfo: nil)), // +1s failure
@@ -204,14 +210,16 @@ final class EventPipelineTests: XCTestCase {
         ]
 
         pipeline.flush()
-        // Expected: upload 0 (instant) + upload 1 (1s retry delay)
-        wait(for: [uploadExpectations[0], uploadExpectations[1]], timeout: 5)
+        XCTAssertTrue(waitForCondition(timeout: 3) {
+            self.httpClient.uploadCount == 2 && self.pipeline.configuration.offline == false
+        }, "Expected 2 upload attempts before the pipeline goes offline")
 
         XCTAssertEqual(httpClient.uploadCount, 2)
         XCTAssertEqual(pipeline.configuration.offline, false)
 
-        // Expected: upload 2 (2s retry delay)
-        wait(for: [uploadExpectations[2]], timeout: 5)
+        XCTAssertTrue(waitForCondition(timeout: 4) {
+            self.httpClient.uploadCount == 3 && self.pipeline.configuration.offline == true
+        }, "Expected the third upload attempt to mark the pipeline offline")
 
         XCTAssertEqual(httpClient.uploadCount, 3)
         XCTAssertEqual(pipeline.configuration.offline, true)
@@ -221,7 +229,10 @@ final class EventPipelineTests: XCTestCase {
         pipeline.flush {
             flushExpectation.fulfill()
         }
-        wait(for: [uploadExpectations[3], flushExpectation], timeout: 2)
+        wait(for: [flushExpectation], timeout: 2)
+        XCTAssertTrue(waitForCondition(timeout: 1) {
+            self.httpClient.uploadCount == 4
+        }, "Expected a final successful upload after re-enabling the pipeline")
 
         XCTAssertEqual(httpClient.uploadCount, 4)
     }
@@ -261,5 +272,21 @@ final class EventPipelineTests: XCTestCase {
 
         XCTAssertEqual(httpClient.uploadCount, 3)
         XCTAssertEqual(pipeline.configuration.offline, false)
+    }
+
+    @discardableResult
+    private func waitForCondition(timeout: TimeInterval,
+                                  pollInterval: TimeInterval = 0.01,
+                                  condition: @escaping () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+
+        repeat {
+            if condition() {
+                return true
+            }
+            RunLoop.current.run(until: min(deadline, Date().addingTimeInterval(pollInterval)))
+        } while Date() < deadline
+
+        return condition()
     }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### TODO
- The PR’s unit-test pass rate is higher than main’s, but because the Runner’s success rate varies over time, I’ll run tests multiple times at different times to confirm its effectiveness.

### Summary
This PR fixes several unit tests that were stable locally but flaky on GitHub runners because they depended on timing-sensitive async behavior during startup, uploads, and remote config fetches.

All changes are test-only. No SDK production code was changed.

Ran three times in a row with no UT failures.

### Note on testSetIdentityForAutoCapturedEvents

This PR intentionally changes the scope of testSetIdentityForAutoCapturedEvents.

The previous test was asserting a behavior we cannot guarantee: if the app is already active during Amplitude initialization, startup autocapture may already be queued or running before the caller sets amplitude.identity. In that case, there is no deterministic guarantee that the auto-captured event will pick up the new identity.

The updated test now covers the narrower behavior that the SDK can guarantee: when identity is set before didBecomeActive triggers autocapture, the auto-captured event uses that identity. This makes the test deterministic and aligns it with the actual contract instead of a timing-dependent race.

### What changed

- Made testSetIdentityForAutoCapturedEvents deterministic by avoiding the race between startup autocapture and post-init identity assignment.
- Reworked NetworkTrackingPluginTest to wait on actual collected events instead of fixed sleeps, and removed the crash path that indexed missing events after a failed count assertion.
- Hardened FakeURLProtocol so shared mock response state is synchronized, cleared between tests, and request lifecycle is handled more safely.
- Updated testContinuousFailure to wait on pipeline state transitions instead of expectation ordering, and isolated its storage/logging setup per test.
- Added gating to the remote-config test transport so AutocaptureRemoteConfigTests can assert local defaults before allowing remote config to be applied.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are test-only, but they do refactor shared test harness utilities (mock URL protocols and remote-config transport) where subtle timing/concurrency mistakes could still cause new flakes.
> 
> **Overview**
> **Stabilizes multiple CI-flaky tests by removing timing races and improving per-test isolation.** Session autocapture identity test now starts the app inactive and triggers `didBecomeActive` after setting identity to avoid a startup race.
> 
> Remote-config autocapture tests gain a controllable fetch gate (pause/resume) plus protocol state resets, so assertions can reliably check local defaults before remote config applies; the underlying `RemoteConfigUrlProtocol` is hardened with synchronized state and safer request lifecycle handling.
> 
> Network tracking and pipeline tests are rewritten to wait for observable conditions (collected events / state transitions) instead of fixed sleeps and brittle expectation ordering, while `FakeURLProtocol` is made thread-safe, concurrent, and resettable between tests to prevent cross-test interference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 365239ed2ac060a08f9eee7735bc19f5af64fb72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->