### PR TITLE
fix: update AmplitudeCore to 1.4.6 to fix libswiftCore notarization error

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -1166,7 +1166,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
@@ -1204,7 +1203,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
@@ -1354,7 +1352,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
@@ -1391,7 +1388,6 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";

--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -1164,9 +1164,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1201,9 +1199,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1350,9 +1346,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1386,9 +1380,7 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1453,7 +1445,7 @@
 			repositoryURL = "https://github.com/amplitude/AmplitudeCore-Swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.4.2;
+				minimumVersion = 1.4.6;
 			};
 		};
 		4EB530762CD2EB9700E961F4 /* XCRemoteSwiftPackageReference "analytics-connector-ios" */ = {

--- a/Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Amplitude-Swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/amplitude/AmplitudeCore-Swift",
       "state" : {
-        "revision" : "1d3bdbdac54494650728b8fee297c0fa5298e969",
-        "version" : "1.4.2"
+        "revision" : "9b951efa8f1f83a5a3c3a981537d3ff752d9d1fb",
+        "version" : "1.4.6"
       }
     },
     {

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.visionos.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
   s.dependency 'AnalyticsConnector', '~> 1.3.0'
-  s.dependency 'AmplitudeCore', '>=1.4.2', '<2.0.0'
+  s.dependency 'AmplitudeCore', '>=1.4.6', '<2.0.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "amplitude/analytics-connector-ios" ~> 1.3.0
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.4.2
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.4.6

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.2"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.6"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -21,7 +21,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.2"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.6"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Fixes the `libswiftCore.dylib` notarization failure that quarantined host apps embedding the SDK (e.g. Camtasia on macOS 15). Two parts:

1. **Bump AmplitudeCore to 1.4.6** — the reported failure is in `AmplitudeCore.framework`; 1.4.6 ships that binary with the Xcode toolchain rpath removed (amplitude/AmplitudeCore-Swift#81). This delivers the fix to SPM / CocoaPods / Carthage consumers.
2. **Remove the same rpath from `Amplitude-Swift.xcodeproj`** — companion hygiene for the Carthage `AmplitudeSwift.xcframework`.

## Root cause
Shipped binaries carried `LD_RUNPATH_SEARCH_PATHS = ($(inherited), $(TOOLCHAIN_DIR)/usr/lib/swift/macosx)`, baking the build host's Xcode path (e.g. `/Applications/Xcode_16.3.app/…`). On the x86_64 macOS slice (libswiftCore loaded via `@rpath`), Apple's notary service resolves `@rpath/libswiftCore.dylib` against the dead toolchain path → Fatal "Bad Load Command". Full analysis + fix in amplitude/AmplitudeCore-Swift#81.

## Changes
- `Package.swift`, `Package@swift-5.9.swift`: AmplitudeCore `from: "1.4.6"`
- `AmplitudeSwift.podspec`: `'AmplitudeCore', '>=1.4.6', '<2.0.0'`
- `Cartfile`: `AmplitudeCore.json ~> 1.4.6`
- `Amplitude-Swift.xcodeproj`: drop `$(TOOLCHAIN_DIR)/usr/lib/swift/macosx` from the 4 framework configs (test target's `@loader_path` rpaths untouched)

Fixes #405 · Linear: SDKI-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect shipped macOS binaries and all integration paths, but scope is limited to dependency version and linker rpaths with no runtime logic changes.
> 
> **Overview**
> Addresses **macOS notarization failures** (e.g. `libswiftCore.dylib` / bad load commands) by shipping dependency and build settings that no longer bake in the build host’s Xcode Swift toolchain path.
> 
> **AmplitudeCore is raised from 1.4.2 to 1.4.6** everywhere consumers resolve it: `Package.swift`, `Package@swift-5.9.swift`, `AmplitudeSwift.podspec`, `Cartfile`, the Xcode SPM package reference, and `Package.resolved`.
> 
> In **`Amplitude-Swift.xcodeproj`**, **`LD_RUNPATH_SEARCH_PATHS`** for the main framework targets (Debug/Release for both UIKit and NoUIKit variants) is simplified from `$(inherited)` plus **`$(TOOLCHAIN_DIR)/usr/lib/swift/macosx`** to **`$(inherited)` only**, so Carthage/xcframework builds match the AmplitudeCore fix. Test target `@loader_path` rpaths are unchanged.
> 
> No SDK Swift source changes—dependency and linker packaging only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e642d308b623dd41eb00608edfb1daaf848d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->