### PR TITLE
chore: support building with Xcode 27

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -1164,8 +1164,11 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos27*]" = 15.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator27*]" = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				"MACOSX_DEPLOYMENT_TARGET[sdk=macosx27*]" = 12.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "Amplitude-Swift";
@@ -1177,7 +1180,11 @@
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
 				TARGET_NAME = AmplitudeSwiftNoUIKit;
 				TVOS_DEPLOYMENT_TARGET = 13.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvos27*]" = 15.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvsimulator27*]" = 15.0;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchos27*]" = 9.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchsimulator27*]" = 9.0;
 				XROS_DEPLOYMENT_TARGET = 1.3;
 			};
 			name = Debug;
@@ -1199,8 +1206,11 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos27*]" = 15.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator27*]" = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				"MACOSX_DEPLOYMENT_TARGET[sdk=macosx27*]" = 12.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "Amplitude-Swift";
@@ -1212,7 +1222,11 @@
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
 				TARGET_NAME = AmplitudeSwiftNoUIKit;
 				TVOS_DEPLOYMENT_TARGET = 13.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvos27*]" = 15.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvsimulator27*]" = 15.0;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchos27*]" = 9.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchsimulator27*]" = 9.0;
 				XROS_DEPLOYMENT_TARGET = 1.3;
 			};
 			name = Release;
@@ -1235,12 +1249,15 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos27*]" = 15.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator27*]" = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				"MACOSX_DEPLOYMENT_TARGET[sdk=macosx27*]" = 12.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1248,7 +1265,11 @@
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = "Amplitude-SwiftTests";
 				TVOS_DEPLOYMENT_TARGET = 14.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvos27*]" = 15.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvsimulator27*]" = 15.0;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchos27*]" = 9.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchsimulator27*]" = 9.0;
 			};
 			name = Debug;
 		};
@@ -1266,12 +1287,15 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos27*]" = 15.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator27*]" = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				"MACOSX_DEPLOYMENT_TARGET[sdk=macosx27*]" = 12.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -1279,7 +1303,11 @@
 				SWIFT_VERSION = 5.0;
 				TARGET_NAME = "Amplitude-SwiftTests";
 				TVOS_DEPLOYMENT_TARGET = 14.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvos27*]" = 15.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvsimulator27*]" = 15.0;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchos27*]" = 9.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchsimulator27*]" = 9.0;
 			};
 			name = Release;
 		};
@@ -1298,6 +1326,7 @@
 					"DEBUG=1",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				"MACOSX_DEPLOYMENT_TARGET[sdk=macosx27*]" = 12.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1319,6 +1348,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_OPTIMIZATION_LEVEL = s;
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				"MACOSX_DEPLOYMENT_TARGET[sdk=macosx27*]" = 12.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DXcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1346,8 +1376,11 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos27*]" = 15.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator27*]" = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				"MACOSX_DEPLOYMENT_TARGET[sdk=macosx27*]" = 12.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "Amplitude-Swift";
@@ -1359,7 +1392,11 @@
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
 				TARGET_NAME = AmplitudeSwift;
 				TVOS_DEPLOYMENT_TARGET = 13.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvos27*]" = 15.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvsimulator27*]" = 15.0;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchos27*]" = 9.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchsimulator27*]" = 9.0;
 				XROS_DEPLOYMENT_TARGET = 1.3;
 			};
 			name = Debug;
@@ -1380,8 +1417,11 @@
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "Amplitude-Swift.xcodeproj/Amplitude_Swift_Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos27*]" = 15.0;
+				"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphonesimulator27*]" = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				"MACOSX_DEPLOYMENT_TARGET[sdk=macosx27*]" = 12.0;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = "Amplitude-Swift";
@@ -1393,7 +1433,11 @@
 				TARGETED_DEVICE_FAMILY = "1,2,3,4,6,7";
 				TARGET_NAME = AmplitudeSwift;
 				TVOS_DEPLOYMENT_TARGET = 13.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvos27*]" = 15.0;
+				"TVOS_DEPLOYMENT_TARGET[sdk=appletvsimulator27*]" = 15.0;
 				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchos27*]" = 9.0;
+				"WATCHOS_DEPLOYMENT_TARGET[sdk=watchsimulator27*]" = 9.0;
 				XROS_DEPLOYMENT_TARGET = 1.3;
 			};
 			name = Release;


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Xcode 27's SDKs raise the minimum deployment targets to iOS 15 / macOS 12 / tvOS 15 / watchOS 9, so building this project with Xcode 27 fails.

This PR adds SDK-conditional build settings to the Xcode project, e.g. `"IPHONEOS_DEPLOYMENT_TARGET[sdk=iphoneos27*]" = 15.0`, which only apply when building against the 27 SDKs. Xcode ≤ 26 builds are unchanged — not a breaking change.

Notes on other channels:
- **SPM**: no change needed — package deployment targets are clamped to the SDK floor automatically (verified: built artifacts get minos 15.0 under Xcode 27).
- **Carthage**: the default binary path is unaffected; building from source under Xcode 27 works with this fix, but the dependency chain still fails at analytics-connector-ios, which needs the same treatment in its own repo.
- **CocoaPods**: no conditional mechanism; pod users on Xcode 27 should bump pod deployment targets in their Podfile's `post_install` until the unified target bump.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-setting-only change scoped to Xcode 27 SDKs; no SDK runtime or analytics logic is modified in this diff.
> 
> **Overview**
> Adds **SDK-conditional deployment targets** in `Amplitude-Swift.xcodeproj` so builds against **Xcode 27** SDKs meet Apple’s higher minimums without changing the default floors used on older toolchains.
> 
> When the SDK name matches `*27*` (e.g. `iphoneos27`, `macosx27`), overrides apply: **iOS/tvOS 15**, **macOS 12**, **watchOS 9**. Unconditional values (e.g. iOS 13, macOS 10.15) are left as-is. The same overrides are wired into **AmplitudeSwift**, **AmplitudeSwiftNoUIKit**, **Amplitude-SwiftTests**, and the project-level Debug/Release configs.
> 
> This is the Xcode-project side of Xcode 27 compatibility (local dev, tests, Carthage); it is not a global minimum bump for consumers on Xcode ≤ 26.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac434d21f03fc0d0ee7c687d56c0d604d9bc2d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->