### PR TITLE
fix: require AmplitudeCore 1.4.8 and AnalyticsConnector 1.3.2

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -1489,7 +1489,7 @@
 			repositoryURL = "https://github.com/amplitude/AmplitudeCore-Swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.4.6;
+				minimumVersion = 1.4.8;
 			};
 		};
 		4EB530762CD2EB9700E961F4 /* XCRemoteSwiftPackageReference "analytics-connector-ios" */ = {
@@ -1497,7 +1497,7 @@
 			repositoryURL = "https://github.com/amplitude/analytics-connector-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.3.0;
+				minimumVersion = 1.3.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AmplitudeSwift.podspec
+++ b/AmplitudeSwift.podspec
@@ -31,8 +31,8 @@ Pod::Spec.new do |s|
   s.visionos.source_files      = 'Sources/Amplitude/**/*.{h,swift}'
   s.visionos.resource_bundle    = { 'Amplitude': ['Sources/Amplitude/PrivacyInfo.xcprivacy'] }
 
-  s.dependency 'AnalyticsConnector', '~> 1.3.0'
-  s.dependency 'AmplitudeCore', '>=1.4.6', '<2.0.0'
+  s.dependency 'AnalyticsConnector', '~> 1.3.2'
+  s.dependency 'AmplitudeCore', '>=1.4.8', '<2.0.0'
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "amplitude/analytics-connector-ios" ~> 1.3.0
-binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.4.6
+github "amplitude/analytics-connector-ios" ~> 1.3.2
+binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json" ~> 1.4.8

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.6"),
+        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.2"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.8"),
     ],
     targets: [
         .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -20,8 +20,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.0"),
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.6"),
+        .package(url: "https://github.com/amplitude/analytics-connector-ios.git", from: "1.3.2"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.4.8"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
### Summary

Completes the fix for #417 / SDKI-12. AmplitudeCore [1.4.8](https://github.com/amplitude/AmplitudeCore-Swift/releases/tag/v1.4.8) and AnalyticsConnector [1.3.2](https://github.com/amplitude/analytics-connector-ios/releases/tag/v1.3.2) ship `Package@swift-6.4.swift` manifest variants (amplitude/AmplitudeCore-Swift#87, amplitude/analytics-connector-ios#26) that avoid the platform-version constants Swift 6.4 (Xcode 27) deprecates, so package resolution no longer emits:

```
warning: 'v4' is deprecated: watchOS 9.0 is the oldest supported version
```

This raises the minimum dependency versions everywhere they're declared — `Package.swift` + `Package@swift-5.9.swift`, `AmplitudeSwift.podspec`, the Xcode project's package references, and `Cartfile` — so integrations pinned by `Package.resolved`/`Podfile.lock` pick up the fixed manifests when they update the SDK (same pattern as #406 for the Core 1.4.6 bump).

Verified: fresh `swift package update` resolves AmplitudeCore 1.4.8 + AnalyticsConnector 1.3.2 with **zero deprecation warnings** under Xcode 27.0 (27A5194q) and Xcode 26.5.

Fixes #417

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version floor changes with no SDK code changes; risk is limited to integrators needing to accept newer transitive dependency versions on update.
> 
> **Overview**
> Raises minimum **AmplitudeCore** from `1.4.6` to **`1.4.8`** and **AnalyticsConnector** from `1.3.0` to **`1.3.2`** everywhere dependencies are declared: `Package.swift`, `Package@swift-5.9.swift`, `AmplitudeSwift.podspec`, `Cartfile`, and the Xcode project’s Swift package references.
> 
> Those upstream releases include `Package@swift-6.4.swift` manifests that avoid deprecated platform-version constants under Swift 6.4 / Xcode 27, so consumers resolving packages after updating the SDK should no longer see watchOS (and related) deprecation warnings during `swift package` resolution. No Amplitude-Swift source or runtime behavior changes—only dependency floor alignment, following the same pattern as the prior Core **1.4.6** bump in #406.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2446f0fc6d1c40a954f9be5ede259da008d84d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->