### PR TITLE
fix: quarantine unreadable event files and recover from unopenable ones

### DIFF
--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -370,6 +370,22 @@ extension PersistentStorage {
             open(file: storeFile)
         }
 
+        // If the file still can't be opened for writing (e.g., Data Protection
+        // locked, permissions, filesystem error), roll the unopenable file out
+        // of the .tmp namespace and start a fresh one. Without this, the
+        // optional chaining at outputStream?.write below silently drops every
+        // new event into the void.
+        if outputStream == nil {
+            diagonosticsClient.increment(name: "analytics.events.file.open.failed")
+            diagonosticsClient.recordEvent(name: "analytics.events.file.open.failed", properties: [
+                "file": storeFile.lastPathComponent
+            ])
+            logger?.error(message: "Could not open events file for writing \(storeFile.lastPathComponent); rolling over to a fresh file.")
+            forceAdvanceToNewFile(storeFile)
+            storeFile = getCurrentEventFile()
+            start(file: storeFile)
+        }
+
         // Verify file size isn't too large
         if let attributes = try? fileManager.attributesOfItem(atPath: storeFile.path),
             let fileSize = attributes[FileAttributeKey.size] as? UInt64,
@@ -417,27 +433,33 @@ extension PersistentStorage {
     }
 
     private func start(file: URL) {
+        // Only assign outputStream after both the init AND the create/open
+        // succeed. Otherwise a throw from create() leaves a half-initialized
+        // stream with a nil fileHandle — which would pass the "outputStream ==
+        // nil" guard in storeEvent while still silently dropping writes via
+        // optional chaining at outputStream?.write.
         do {
-            outputStream = try OutputFileStream(fileURL: file)
-            try outputStream?.create()
+            let stream = try OutputFileStream(fileURL: file)
+            try stream.create()
+            outputStream = stream
         } catch {
             diagonostics.addErrorLog(error.localizedDescription)
             logger?.error(message: error.localizedDescription)
+            outputStream = nil
         }
     }
 
     private func open(file: URL) {
-        if outputStream == nil {
-            // this can happen if an instance was terminated before finishing a file.
-            do {
-                outputStream = try OutputFileStream(fileURL: file)
-                if let outputStream = outputStream {
-                    try outputStream.open()
-                }
-            } catch {
-                diagonostics.addErrorLog(error.localizedDescription)
-                logger?.error(message: error.localizedDescription)
-            }
+        guard outputStream == nil else { return }
+        // this can happen if an instance was terminated before finishing a file.
+        do {
+            let stream = try OutputFileStream(fileURL: file)
+            try stream.open()
+            outputStream = stream
+        } catch {
+            diagonostics.addErrorLog(error.localizedDescription)
+            logger?.error(message: error.localizedDescription)
+            outputStream = nil
         }
     }
 
@@ -454,6 +476,14 @@ extension PersistentStorage {
         }
         self.outputStream = nil
 
+        forceAdvanceToNewFile(file)
+    }
+
+    // Rolls `file` out of the .tmp namespace and bumps the stored file index so
+    // the next getCurrentEventFile() call returns a fresh path. Used both by
+    // finish() on normal rollover and by storeEvent() when the current file
+    // can't be opened for writing.
+    private func forceAdvanceToNewFile(_ file: URL) {
         rename(file)
         let currentFileIndex: Int = (getCurrentEventFileIndex() ?? 0) + 1
         userDefaults?.set(currentFileIndex, forKey: eventsFileKey)

--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -99,10 +99,41 @@ class PersistentStorage: Storage {
                 return readV1File(content: content!)
             }
         } catch {
-            diagonostics.addErrorLog(error.localizedDescription)
-            logger?.error(message: error.localizedDescription)
+            diagonosticsClient.increment(name: "analytics.events.file.read.failed")
+            diagonosticsClient.recordEvent(name: "analytics.events.file.read.failed", properties: [
+                "file": eventBlock.lastPathComponent,
+                "error": error.localizedDescription
+            ])
+            logger?.error(message: "Could not read events file \(eventBlock.lastPathComponent): \(error.localizedDescription)")
+            // Quarantine the unreadable file so the upload pipeline can make progress.
+            // Without this, the same file blocks every subsequent flush forever.
+            quarantineUnreadableFile(eventBlock)
         }
         return content
