### PR TITLE
fix: Use Application Support for event storage

### DIFF
--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -36,6 +36,7 @@ class PersistentStorage: Storage {
     let logger: (any Logger)?
     let diagonostics: Diagnostics
     let diagonosticsClient: CoreDiagnostics
+    private var didExcludeStorageFromBackup = false
 
     init(storagePrefix: String, logger: (any Logger)?, diagonostics: Diagnostics, diagnosticsClient: CoreDiagnostics) {
         self.storagePrefix = storagePrefix == PersistentStorage.DEFAULT_STORAGE_PREFIX || storagePrefix.starts(with: "\(PersistentStorage.DEFAULT_STORAGE_PREFIX)-")
@@ -50,6 +51,8 @@ class PersistentStorage: Storage {
         self.diagonosticsClient = diagnosticsClient
         // Make sure Amplitude data is sandboxed per app
         self.appPath = Self.getAppPath(sandboxed: isStorageSandboxed())
+
+        migrateLegacyStorageDirectories()
         handleV1Files()
     }
 
@@ -196,6 +199,7 @@ class PersistentStorage: Storage {
                 try? fileManager.removeItem(atPath: url.path)
             }
             try? fileManager.removeItem(at: getQuarantineDirectory())
+            didExcludeStorageFromBackup = false
         }
     }
 
