### PR TITLE
feat: raise minimum iOS deployment target to 15.0

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -1163,7 +1163,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
@@ -1198,7 +1198,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
@@ -1234,7 +1234,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../Frameworks",
@@ -1265,7 +1265,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../Frameworks",
@@ -1345,7 +1345,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
@@ -1379,7 +1379,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
 
   s.swift_version = '5.9'
 
-  s.ios.deployment_target  = '13.0'
+  s.ios.deployment_target  = '15.0'
   s.ios.source_files       = 'Sources/Amplitude/**/*.{h,swift}'
   s.ios.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Amplitude-Swift",
     platforms: [
         .macOS("10.15"),
-        .iOS("13.0"),
+        .iOS("15.0"),
         .tvOS("13.0"),
         .watchOS("7.0"),
     ],


### PR DESCRIPTION
## Why

Closes amplitude/Amplitude-Swift#409.

Xcode 27 no longer supports iOS deployment targets below 15.0 and emits "The iOS deployment target X.0 is set, but the range of supported deployment target versions is 15.0 to …" warnings on every build against \`Amplitude-Swift\`. The reporter is hitting this on Xcode 27 beta.

## What

Bumps the iOS floor across all three integration paths:

<!-- linear:table-colwidths:266,266,266 -->
| File | From | To |
| -- | -- | -- |
| \`Package.swift\` | \`.iOS("13.0")\` | \`.iOS("15.0")\` |
| \`AmplitudeSwift.podspec\` | \`s.ios.deployment_target = '13.0'\` | \`'15.0'\` |
| \`Amplitude-Swift.xcodeproj\` | \`IPHONEOS_DEPLOYMENT_TARGET = 13.0\` (and 14.0 in the test target) | \`15.0\` everywhere |

Other platforms (\`macOS 10.15\`, \`tvOS 13.0\`, \`watchOS 7.0\`) are unaffected — Xcode 27 still supports them.

## Build

\`swift build\` → clean.

## Compat note

This is a deployment-target bump only; no source uses iOS-15-exclusive APIs newly. Pre-existing \`@available(iOS 14.0, \*)\` checks (e.g. \`UIKitElementInteractions.swift:402\`) become statically true and can be cleaned up in a follow-up — left untouched here to keep the diff minimal and reviewable.

---

> \[!NOTE\]<br>**Medium Risk**<br>Semver-relevant platform floor increase drops iOS 13–14 consumers, but there is no change to analytics, auth, or runtime SDK logic.
>
> **Overview**<br>Raises the **minimum supported iOS version from 13.0 to 15.0** (and aligns the test target from 14.0 to 15.0) so builds on Xcode 27 stop warning about unsupported deployment targets. The change is **metadata only**—no SDK source changes.
>
> It is applied consistently across **Swift Package Manager** (`Package.swift` `.iOS("15.0")`), **CocoaPods** (`AmplitudeSwift.podspec` `s.ios.deployment_target`), and **Xcode** (`IPHONEOS_DEPLOYMENT_TARGET` on Amplitude-Swift, Amplitude-Swift-NoUIKit, and Amplitude-SwiftTests). **macOS, tvOS, watchOS, and visionOS** floors are unchanged.
>
> **Consumer impact:** Apps that still target iOS 13–14 must bump their deployment target to adopt this SDK version; runtime behavior of the library is not altered by this PR alone.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit f619ad90e1d2d60c7571d43a2804461dd6005e31. Bugbot is set up for automated code reviews on this repo. Configure [here](<https://www.cursor.com/dashboard/bugbot>).