### PR TITLE
Raise minimum iOS deployment target to 15

### DIFF
--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.9'
 
-  s.ios.deployment_target  = '13.0'
+  s.ios.deployment_target  = '15.0'
   s.ios.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
   s.ios.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Amplitude-Swift",
     platforms: [
         .macOS("10.15"),
-        .iOS("13.0"),
+        .iOS("15.0"),
         .tvOS("13.0"),
         .watchOS("7.0"),
     ],

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Amplitude-Swift",
     platforms: [
         .macOS("10.15"),
-        .iOS("13.0"),
+        .iOS("15.0"),
         .tvOS("13.0"),
         .watchOS("7.0"),
         .visionOS("1.0"),


### PR DESCRIPTION
Resolves #409.

Xcode 27 beta no longer supports iOS deployment targets below **iOS 15**. The current iOS 13 floor emits a `the iOS deployment target ... is set to 13.0, but the range of supported deployment target versions is 15.0 to ...` warning when building under Xcode 27.

### Changes
- `Package.swift`: `.iOS("13.0")` → `.iOS("15.0")`
- `Package@swift-5.9.swift`: `.iOS("13.0")` → `.iOS("15.0")` — this is the manifest SPM selects on modern toolchains, so it must be bumped too
- `AmplitudeSwift.podspec`: `s.ios.deployment_target` `13.0` → `15.0`

macOS / tvOS / watchOS / visionOS targets are unchanged.

### Verification
Built the `Amplitude-Swift` product clean against the **iOS 27 SDK (Xcode 27.0 beta, 27A5194q)** for `generic/platform=iOS Simulator` — `** BUILD SUCCEEDED **`, no deployment-target warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for apps that must support iOS 13–14 when upgrading the SDK; no runtime logic changes, only packaging constraints.
> 
> **Overview**
> Raises the **minimum supported iOS version from 13 to 15** across Swift Package Manager (`Package.swift`, `Package@swift-5.9.swift`) and CocoaPods (`AmplitudeSwift.podspec`). **macOS, tvOS, watchOS, and visionOS floors are unchanged.**
> 
> This aligns the SDK with **Xcode 27**, which no longer accepts iOS deployment targets below 15 and was producing build warnings at iOS 13. There are **no Swift source or API changes**—only declared platform requirements for integrators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c2afbb1b6bdc5b22eec395789645c3faafc0daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->