@@ -319,7 +323,7 @@ extension PersistentStorage {
         finish(file: currentFile)
 
         let allFiles = try? fileManager.contentsOfDirectory(
-            at: getEventsStorageDirectory(),
+            at: eventsStorageDirectory,
             includingPropertiesForKeys: [],
             options: .skipsHiddenFiles
         )
@@ -338,9 +342,86 @@ extension PersistentStorage {
         return result
     }
 
+    private func migrateLegacyStorageDirectories() {
+        syncQueue.sync {
+            let legacyStorageDirectory = getLegacyEventsStorageDirectory(createDirectory: false)
+            guard fileManager.fileExists(atPath: legacyStorageDirectory.path) else {
+                return
+            }
+
+            defer {
+                // Clean up directory if it is empty
+                let remainingLegacyFiles = try? fileManager.contentsOfDirectory(
+                    at: legacyStorageDirectory,
+                    includingPropertiesForKeys: [],
+                    options: []
+                )
+                if remainingLegacyFiles?.isEmpty == true {
+                    try? fileManager.removeItem(at: legacyStorageDirectory)
+                }
+            }
+
+            // Remove anything in legacy quarantine directory
+            let legacyQuarantineDirectory = legacyStorageDirectory
+                .appendingPathComponent(PersistentStorage.QUARANTINE_DIR_NAME)
+            if fileManager.fileExists(atPath: legacyQuarantineDirectory.path) {
+                try? fileManager.removeItem(at: legacyQuarantineDirectory)
+            }
+
+            // Move event files
+            let legacyFiles = (try? fileManager.contentsOfDirectory(
+                at: legacyStorageDirectory,
+                includingPropertiesForKeys: [],
+                options: .skipsHiddenFiles
+            )) ?? []
+
+            guard !legacyFiles.isEmpty else {
+                return
+            }
+
+            let storageDirectory = getEventsStorageDirectory(createDirectory: true)
+            for legacyFile in legacyFiles {
+                var destinationFile = storageDirectory.appendingPathComponent(legacyFile.lastPathComponent)
+                if legacyFile.pathExtension == PersistentStorage.TEMP_FILE_EXTENSION {
+                    destinationFile = destinationFile.deletingPathExtension()
+                }
+                if fileManager.fileExists(atPath: destinationFile.path) {
+                    let suffix = "-\(Date().timeIntervalSince1970)-\(Int.random(in: 0..<1000))"
+                    destinationFile = destinationFile.appendFileNameSuffix(suffix: suffix)
+                }
+                do {
+                    try fileManager.moveItem(at: legacyFile, to: destinationFile)
+                } catch {
+                    diagonostics.addErrorLog(error.localizedDescription)
+                    logger?.error(message: "Unable to migrate legacy event file: \(legacyFile.path)")
+                }
+            }
+        }
+    }
+
     internal func getEventsStorageDirectory(createDirectory: Bool = true) -> URL {
-        // TODO: Update to use applicationSupportDirectory for all platforms (this will require a migration)
-        // let searchPathDirectory = FileManager.SearchPathDirectory.applicationSupportDirectory
+        let storageUrl = getEventsStorageDirectory(searchPathDirectory: .applicationSupportDirectory,
+                                                  createDirectory: createDirectory)
+
+        // This call is prohibitively expensive to be called at each event, run it once per instance lifetime.
+        if createDirectory, !didExcludeStorageFromBackup {
+            var mutableStorageUrl = storageUrl
+            do {
+                var resourceValues = URLResourceValues()
+                resourceValues.isExcludedFromBackup = true
+                try mutableStorageUrl.setResourceValues(resourceValues)
+                didExcludeStorageFromBackup = true
+            } catch {
+                let nsError = error as NSError
+                diagonostics.addErrorLog("Unable to exclude storage directory from backup: \(nsError.domain)#\(nsError.code)")
+                logger?.error(message: "Unable to exclude storage directory from backup: \(storageUrl.path)")
+            }
+        }
+
+        return storageUrl
+    }
+
+    internal func getLegacyEventsStorageDirectory(createDirectory: Bool = true) -> URL {
         // tvOS doesn't have access to document
         // macOS /Documents dir might be synced with iCloud
         #if os(tvOS) || os(macOS)
@@ -348,7 +429,10 @@ extension PersistentStorage {
         #else
             let searchPathDirectory = FileManager.SearchPathDirectory.documentDirectory
         #endif
+        return getEventsStorageDirectory(searchPathDirectory: searchPathDirectory, createDirectory: createDirectory)
+    }
 
+    private func getEventsStorageDirectory(searchPathDirectory: FileManager.SearchPathDirectory, createDirectory: Bool) -> URL {
         let urls = fileManager.urls(for: searchPathDirectory, in: .userDomainMask)
         let docUrl = urls[0]
         let storageUrl = docUrl.appendingPathComponent("amplitude/\(appPath ?? "")\(eventsFileKey)/")

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -371,6 +371,186 @@ final class PersistentStorageTests: XCTestCase {
         persistentStorage.reset()
     }
 
+    func testDefaultStorageDirectoryUsesApplicationSupport() {
+        let persistentStorage = PersistentStorage(storagePrefix: "application-support-instance", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+
+        let storageUrl = persistentStorage.getEventsStorageDirectory(createDirectory: false)
+        let applicationSupportUrl = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+
+        XCTAssertTrue(storageUrl.path.hasPrefix(applicationSupportUrl.path))
+        persistentStorage.reset()
+    }
+
+    func testStorageDirectoryIsExcludedFromBackupWhenCreated() throws {
+        let persistentStorage = PersistentStorage(storagePrefix: "excluded-from-backup-instance-\(UUID().uuidString)", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+
+        let storageUrl = persistentStorage.getEventsStorageDirectory(createDirectory: true)
+        let resourceValues = try storageUrl.resourceValues(forKeys: [.isExcludedFromBackupKey])
+
+        XCTAssertEqual(resourceValues.isExcludedFromBackup, true)
+        persistentStorage.reset()
+    }
+
+    func testStorageDirectoryBackupExclusionIsOnlySetOncePerInstance() throws {
+        let persistentStorage = PersistentStorage(storagePrefix: "excluded-from-backup-once-instance-\(UUID().uuidString)", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+
+        let storageUrl = persistentStorage.getEventsStorageDirectory(createDirectory: true)
+        var resourceValues = try storageUrl.resourceValues(forKeys: [.isExcludedFromBackupKey])
+        XCTAssertEqual(resourceValues.isExcludedFromBackup, true)
+
+        var mutableStorageUrl = storageUrl
+        resourceValues.isExcludedFromBackup = false
+        try mutableStorageUrl.setResourceValues(resourceValues)
+
+        _ = persistentStorage.getEventsStorageDirectory(createDirectory: true)
+        let updatedResourceValues = try storageUrl.resourceValues(forKeys: [.isExcludedFromBackupKey])
+
+        XCTAssertEqual(updatedResourceValues.isExcludedFromBackup, false)
+        persistentStorage.reset()
+    }
+
+    func testMigratesLegacyEventFilesToCurrentStorageDirectory() {
+        let storagePrefix = "legacy-directory-instance"
+        let persistentStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+
+        let storageDirectory = persistentStorage.getEventsStorageDirectory(createDirectory: false)
+        let legacyStorageDirectory = persistentStorage.getLegacyEventsStorageDirectory(createDirectory: true)
+        let legacyFile = legacyStorageDirectory.appendingPathComponent("\(PersistentStorage.STORAGE_V2_PREFIX)0")
+        writeContent(file: legacyFile, content: "\(BaseEvent(eventType: "legacy-event").toString())\(PersistentStorage.DELMITER)")
+
+        let migratedStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        let eventFiles: [URL]? = migratedStorage.read(key: StorageKey.EVENTS)
+        let migratedFile = storageDirectory.appendingPathComponent(legacyFile.lastPathComponent)
+        XCTAssertEqual(eventFiles?.count, 1)
+        XCTAssertEqual(eventFiles?.first, migratedFile)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyStorageDirectory.path))
+
+        let eventString = migratedStorage.getEventsString(eventBlock: migratedFile)
+        let decodedEvents = BaseEvent.fromArrayString(jsonString: eventString ?? "")
+        XCTAssertEqual(decodedEvents?.count, 1)
+        XCTAssertEqual(decodedEvents?.first?.eventType, "legacy-event")
+
+        migratedStorage.reset()
+    }
+
+    func testQuarantinesLegacyUnreadableEventFilesInCurrentStorageDirectory() throws {
+        let storagePrefix = "legacy-quarantine-directory-instance"
+        let persistentStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+
+        let storageDirectory = persistentStorage.getEventsStorageDirectory(createDirectory: false)
+        let legacyStorageDirectory = persistentStorage.getLegacyEventsStorageDirectory(createDirectory: true)
+        let legacyFile = legacyStorageDirectory.appendingPathComponent("\(PersistentStorage.STORAGE_V2_PREFIX)0")
+        let invalidUTF8 = Data([0xFF, 0xFE, 0xFD, 0xFC, 0xC0, 0xC1, 0xF5])
+        try invalidUTF8.write(to: legacyFile)
+
+        let migratedStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        let eventFiles = try XCTUnwrap(migratedStorage.read(key: StorageKey.EVENTS) as [URL]?)
+        XCTAssertEqual(eventFiles.count, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyFile.path))
+
+        let result = migratedStorage.getEventsString(eventBlock: eventFiles[0])
+        XCTAssertNil(result)
+
+        let currentQuarantineDir = storageDirectory.appendingPathComponent(PersistentStorage.QUARANTINE_DIR_NAME)
+        let legacyQuarantineDir = legacyStorageDirectory.appendingPathComponent(PersistentStorage.QUARANTINE_DIR_NAME)
+        let quarantined = (try? FileManager.default.contentsOfDirectory(atPath: currentQuarantineDir.path)) ?? []
+        XCTAssertEqual(quarantined.count, 1)
+        XCTAssertTrue(quarantined[0].hasPrefix("\(eventFiles[0].lastPathComponent)."))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyQuarantineDir.path))
+
+        migratedStorage.reset()
+    }
+
+    func testRemovesLegacyQuarantineDirectoryDuringMigration() throws {
+        let storagePrefix = "legacy-remove-quarantine-directory-instance-\(UUID().uuidString)"
+        let persistentStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+
+        let legacyStorageDirectory = persistentStorage.getLegacyEventsStorageDirectory(createDirectory: true)
+        let legacyFile = legacyStorageDirectory.appendingPathComponent("\(PersistentStorage.STORAGE_V2_PREFIX)0")
+        let legacyQuarantineDirectory = legacyStorageDirectory.appendingPathComponent(PersistentStorage.QUARANTINE_DIR_NAME)
+        try FileManager.default.createDirectory(at: legacyQuarantineDirectory, withIntermediateDirectories: true)
+        writeContent(file: legacyFile, content: "\(BaseEvent(eventType: "legacy-event").toString())\(PersistentStorage.DELMITER)")
+        writeContent(file: legacyQuarantineDirectory.appendingPathComponent("quarantined-event"), content: "unreadable")
+
+        let migratedStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        let eventFiles: [URL]? = migratedStorage.read(key: StorageKey.EVENTS)
+
+        XCTAssertEqual(eventFiles?.count, 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyQuarantineDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyStorageDirectory.path))
+
+        migratedStorage.reset()
+    }
+
+    func testRemovesLegacyQuarantineDirectoryWithoutLegacyEventFiles() throws {
+        let storagePrefix = "legacy-remove-only-quarantine-directory-instance-\(UUID().uuidString)"
+        let persistentStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+
+        let legacyStorageDirectory = persistentStorage.getLegacyEventsStorageDirectory(createDirectory: true)
+        let legacyQuarantineDirectory = legacyStorageDirectory.appendingPathComponent(PersistentStorage.QUARANTINE_DIR_NAME)
+        try FileManager.default.createDirectory(at: legacyQuarantineDirectory, withIntermediateDirectories: true)
+        writeContent(file: legacyQuarantineDirectory.appendingPathComponent("quarantined-event"), content: "unreadable")
+
+        let migratedStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        let eventFiles: [URL]? = migratedStorage.read(key: StorageKey.EVENTS)
+
+        XCTAssertTrue(eventFiles?.isEmpty ?? false)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyQuarantineDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyStorageDirectory.path))
+
+        migratedStorage.reset()
+    }
+
+    func testMigratesLegacyUnfinishedEventFilesToCurrentStorageDirectory() {
+        let storagePrefix = "legacy-unfinished-directory-instance"
+        let persistentStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+
+        let storageDirectory = persistentStorage.getEventsStorageDirectory(createDirectory: false)
+        let legacyStorageDirectory = persistentStorage.getLegacyEventsStorageDirectory(createDirectory: true)
+        let legacyTempFile = legacyStorageDirectory.appendingPathComponent("\(PersistentStorage.STORAGE_V2_PREFIX)0").appendingPathExtension(PersistentStorage.TEMP_FILE_EXTENSION)
+        writeContent(file: legacyTempFile, content: "\(BaseEvent(eventType: "legacy-unfinished-event").toString())\(PersistentStorage.DELMITER)")
+
+        let migratedStorage = PersistentStorage(storagePrefix: storagePrefix, logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        let eventFiles: [URL]? = migratedStorage.read(key: StorageKey.EVENTS)
+        let migratedFile = storageDirectory.appendingPathComponent(legacyTempFile.deletingPathExtension().lastPathComponent)
+        XCTAssertEqual(eventFiles?.count, 1)
+        XCTAssertEqual(eventFiles?.first, migratedFile)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyTempFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyStorageDirectory.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: migratedFile.path))
+
+        let eventString = migratedStorage.getEventsString(eventBlock: migratedFile)
+        let decodedEvents = BaseEvent.fromArrayString(jsonString: eventString ?? "")
+        XCTAssertEqual(decodedEvents?.count, 1)
+        XCTAssertEqual(decodedEvents?.first?.eventType, "legacy-unfinished-event")
+
+        migratedStorage.reset()
+    }
+
+    func testDoesNotFinalizeStaleUnfinishedEventFilesFromCurrentStorageDirectory() {
+        let persistentStorage = PersistentStorage(storagePrefix: "current-unfinished-directory-instance", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+
+        let storageDirectory = persistentStorage.getEventsStorageDirectory(createDirectory: true)
+        let tempFile = storageDirectory.appendingPathComponent("\(PersistentStorage.STORAGE_V2_PREFIX)0").appendingPathExtension(PersistentStorage.TEMP_FILE_EXTENSION)
+        writeContent(file: tempFile, content: "\(BaseEvent(eventType: "current-unfinished-event").toString())\(PersistentStorage.DELMITER)")
+
+        let eventFiles: [URL]? = persistentStorage.read(key: StorageKey.EVENTS)
+        XCTAssertTrue(eventFiles?.isEmpty ?? false)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempFile.path))
+
+        persistentStorage.reset()
+    }
+
     #if os(macOS)
     func testMacOsStorageDirectorySandboxedWhenAppSandboxDisabled() {
         let persistentStorage = PersistentStorage(storagePrefix: "mac-instance", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Moves event storage location to `Application Support`.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk location and lifecycle of persisted analytics event files, adding a one-time migration path; mistakes here could lead to lost/duplicated events or stuck flushes.
> 
> **Overview**
> **Event file storage now defaults to `Application Support`** (instead of the prior per-platform Documents/Caches path) and marks the created directory as *excluded from backups* (cached once per `PersistentStorage` instance).
> 
> Adds a **startup migration** (`migrateLegacyStorageDirectories`) that moves legacy event files (including unfinished `.tmp` files) into the new storage directory, removes any legacy `.quarantine` folder, and cleans up the legacy directory when empty; `reset()` now also clears the backup-exclusion flag.
> 
> Expands tests to cover the new storage location, backup exclusion behavior, and legacy directory migration/quarantine cleanup scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c3ca5096b55f444d240741c915e37c39350c4e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->