### PR TITLE
fix: dedup frustration interactions

### DIFF
--- a/Sources/Amplitude/Plugins/iOS/FrustrationInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/FrustrationInteractions.swift
@@ -10,7 +10,7 @@ import UIKit
 import AmplitudeCore
 
 struct FrustrationClickData {
-    let time: Date
+    let time: Date = Date()
     let eventData: UIKitElementInteractions.EventData
     let location: CGPoint
     let action: String
@@ -182,7 +182,10 @@ class RageClickDetector {
 
             debounceTimer?.invalidate()
             debounceTimer = Timer.scheduledTimer(withTimeInterval: timeoutInterval, repeats: false) { [weak self] _ in
-                self?.triggerRageClick()
+                guard let self else { return }
+                lock.withLock {
+                    self.triggerRageClick()
+                }
             }
         }
     }

--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -132,37 +132,84 @@ class UIKitElementInteractions {
         }
     }
 
-    fileprivate static func processFrustrationInteractionForView(_ view: UIView,
-                                                                 location: CGPoint,
-                                                                 action: String,
-                                                                 source: EventData.Source?,
-                                                                 sourceName: String?) {
-        let clickData = FrustrationClickData(
-            time: Date(),
-            eventData: view.eventData,
-            location: location,
-            action: action,
-            source: source,
-            sourceName: sourceName
-        )
+    private static let physicalTapDedupDistanceThreshold: CGFloat = 12
+    private static var physicalTapDedupCandidates: [PhysicalTapDedupCandidate] = []
+    private static var physicalTapDedupClearWorkItem: DispatchWorkItem?
 
+    private final class PhysicalTapDedupCandidate {
+        weak var window: UIWindow?
+        let location: CGPoint
+
+        init(view: UIView, location: CGPoint) {
+            self.window = view.window
+            self.location = location
+        }
+    }
+
+    fileprivate static func processFrustrationInteractionForView(_ view: UIView,
+                                                                 clickData: FrustrationClickData,
+                                                                 includeRageClick: Bool,
+                                                                 includeDeadClick: Bool) {
         lock.withLock {
+            guard !isDuplicatePhysicalTap(view: view, location: clickData.location) else {
+                return
+            }
+
             for amplitude in amplitudeInstances.allObjects {
                 let identifier = ObjectIdentifier(amplitude)
 
                 // Check if rage click detector exists (enabled via remote config or local config)
-                if let rageClickDetector = rageClickDetectors[identifier],
-                   !view.amp_ignoreRageClick {
+                if includeRageClick, let rageClickDetector = rageClickDetectors[identifier] {
                     rageClickDetector.processClick(clickData)
                 }
 
                 // Check if dead click detector exists (enabled via remote config or local config)
-                if let deadClickDetector = deadClickDetectors[identifier],
-                   !view.amp_ignoreDeadClick {
+                if includeDeadClick, let deadClickDetector = deadClickDetectors[identifier] {
                     deadClickDetector.processClick(clickData)
                 }
             }
         }
+    }
+
+    private static func isDuplicatePhysicalTap(view: UIView, location: CGPoint) -> Bool {
+        physicalTapDedupCandidates.removeAll { $0.window == nil }
+
+        let duplicate = physicalTapDedupCandidates.contains { candidate in
+            guard isWithinPhysicalTapDedupDistance(candidate.location, location) else {
+                return false
+            }
+
+            return isSameWindow(candidate.window, view.window)
+        }
+
+        if !duplicate {
+            physicalTapDedupCandidates.append(PhysicalTapDedupCandidate(view: view, location: location))
+        }
+        schedulePhysicalTapDedupClearIfNeeded()
+
+        return duplicate
+    }
+
+    private static func schedulePhysicalTapDedupClearIfNeeded() {
+        guard physicalTapDedupClearWorkItem == nil else { return }
+
+        let workItem = DispatchWorkItem {
+            lock.withLock {
+                physicalTapDedupCandidates.removeAll()
+                physicalTapDedupClearWorkItem = nil
+            }
+        }
+        physicalTapDedupClearWorkItem = workItem
+        DispatchQueue.main.async(execute: workItem)
+    }
+
+    private static func isWithinPhysicalTapDedupDistance(_ point1: CGPoint, _ point2: CGPoint) -> Bool {
+        return hypot(point1.x - point2.x, point1.y - point2.y) <= physicalTapDedupDistanceThreshold
+    }
+
+    private static func isSameWindow(_ window1: UIWindow?, _ window2: UIWindow?) -> Bool {
+        guard let window1, let window2 else { return false }
+        return window1 === window2
     }
 }
 
@@ -201,7 +248,10 @@ extension UIApplication {
             }
         }
 
-        if actionEvent == "touch", !control.amp_ignoreRageClick || !control.amp_ignoreDeadClick {
+        let shouldProcessRageClick = !control.amp_ignoreRageClick
+        let shouldProcessDeadClick = !control.amp_ignoreDeadClick
+
+        if actionEvent == "touch", shouldProcessRageClick || shouldProcessDeadClick {
             var location = CGPoint.zero
 
             if let event = event, let touch = event.allTouches?.first {
@@ -220,7 +270,20 @@ extension UIApplication {
                 }
             }
 
-            UIKitElementInteractions.processFrustrationInteractionForView(control, location: location, action: actionEvent, source: .actionMethod, sourceName: NSStringFromSelector(action))
+            let clickData = FrustrationClickData(
+                eventData: control.eventData,
+                location: location,
+                action: actionEvent,
+                source: .actionMethod,
+                sourceName: NSStringFromSelector(action)
+            )
+
+            UIKitElementInteractions.processFrustrationInteractionForView(
+                control,
+                clickData: clickData,
+                includeRageClick: shouldProcessRageClick,
+                includeDeadClick: shouldProcessDeadClick
+            )
         }
 
         return sendActionResult
@@ -246,10 +309,16 @@ extension UIGestureRecognizer {
 #endif
         }
 
+        var isTap = false
         let gestureAction: String?
         switch self {
-        case is UITapGestureRecognizer:
+        case let tapGestureRecognizer as UITapGestureRecognizer:
             gestureAction = "tap"
+#if !os(tvOS)
+            isTap = tapGestureRecognizer.numberOfTapsRequired == 1 && tapGestureRecognizer.numberOfTouchesRequired == 1
+#else
+            isTap = tapGestureRecognizer.numberOfTapsRequired == 1
+#endif
         case is UISwipeGestureRecognizer:
             gestureAction = "swipe"
         case is UIPanGestureRecognizer:
@@ -286,9 +355,23 @@ extension UIGestureRecognizer {
             }
         }
 
-        if !view.amp_ignoreDeadClick || !view.amp_ignoreRageClick {
-            let location = self.location(in: nil)
-            UIKitElementInteractions.processFrustrationInteractionForView(view, location: location, action: gestureAction, source: .gestureRecognizer, sourceName: descriptiveTypeName)
+        let shouldProcessRageClick = !view.amp_ignoreRageClick
+        let shouldProcessDeadClick = !view.amp_ignoreDeadClick
+
+        if isTap, shouldProcessDeadClick || shouldProcessRageClick {
+            let clickData = FrustrationClickData(
+                eventData: view.eventData,
+                location: location(in: nil),
+                action: gestureAction,
+                source: .gestureRecognizer,
+                sourceName: descriptiveTypeName)
+
+            UIKitElementInteractions.processFrustrationInteractionForView(
+                view,
+                clickData: clickData,
+                includeRageClick: shouldProcessRageClick,
+                includeDeadClick: shouldProcessDeadClick
+            )
         }
     }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Views with multiple gesture recognizers that fire simultaneously (WKContentView as part of WKWebview, for instance) can trigger rage clicks with a single click as each gesture recognizer will be counted.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core autocapture event triggering and introduces tap deduplication logic that could suppress legitimate rage/dead-click events if the heuristic misfires.
> 
> **Overview**
> Prevents multiple simultaneous gesture recognizers (e.g., in `WKWebView`) from generating multiple rage/dead-click inputs for a single physical tap by adding a per-window, same-tick tap deduplication step in `UIKitElementInteractions`.
> 
> Refactors frustration interaction processing to build a single `FrustrationClickData` instance and pass explicit `includeRageClick`/`includeDeadClick` flags, and limits gesture-based frustration processing to *single-finger, single-tap* recognizers only. Also tightens thread-safety around the rage-click debounce timer by acquiring the detector lock before triggering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25866c9c62025c92ff4b8f9ce0627a5310cf8e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->