+    }
+
+    private func quarantineUnreadableFile(_ file: URL) {
+        syncQueue.sync {
+            guard fileManager.fileExists(atPath: file.path) else { return }
+            let directory = file.deletingLastPathComponent()
+            let timestamp = Int(Date().timeIntervalSince1970)
+            // Leading "." makes the file hidden; getEventFiles uses skipsHiddenFiles so
+            // the quarantined file drops out of the upload queue automatically while
+            // staying on disk for diagnostics.
+            let quarantineName = ".\(file.lastPathComponent).corrupt.\(timestamp)"
+            let target = directory.appendingPathComponent(quarantineName)
+            do {
+                try fileManager.moveItem(at: file, to: target)
+                logger?.error(message: "Quarantined unreadable events file: \(file.lastPathComponent) -> \(quarantineName)")
+            } catch {
+                diagonosticsClient.increment(name: "analytics.events.file.quarantine.failed")
+                diagonosticsClient.recordEvent(name: "analytics.events.file.quarantine.failed", properties: [
+                    "file": file.lastPathComponent,
+                    "error": error.localizedDescription
+                ])
+                logger?.error(message: "Unable to quarantine unreadable events file \(file.lastPathComponent): \(error.localizedDescription)")
+            }
+        }
     }
 
     func remove(eventBlock: EventBlock) {

--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -115,16 +115,16 @@ class PersistentStorage: Storage {
     private func quarantineUnreadableFile(_ file: URL) {
         syncQueue.sync {
             guard fileManager.fileExists(atPath: file.path) else { return }
-            let directory = file.deletingLastPathComponent()
+            let quarantineDir = getQuarantineDirectory()
             let timestamp = Int(Date().timeIntervalSince1970)
-            // Leading "." makes the file hidden; getEventFiles uses skipsHiddenFiles so
-            // the quarantined file drops out of the upload queue automatically while
-            // staying on disk for diagnostics.
-            let quarantineName = ".\(file.lastPathComponent).corrupt.\(timestamp)"
-            let target = directory.appendingPathComponent(quarantineName)
+            let target = quarantineDir.appendingPathComponent("\(file.lastPathComponent).\(timestamp)")
             do {
+                try fileManager.createDirectory(at: quarantineDir, withIntermediateDirectories: true, attributes: nil)
                 try fileManager.moveItem(at: file, to: target)
-                logger?.error(message: "Quarantined unreadable events file: \(file.lastPathComponent) -> \(quarantineName)")
+                logger?.error(message: "Quarantined unreadable events file: \(file.lastPathComponent) -> \(PersistentStorage.QUARANTINE_DIR_NAME)/\(target.lastPathComponent)")
+                if let contents = try? fileManager.contentsOfDirectory(atPath: quarantineDir.path) {
+                    diagonosticsClient.recordHistogram(name: "analytics.events.file.quarantined.count", value: Double(contents.count))
+                }
             } catch {
                 diagonosticsClient.increment(name: "analytics.events.file.quarantine.failed")
                 diagonosticsClient.recordEvent(name: "analytics.events.file.quarantine.failed", properties: [
@@ -134,6 +134,11 @@ class PersistentStorage: Storage {
                 logger?.error(message: "Unable to quarantine unreadable events file \(file.lastPathComponent): \(error.localizedDescription)")
             }
         }
+    }
+
+    private func getQuarantineDirectory() -> URL {
+        return getEventsStorageDirectory(createDirectory: false)
+            .appendingPathComponent(PersistentStorage.QUARANTINE_DIR_NAME)
     }
 
     func remove(eventBlock: EventBlock) {
@@ -190,6 +195,7 @@ class PersistentStorage: Storage {
             for url in urls {
                 try? fileManager.removeItem(atPath: url.path)
             }
+            try? fileManager.removeItem(at: getQuarantineDirectory())
         }
     }
 
@@ -255,6 +261,10 @@ extension PersistentStorage {
     static let DELMITER = "\u{0000}"
     static let STORAGE_VERSION = "amplitude.events.storage.version"
     static let STORAGE_V2_PREFIX = "v2-"
+    // Leading "." keeps the quarantine folder hidden so contentsOfDirectory
+    // with skipsHiddenFiles (the default in getEventFiles and
+    // getCurrentEventFile) ignores it without any explicit filtering.
+    static let QUARANTINE_DIR_NAME = ".quarantine"
 
     enum Exception: Error {
         case unsupportedType

--- a/Sources/Amplitude/Utilities/EventPipeline.swift
+++ b/Sources/Amplitude/Utilities/EventPipeline.swift
@@ -137,7 +137,7 @@ public class EventPipeline {
                             return
                         }
                         self.currentUpload = nil
-                        self.sendNextEventFile(failures: failures)
+                        self.sendNextEventFile(failures: failures, skipFiles: skipFiles)
                     }
 
                     if failures == 0 || handled {

--- a/Sources/Amplitude/Utilities/EventPipeline.swift
+++ b/Sources/Amplitude/Utilities/EventPipeline.swift
@@ -69,7 +69,7 @@ public class EventPipeline {
         }
     }
 
-    private func sendNextEventFile(failures: Int = 0) {
+    private func sendNextEventFile(failures: Int = 0, skipFiles: Set<URL> = []) {
         autoreleasepool {
             guard currentUpload == nil else {
                 logger?.log(message: "Existing upload in progress, skipping...")
@@ -78,7 +78,7 @@ public class EventPipeline {
 
             guard let storage = storage,
                   let eventFiles: [URL] = storage.read(key: StorageKey.EVENTS),
-                  let nextEventFile = eventFiles.first else {
+                  let nextEventFile = eventFiles.first(where: { !skipFiles.contains($0) }) else {
                 flushCompletions.forEach { $0() }
                 flushCompletions.removeAll()
                 logger?.debug(message: "No event files to upload")
@@ -93,6 +93,15 @@ public class EventPipeline {
             guard let eventsString = storage.getEventsString(eventBlock: nextEventFile),
                   !eventsString.isEmpty else {
                 logger?.log(message: "Could not read events file: \(nextEventFile)")
+                // Storage quarantines unreadable files inside getEventsString. Add the
+                // file to skipFiles so this flush chain continues to later files even
+                // if the quarantine rename itself failed, and so we don't revisit it
+                // within the same flush.
+                var newSkipFiles = skipFiles
+                newSkipFiles.insert(nextEventFile)
+                uploadsQueue.async { [weak self] in
+                    self?.sendNextEventFile(failures: failures, skipFiles: newSkipFiles)
+                }
                 return
             }
 

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -100,6 +100,47 @@ final class PersistentStorageTests: XCTestCase {
         persistentStorage.reset()
     }
 
+    func testQuarantineUnreadableEventFile() throws {
+        let persistentStorage = PersistentStorage(storagePrefix: "quarantine-instance", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        let storeDirectory = persistentStorage.getEventsStorageDirectory(createDirectory: false)
+        try? persistentStorage.write(
+            key: StorageKey.EVENTS,
+            value: BaseEvent(eventType: "test1")
+        )
+        persistentStorage.rollover()
+        let eventFiles = try XCTUnwrap(persistentStorage.read(key: StorageKey.EVENTS) as [URL]?)
+        XCTAssertEqual(eventFiles.count, 1)
+        let corruptFile = eventFiles[0]
+
+        // Overwrite finalized file with bytes that are invalid UTF-8, mimicking the
+        // iOS 26 corruption report where String(contentsOf:encoding:) throws.
+        let invalidUTF8 = Data([0xFF, 0xFE, 0xFD, 0xFC, 0xC0, 0xC1, 0xF5])
+        try invalidUTF8.write(to: corruptFile)
+
+        let result = persistentStorage.getEventsString(eventBlock: corruptFile)
+        XCTAssertNil(result, "Unreadable file should return nil")
+
+        // Original file must be gone (quarantined) so the next flush advances past it.
+        XCTAssertFalse(FileManager.default.fileExists(atPath: corruptFile.path), "Corrupt file should be renamed away")
+
+        // read(key: .EVENTS) must no longer return the corrupt file — otherwise the
+        // EventPipeline stays stuck on it.
+        let remaining: [URL]? = persistentStorage.read(key: StorageKey.EVENTS)
+        XCTAssertTrue(remaining?.isEmpty ?? true, "Upload queue should no longer surface the corrupt file")
+
+        // Quarantined file stays on disk (hidden) for diagnostics.
+        let allOnDisk = try FileManager.default.contentsOfDirectory(atPath: storeDirectory.path)
+        let quarantined = allOnDisk.filter { $0.hasPrefix(".\(corruptFile.lastPathComponent).corrupt.") }
+        XCTAssertEqual(quarantined.count, 1, "Quarantine file should exist on disk for diagnostics")
+
+        persistentStorage.reset()
+        // reset() uses skipsHiddenFiles so the quarantine file is intentionally left behind;
+        // clean it up manually to keep the test directory tidy.
+        for hidden in quarantined {
+            try? FileManager.default.removeItem(atPath: storeDirectory.appendingPathComponent(hidden).path)
+        }
+    }
+
     func testRemove() {
         let persistentStorage = PersistentStorage(storagePrefix: "xxx-instance", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
         let storeDirectory = persistentStorage.getEventsStorageDirectory(createDirectory: false)

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -128,17 +128,15 @@ final class PersistentStorageTests: XCTestCase {
         let remaining: [URL]? = persistentStorage.read(key: StorageKey.EVENTS)
         XCTAssertTrue(remaining?.isEmpty ?? true, "Upload queue should no longer surface the corrupt file")
 
-        // Quarantined file stays on disk (hidden) for diagnostics.
-        let allOnDisk = try FileManager.default.contentsOfDirectory(atPath: storeDirectory.path)
-        let quarantined = allOnDisk.filter { $0.hasPrefix(".\(corruptFile.lastPathComponent).corrupt.") }
-        XCTAssertEqual(quarantined.count, 1, "Quarantine file should exist on disk for diagnostics")
+        // Quarantined file lives inside the hidden .quarantine subfolder for diagnostics.
+        let quarantineDir = storeDirectory.appendingPathComponent(PersistentStorage.QUARANTINE_DIR_NAME)
+        let quarantined = (try? FileManager.default.contentsOfDirectory(atPath: quarantineDir.path)) ?? []
+        XCTAssertEqual(quarantined.count, 1, "Quarantine file should exist in quarantine subfolder for diagnostics")
+        XCTAssertTrue(quarantined[0].hasPrefix("\(corruptFile.lastPathComponent)."))
 
+        // reset() should now sweep the quarantine directory too.
         persistentStorage.reset()
-        // reset() uses skipsHiddenFiles so the quarantine file is intentionally left behind;
-        // clean it up manually to keep the test directory tidy.
-        for hidden in quarantined {
-            try? FileManager.default.removeItem(atPath: storeDirectory.appendingPathComponent(hidden).path)
-        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: quarantineDir.path), "reset() should remove the quarantine directory")
     }
 
     func testRemove() {

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -139,6 +139,45 @@ final class PersistentStorageTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: quarantineDir.path), "reset() should remove the quarantine directory")
     }
 
+    func testWriteRecoversFromUnopenableFile() throws {
+        let persistentStorage = PersistentStorage(storagePrefix: "unopenable-write", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+        let storeDirectory = persistentStorage.getEventsStorageDirectory(createDirectory: true)
+
+        // Pre-create the first .tmp path as a *directory* so FileHandle(forWritingTo:)
+        // will throw. This mimics the production scenario where the existing .tmp
+        // cannot be opened for append (e.g., Data Protection locked, permissions).
+        let blockedTmp = storeDirectory.appendingPathComponent("v2-0.tmp")
+        try FileManager.default.createDirectory(at: blockedTmp, withIntermediateDirectories: false)
+
+        // Write an event. Without the recovery path, outputStream would stay nil and
+        // the event would be silently dropped via optional chaining at outputStream?.write.
+        try persistentStorage.write(key: StorageKey.EVENTS, value: BaseEvent(eventType: "after-recovery"))
+        persistentStorage.rollover()
+
+        // Blocked tmp should be renamed out of the .tmp namespace (same rename()
+        // used by rollover — moves "v2-0.tmp" -> "v2-0").
+        XCTAssertFalse(FileManager.default.fileExists(atPath: blockedTmp.path))
+
+        // read(key:.EVENTS) must surface both the new file (with the event we
+        // just wrote) and the blocked one as an unreadable candidate.
+        let eventFiles = try XCTUnwrap(persistentStorage.read(key: StorageKey.EVENTS) as [URL]?)
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        XCTAssertEqual(eventFiles.count, 2)
+        XCTAssertEqual(eventFiles[0].lastPathComponent, "v2-0")
+        XCTAssertTrue(eventFiles[1].lastPathComponent.hasPrefix("v2-1"))
+
+        // Reading the blocked entry triggers quarantine; reading the new file
+        // returns the event that otherwise would have been lost.
+        _ = persistentStorage.getEventsString(eventBlock: eventFiles[0])
+        let recoveredString = persistentStorage.getEventsString(eventBlock: eventFiles[1])
+        let recoveredEvents = BaseEvent.fromArrayString(jsonString: recoveredString ?? "")
+        XCTAssertEqual(recoveredEvents?.count, 1)
+        XCTAssertEqual(recoveredEvents?[0].eventType, "after-recovery")
+
+        persistentStorage.reset()
+    }
+
     func testRemove() {
         let persistentStorage = PersistentStorage(storagePrefix: "xxx-instance", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
         let storeDirectory = persistentStorage.getEventsStorageDirectory(createDirectory: false)

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -226,6 +226,40 @@ final class EventPipelineTests: XCTestCase {
         XCTAssertEqual(httpClient.uploadCount, 4)
     }
 
+    func testFlushSkipsMultipleUnreadableFiles() throws {
+        let storeDirectory = storage.getEventsStorageDirectory(createDirectory: false)
+
+        // Create three finalized event files.
+        for i in 0..<3 {
+            try? pipeline.storage?.write(
+                key: StorageKey.EVENTS,
+                value: BaseEvent(userId: "u", deviceId: "d", eventType: "event-\(i)")
+            )
+            pipeline.storage?.rollover()
+        }
+
+        let initialFiles = (try FileManager.default.contentsOfDirectory(at: storeDirectory, includingPropertiesForKeys: nil))
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        XCTAssertEqual(initialFiles.count, 3)
+
+        // Corrupt the first two files. The third remains a valid event block.
+        let invalidUTF8 = Data([0xFF, 0xFE, 0xFD, 0xFC, 0xC0, 0xC1, 0xF5])
+        try invalidUTF8.write(to: initialFiles[0])
+        try invalidUTF8.write(to: initialFiles[1])
+
+        let flushExpectation = expectation(description: "flush")
+        pipeline.flush {
+            flushExpectation.fulfill()
+        }
+        wait(for: [flushExpectation], timeout: 2)
+
+        // Pipeline must have walked past the two corrupt files and uploaded the third.
+        XCTAssertEqual(httpClient.uploadCount, 1, "Pipeline should not stall on corrupt files")
+        let uploaded = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
+        XCTAssertEqual(uploaded?.count, 1)
+        XCTAssertEqual(uploaded?[0].eventType, "event-2")
+    }
+
     func testContinuesHandledFailure() {
         pipeline.configuration.offline = false
         pipeline.configuration.flushMaxRetries = 1

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -229,16 +229,21 @@ final class EventPipelineTests: XCTestCase {
     func testFlushSkipsMultipleUnreadableFiles() throws {
         let storeDirectory = storage.getEventsStorageDirectory(createDirectory: false)
 
+        // Clear anything written during Amplitude init (e.g. session_start)
+        // so the files below are the only finalized event blocks on disk.
+        storage.reset()
+
         // Create three finalized event files.
         for i in 0..<3 {
             try? pipeline.storage?.write(
                 key: StorageKey.EVENTS,
-                value: BaseEvent(userId: "u", deviceId: "d", eventType: "event-\(i)")
+                value: BaseEvent(userId: "u", deviceId: "d", eventType: "marker-\(i)")
             )
             pipeline.storage?.rollover()
         }
 
         let initialFiles = (try FileManager.default.contentsOfDirectory(at: storeDirectory, includingPropertiesForKeys: nil))
+            .filter { $0.pathExtension.isEmpty }
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
         XCTAssertEqual(initialFiles.count, 3)
 
@@ -257,7 +262,109 @@ final class EventPipelineTests: XCTestCase {
         XCTAssertEqual(httpClient.uploadCount, 1, "Pipeline should not stall on corrupt files")
         let uploaded = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
         XCTAssertEqual(uploaded?.count, 1)
-        XCTAssertEqual(uploaded?[0].eventType, "event-2")
+        XCTAssertEqual(uploaded?[0].eventType, "marker-2")
+    }
+
+    func testFlushKeepsSkippingUnreadableFilesAfterUpload() throws {
+        // Counts getEventsString invocations per URL so we can catch the
+        // regression where skipFiles is dropped after a successful upload,
+        // causing quarantine-failed corrupt files to be re-read on each
+        // iteration (O(N×M) instead of O(N+M)).
+        class CountingStorage: PersistentStorage {
+            var readAttempts: [URL: Int] = [:]
+            override func getEventsString(eventBlock: URL) -> String? {
+                readAttempts[eventBlock, default: 0] += 1
+                return super.getEventsString(eventBlock: eventBlock)
+            }
+        }
+
+        let spyStorage = CountingStorage(
+            storagePrefix: "event-pipeline-spy",
+            logger: nil,
+            diagonostics: Diagnostics(),
+            diagnosticsClient: FakeDiagnosticsClient())
+        let spyConfiguration = Configuration(
+            apiKey: "testApiKey",
+            flushIntervalMillis: Int(Self.FLUSH_INTERVAL_SECONDS * 1000),
+            storageProvider: spyStorage,
+            offline: NetworkConnectivityCheckerPlugin.Disabled
+        )
+        let spyAmplitude = Amplitude(configuration: spyConfiguration)
+        let spyHttp = FakeHttpClient(configuration: spyConfiguration, diagnostics: spyConfiguration.diagonostics)
+        let spyPipeline = EventPipeline(amplitude: spyAmplitude)
+        spyPipeline.httpClient = spyHttp
+        spyPipeline.flushTimer?.suspend()
+
+        let storeDirectory = spyStorage.getEventsStorageDirectory(createDirectory: false)
+        // Clear anything written during Amplitude init (e.g. session_start) so
+        // we have a clean slate for the interleaved layout below.
+        spyStorage.reset()
+        spyStorage.readAttempts.removeAll()
+
+        // Layout: [corrupt, good, corrupt, good]. The earlier corrupt file lives
+        // to the left of later good files, so if the upload path drops skipFiles
+        // on recursion the pipeline re-reads the corrupt file after each good
+        // upload.
+        for i in 0..<4 {
+            try? spyPipeline.storage?.write(
+                key: StorageKey.EVENTS,
+                value: BaseEvent(userId: "u", deviceId: "d", eventType: "marker-\(i)")
+            )
+            spyPipeline.storage?.rollover()
+        }
+        let allFiles = try FileManager.default.contentsOfDirectory(at: storeDirectory, includingPropertiesForKeys: nil)
+        let files = allFiles
+            .filter { $0.pathExtension.isEmpty }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        XCTAssertEqual(files.count, 4)
+
+        let invalidUTF8 = Data([0xFF, 0xFE, 0xFD, 0xFC, 0xC0, 0xC1, 0xF5])
+        try invalidUTF8.write(to: files[0])
+        try invalidUTF8.write(to: files[2])
+
+        // Pre-create the quarantine targets for a window of timestamps around
+        // "now" so PersistentStorage's moveItem throws NSFileWriteFileExistsError.
+        // With quarantine failing, skipFiles must persist across upload recursions
+        // or the pipeline re-reads corrupt files once per good upload.
+        let quarantineDir = storeDirectory.appendingPathComponent(PersistentStorage.QUARANTINE_DIR_NAME)
+        try FileManager.default.createDirectory(at: quarantineDir, withIntermediateDirectories: true)
+        let now = Int(Date().timeIntervalSince1970)
+        var precreated: [URL] = []
+        for delta in -2...10 {
+            for corrupt in [files[0], files[2]] {
+                let blocker = quarantineDir.appendingPathComponent("\(corrupt.lastPathComponent).\(now + delta)")
+                FileManager.default.createFile(atPath: blocker.path, contents: Data())
+                precreated.append(blocker)
+            }
+        }
+
+        let flushExpectation = expectation(description: "flush")
+        spyPipeline.flush {
+            flushExpectation.fulfill()
+        }
+        wait(for: [flushExpectation], timeout: 2)
+
+        XCTAssertEqual(spyHttp.uploadCount, 2, "Both good files should upload exactly once")
+        let uploaded0 = BaseEvent.fromArrayString(jsonString: spyHttp.uploadedEvents[0])
+        let uploaded1 = BaseEvent.fromArrayString(jsonString: spyHttp.uploadedEvents[1])
+        XCTAssertEqual(uploaded0?.first?.eventType, "marker-1")
+        XCTAssertEqual(uploaded1?.first?.eventType, "marker-3")
+
+        // Quarantine failed → corrupt files remain on disk with original names.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: files[0].path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: files[2].path))
+
+        // The key regression assertion: each file is read at most once per flush,
+        // regardless of how many good uploads happened between corrupt files.
+        // Without skipFiles forwarding, the first corrupt file would be re-read
+        // after each good upload (3x total for this layout).
+        for (url, count) in spyStorage.readAttempts {
+            XCTAssertEqual(count, 1, "File \(url.lastPathComponent) was read \(count) times; expected 1")
+        }
+
+        // reset() sweeps the quarantine directory, taking the pre-created blockers with it.
+        spyStorage.reset()
+        XCTAssertFalse(FileManager.default.fileExists(atPath: quarantineDir.path))
     }
 
     func testContinuesHandledFailure() {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Two independent failure modes currently cause events to disappear on iOS:

1. **Read-path stall.** A single unreadable finalized event file (`v2-0`) halts the entire upload pipeline indefinitely. `EventPipeline.sendNextEventFile` always picks `eventFiles.first`, and on read failure it just `return`s — no retry, no skip, no cleanup. Every subsequent flush picks the same file, fails the same way, and no events ship. Field reports on iOS 26.x show devices stuck in this state with `NSFileReadCorruptFileError (259)` on `v2-0`.
2. **Write-path silent drop.** If the current `.tmp` file can't be opened for append (e.g., Data Protection locked, permissions, filesystem error), `outputStream` stays in a nil-or-half-initialized state and the subsequent `outputStream?.write(...)` is a no-op via optional chaining — every tracked event is silently lost with only a log line.

This PR makes both pipelines self-heal:

- **Quarantine on read failure** (`PersistentStorage.getEventsString`): when `String(contentsOf:encoding:)` throws, move the file into a hidden `.quarantine/` subfolder as `<name>.<ts>`. `getEventFiles` / `getCurrentEventFile` use `skipsHiddenFiles` so the subfolder drops out of both the upload queue and the rollover logic automatically — no explicit filtering required. Files remain on disk inside `.quarantine/` for support diagnostics; `reset()` now sweeps the subfolder too.
- **Skip-set recursion** (`EventPipeline.sendNextEventFile`): thread a `skipFiles: Set<URL>` through the recursive walk so the flush continues past every corrupt file even if the quarantine rename itself fails. The set is **also** forwarded through the post-upload recursion — without that, a successful upload resets the set and any corrupt file with a failed quarantine is re-read after every good upload (`O(N×M)` instead of `O(N+M)`).
- **Write-path recovery** (`PersistentStorage.storeEvent`): refactor `start()` / `open()` so `outputStream` is only assigned after *both* the `OutputFileStream` init and the `.create()` / `.open()` call succeed (fixes a latent bug where a failed `.open()` left a half-initialized stream that bypassed the nil guard). When `outputStream` is still nil after the open attempt, force-advance the file index — rename the unopenable file out of `.tmp` namespace, bump the index, and `start()` a fresh file so the new event lands somewhere real.
- **Shared helper**: extracted `forceAdvanceToNewFile(_:)` used by both `finish()` on normal rollover and the `storeEvent` recovery path. Clarifies "advance past the current file" as a single named operation shared by success and failure flows.
- **Diagnostics**: `diagonosticsClient.increment` + `diagonosticsClient.recordEvent` for each failure mode — `analytics.events.file.read.failed`, `analytics.events.file.quarantine.failed`, `analytics.events.file.open.failed` — with `file` + `error` properties. Plus `diagonosticsClient.recordHistogram("analytics.events.file.quarantined.count", ...)` sampling the running quarantine count after each successful quarantine, so we can measure the fleet distribution and peak.

### Recovery semantics

- **Already-stuck devices (read failure)**: next launch + flush quarantines `v2-0`, continues to `v2-1`, pipeline unblocks. Events in the corrupt file are lost (they were already unreadable).
- **New corruption**: self-heals the same way — one file's worth of events lost, no permanent stall.
- **Multiple corrupt files / quarantine failure**: every bad file is visited exactly once per flush, counters reflect real damage, good files still upload.
- **Unopenable current file (write failure)**: the next `track()` call rolls the unopenable file out of `.tmp` and starts fresh. The orphaned file is picked up by the read-path quarantine on the next flush if still unreadable, or uploaded normally if the block was transient (e.g., device unlocked since then).

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence and upload sequencing: incorrect handling could drop events or cause unexpected file churn, but changes are localized and backed by new tests for corruption and recovery scenarios.
> 
> **Overview**
> Prevents the event upload pipeline from stalling forever on a single corrupt event file by **quarantining unreadable blocks** and continuing the flush.
> 
> `PersistentStorage.getEventsString` now emits diagnostics on read failure, moves unreadable files into a hidden `/.quarantine` folder (cleaned up by `reset()`), and adds metrics around quarantine success/failure.
> 
> `EventPipeline.sendNextEventFile` now threads a `skipFiles` set through its recursion so a flush will walk past multiple unreadable files (even if quarantine fails) without repeatedly re-reading the same bad blocks; storage writing also recovers from an unopenable `.tmp` file by rolling over to a fresh file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f3aed47b39530eed7a7ca878f0a77b7956cc26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->