### PR TITLE
fix(identity): stop sending empty identify when properties are cleared

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -77,7 +77,7 @@ public class Amplitude {
             }
         }
 
-        if sendIdentifyIfNeeded, userPropertiesChanged {
+        if sendIdentifyIfNeeded, userPropertiesChanged, !identity.userProperties.isEmpty {
             identify(userProperties: identity.userProperties)
         }
     }

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -824,6 +824,25 @@ final class AmplitudeTests: XCTestCase {
         XCTAssertNotEqual(amplitude.getDeviceId(), "originalDeviceId")
     }
 
+    func testResetDoesNotTriggerAnyEventIncludingIdentify() {
+        let amplitude = Amplitude(configuration: configurationWithFakeMemoryStorage)
+        let eventCollector = EventCollectorPlugin()
+        amplitude.add(plugin: eventCollector)
+        amplitude.setUserId(userId: "originalUserId")
+        amplitude.setDeviceId(deviceId: "originalDeviceId")
+        amplitude.identify(userProperties: ["property": "value"])
+        amplitude.waitForTrackingQueue()
+        eventCollector.events.removeAll()
+
+        amplitude.reset()
+        amplitude.waitForTrackingQueue()
+
+        XCTAssertTrue(
+            eventCollector.events.isEmpty,
+            "Expected reset() not to trigger events, but got: \(eventCollector.events.map(\.eventType))"
+        )
+    }
+
     func testInit_Offline() {
         XCTAssertEqual(Amplitude(configuration: configuration).configuration.offline, false)
     }


### PR DESCRIPTION
### Summary

When user properties are cleared, either by manually calling `amplitude.identity.userProperties.removeAll()` or by calling `amplitude.reset()`, an empty "identify" event is sent.

In theory, this is harmless. But in some edge cases, this empty identify can start a new session at a time where it's not expected (it is quite unexpected that calling `amplitude.reset()` will start a new session if one is not started already for example).

As a result, it's better to avoid sending this empty event.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to when identify is auto-fired; reduces unexpected session side effects and is covered by a new reset test.
> 
> **Overview**
> **`applyIdentityUpdate`** no longer auto-calls **`identify`** when user properties change to an **empty** map. The guard adds **`!identity.userProperties.isEmpty`**, so clearing properties (e.g. **`identity.userProperties.removeAll()`** or **`reset()`**) updates identity and notifies plugins without emitting a **`$identify`** with no payload.
> 
> That avoids edge cases where an empty identify could unexpectedly start a session. A new test asserts **`reset()`** produces **no** tracked events after prior identify traffic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 150f3a2b55a7aabab9b6ed9a0461f3e33dda0679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->