### PR TITLE
fix: increase tap dedup timeout

### DIFF
--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -133,16 +133,18 @@ class UIKitElementInteractions {
     }
 
     private static let physicalTapDedupDistanceThreshold: CGFloat = 12
+    private static let physicalTapDedupTimeThreshold: TimeInterval = 0.005
     private static var physicalTapDedupCandidates: [PhysicalTapDedupCandidate] = []
-    private static var physicalTapDedupClearWorkItem: DispatchWorkItem?
 
     private final class PhysicalTapDedupCandidate {
         weak var window: UIWindow?
         let location: CGPoint
+        let timestamp: TimeInterval
 
-        init(view: UIView, location: CGPoint) {
+        init(view: UIView, location: CGPoint, timestamp: TimeInterval) {
             self.window = view.window
             self.location = location
+            self.timestamp = timestamp
         }
     }
 
@@ -171,8 +173,12 @@ class UIKitElementInteractions {
         }
     }
 
-    private static func isDuplicatePhysicalTap(view: UIView, location: CGPoint) -> Bool {
-        physicalTapDedupCandidates.removeAll { $0.window == nil }
+    static func isDuplicatePhysicalTap(view: UIView,
+                                       location: CGPoint,
+                                       timestamp: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Bool {
+        physicalTapDedupCandidates.removeAll { candidate in
+            candidate.window == nil || timestamp - candidate.timestamp > physicalTapDedupTimeThreshold
+        }
 
         let duplicate = physicalTapDedupCandidates.contains { candidate in
             guard isWithinPhysicalTapDedupDistance(candidate.location, location) else {
@@ -183,24 +189,10 @@ class UIKitElementInteractions {
         }
 
         if !duplicate {
-            physicalTapDedupCandidates.append(PhysicalTapDedupCandidate(view: view, location: location))
+            physicalTapDedupCandidates.append(PhysicalTapDedupCandidate(view: view, location: location, timestamp: timestamp))
         }
-        schedulePhysicalTapDedupClearIfNeeded()
 
         return duplicate
-    }
-
-    private static func schedulePhysicalTapDedupClearIfNeeded() {
-        guard physicalTapDedupClearWorkItem == nil else { return }
-
-        let workItem = DispatchWorkItem {
-            lock.withLock {
-                physicalTapDedupCandidates.removeAll()
-                physicalTapDedupClearWorkItem = nil
-            }
-        }
-        physicalTapDedupClearWorkItem = workItem
-        DispatchQueue.main.async(execute: workItem)
     }
 
     private static func isWithinPhysicalTapDedupDistance(_ point1: CGPoint, _ point2: CGPoint) -> Bool {
@@ -210,6 +202,10 @@ class UIKitElementInteractions {
     private static func isSameWindow(_ window1: UIWindow?, _ window2: UIWindow?) -> Bool {
         guard let window1, let window2 else { return false }
         return window1 === window2
+    }
+
+    static func resetPhysicalTapDedupCandidates() {
+        physicalTapDedupCandidates.removeAll()
     }
 }
 

--- a/Tests/AmplitudeTests/Plugins/UIKitUserInteractionPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/UIKitUserInteractionPluginTest.swift
@@ -5,6 +5,16 @@ import XCTest
 #if os(iOS)
 
 class UIKitElementInteractionsTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UIKitElementInteractions.resetPhysicalTapDedupCandidates()
+    }
+
+    override func tearDown() {
+        UIKitElementInteractions.resetPhysicalTapDedupCandidates()
+        super.tearDown()
+    }
+
     func testExtractDataForUIButton() {
         let mockVC = UIViewController()
         mockVC.title = "Mock VC Title"
@@ -59,6 +69,40 @@ class UIKitElementInteractionsTests: XCTestCase {
 
         class ConstrainedGenericView<T: UIView>: UIView {}
         XCTAssertEqual(ConstrainedGenericView<UIButton>().descriptiveTypeName, "ConstrainedGenericView<UIButton>")
+    }
+
+    func testPhysicalTapDedupSuppressesDuplicateWithinFiveMilliseconds() {
+        let window = UIWindow()
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        window.addSubview(view)
+
+        XCTAssertFalse(UIKitElementInteractions.isDuplicatePhysicalTap(
+            view: view,
+            location: CGPoint(x: 20, y: 20),
+            timestamp: 100
+        ))
+        XCTAssertTrue(UIKitElementInteractions.isDuplicatePhysicalTap(
+            view: view,
+            location: CGPoint(x: 25, y: 25),
+            timestamp: 100.0049
+        ))
+    }
+
+    func testPhysicalTapDedupAllowsSameLocationAfterFiveMilliseconds() {
+        let window = UIWindow()
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        window.addSubview(view)
+
+        XCTAssertFalse(UIKitElementInteractions.isDuplicatePhysicalTap(
+            view: view,
+            location: CGPoint(x: 20, y: 20),
+            timestamp: 100
+        ))
+        XCTAssertFalse(UIKitElementInteractions.isDuplicatePhysicalTap(
+            view: view,
+            location: CGPoint(x: 20, y: 20),
+            timestamp: 100.0051
+        ))
     }
 }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Changes tap dedup from one runloop cycle to 5ms to further improve gesture recognizer dedup.

@sojingle I was way off on my estimates, I think limiting this to tap gestures filtered out some of the longer callbacks we were seeing.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows dedup timing for autocaptured frustration clicks only; production still uses system uptime and could slightly change which duplicate control/gesture events are filtered.
> 
> **Overview**
> **Physical tap deduplication** for rage/dead click frustration tracking no longer clears candidates on the next main runloop. Candidates now carry a **timestamp**, and entries older than **5ms** are dropped when checking for duplicates; nearby taps in the same window within that interval are still treated as one physical tap.
> 
> The previous **`DispatchWorkItem`** that wiped the whole candidate list asynchronously is removed. **`isDuplicatePhysicalTap`** is test-visible (optional **`timestamp`**, default **`systemUptime`**) and **`resetPhysicalTapDedupCandidates()`** resets state in unit tests, with coverage for suppress-within-5ms vs allow-after-5ms behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31e1cf94aff6c6f8c9c60462c12d14c3851408b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->