### PR TITLE
fix: update AmplitudeCore min version

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -1457,7 +1457,7 @@
 			repositoryURL = "https://github.com/amplitude/AmplitudeCore-Swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.4.1;
+				minimumVersion = 1.4.2;
 			};
 		};
 		4EB530762CD2EB9700E961F4 /* XCRemoteSwiftPackageReference "analytics-connector-ios" */ = {

--- a/Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amplitude/AmplitudeCore-Swift",
       "state" : {
-        "revision" : "b84eda8fcacb034d161f8dd565f39c7df006b7c6",
-        "version" : "1.4.1"
+        "revision" : "1d3bdbdac54494650728b8fee297c0fa5298e969",
+        "version" : "1.4.2"
       }
     },
     {

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.visionos.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   s.dependency 'AnalyticsConnector', '~> 1.3.0'
-  s.dependency 'AmplitudeCore', '>=1.4.1', '<2.0.0'
+  s.dependency 'AmplitudeCore', '>=1.4.2', '<2.0.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "amplitude/analytics-connector-ios" ~> 1.3.0
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.4.1
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.4.2

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.1"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.2"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.1"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Updates min version of Core to one without compatibility issues

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency bump only; behavior changes are limited to whatever changed upstream in `AmplitudeCore` 1.4.2 and may affect builds/integration if there are new regressions.
> 
> **Overview**
> Updates the **minimum required `AmplitudeCore` version** from `1.4.1` to `1.4.2` across all supported distribution mechanisms (SwiftPM `Package.swift`/`Package@swift-5.9.swift`, CocoaPods `AmplitudeSwift.podspec`, Carthage `Cartfile`, and the Xcode project SwiftPM reference).
> 
> Refreshes SwiftPM resolution (`Package.resolved`) to pin `AmplitudeCore-Swift` at `1.4.2` (new revision hash).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eddd81f7e6eeeead66fbaa7054dc85753a2d7ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->