### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash

### DIFF
--- a/.github/workflows/dependency-version-check.yml
+++ b/.github/workflows/dependency-version-check.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Check dependency version consistency
         run: |

--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@main
+    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@c832303a64c05b9911b6b1ad3dd8f69099f71179 # @amplitude/analytics-browser@2.36.9
     with:
       label: "Swift"
       subcomponent: "dx_ios_sdk_(swift)"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-14-large
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set Xcode 16
         run: |
           sudo xcode-select -switch /Applications/Xcode_16.1.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: octokit/request-action@v2.1.9
+        uses: octokit/request-action@89697eb6635e52c6e1e5559f15b5c91ba5100cb0 # v2.1.9
         with:
           route: GET /repos/:repository/collaborators/${{ github.actor }}
           repository: ${{ github.repository }}
@@ -31,7 +31,7 @@ jobs:
     needs: [authorize, run-tests]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set Xcode 16.3
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -52,7 +52,7 @@ jobs:
             device: "Apple Vision Pro"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set Xcode ${{ matrix.xcode }}
         run: |
           sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
@@ -122,7 +122,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set Xcode 16
         run: |
           sudo xcode-select -switch /Applications/Xcode_16.4.app


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via automated scripts.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

This pull request was created by [multi-gitter](https://github.com/lindell/multi-gitter).

Please merge this pull request by 2026-04-10.

For any questions, please ask in the Slack channel #help-security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only pins existing GitHub Actions/reusable workflow references to specific commit hashes, with no logic changes to the workflows themselves.
> 
> **Overview**
> Pins CI workflow dependencies to immutable commits for supply-chain hardening.
> 
> Updates `actions/checkout`, `octokit/request-action`, and the reused `jira-issue-create-template` workflow to use full commit SHAs instead of version tags/branches across the dependency check, lint, unit test, and release workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4eb031c6a465d437cd7f67b9348cafa09096198. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->