### PR TITLE
feat: add delayed events HTTP client (internal, no public API)

### DIFF
--- a/Sources/Amplitude/Constants.swift
+++ b/Sources/Amplitude/Constants.swift
@@ -83,6 +83,8 @@ public struct Constants {
     public static let EU_DEFAULT_API_HOST = "https://api.eu.amplitude.com/2/httpapi"
     static let BATCH_API_HOST = "https://api2.amplitude.com/batch"
     static let EU_BATCH_API_HOST = "https://api.eu.amplitude.com/batch"
+    static let DELAYED_API_HOST = "https://api2.amplitude.com/2/httpapi/delayed"
+    static let EU_DELAYED_API_HOST = "https://api.eu.amplitude.com/2/httpapi/delayed"
     static let IDENTIFY_EVENT = "$identify"
     static let GROUP_IDENTIFY_EVENT = "$groupidentify"
     static let MAX_PROPERTY_KEYS = 1024

--- a/Sources/Amplitude/DelayedEvents/DelayedEventsHttpClient.swift
+++ b/Sources/Amplitude/DelayedEvents/DelayedEventsHttpClient.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+protocol DelayedEventsUploading: AnyObject {
+    @discardableResult
+    func upload(_ body: DelayedRequestBody,
+                completion: @escaping (Result<Int, Error>) -> Void) -> URLSessionDataTask?
+}
+
+class DelayedEventsHttpClient: DelayedEventsUploading {
+    let configuration: Configuration
+    let session: URLSession
+    let logger: (any Logger)?
+
+    init(configuration: Configuration) {
+        self.configuration = configuration
+        self.logger = configuration.loggerProvider
+        let sessionConfiguration = URLSessionConfiguration.default
+        sessionConfiguration.httpMaximumConnectionsPerHost = 2
+        sessionConfiguration.urlCache = nil
+        self.session = URLSession(configuration: sessionConfiguration)
+    }
+
+    func getUrl() -> String {
+        if let url = configuration.serverUrl, !url.isEmpty {
+            return url.hasSuffix("/") ? url + "delayed" : url + "/delayed"
+        }
+        return configuration.serverZone == .EU
+            ? Constants.EU_DELAYED_API_HOST
+            : Constants.DELAYED_API_HOST
+    }
+
+    @discardableResult
+    func upload(_ body: DelayedRequestBody,
+                completion: @escaping (Result<Int, Error>) -> Void) -> URLSessionDataTask? {
+        guard let requestUrl = URL(string: getUrl()) else {
+            completion(.failure(HttpClient.Exception.invalidUrl(url: getUrl())))
+            return nil
+        }
+        var request = URLRequest(url: requestUrl, timeoutInterval: 60)
+        request.httpMethod = "POST"
+        request.addValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        let data: Data
+        do {
+            data = try JSONEncoder().encode(body)
+        } catch {
+            completion(.failure(error))
+            return nil
+        }
+        let backgroundTaskCompletion = VendorSystem.current.beginBackgroundTask()
+        let task = session.uploadTask(with: request, from: data) { [logger] data, response, error in
+            if let error = error {
+                logger?.error(message: "Delayed events request failed: \(error.localizedDescription)")
+                completion(.failure(error))
+            } else if let httpResponse = response as? HTTPURLResponse {
+                switch httpResponse.statusCode {
+                case 1..<300:
+                    completion(.success(httpResponse.statusCode))
+                default:
+                    completion(.failure(HttpClient.Exception.httpError(code: httpResponse.statusCode,
+                                                                       data: data)))
+                }
+            }
+            backgroundTaskCompletion?()
+        }
+        task.resume()
+        return task
+    }
+}

--- a/Sources/Amplitude/DelayedEvents/DelayedRequestBody.swift
+++ b/Sources/Amplitude/DelayedEvents/DelayedRequestBody.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct DelayedRequestBody: Codable {
+    let apiKey: String
+    let id: String
+    let timeout: Int64        // milliseconds
+    let events: [BaseEvent]
+    let instantEvents: [BaseEvent]?
+
+    enum CodingKeys: String, CodingKey {
+        case apiKey = "api_key"
+        case id
+        case timeout
+        case events
+        case instantEvents = "instant_events"
+    }
+}

--- a/Tests/AmplitudeTests/DelayedEvents/DelayedEventsHttpClientTests.swift
+++ b/Tests/AmplitudeTests/DelayedEvents/DelayedEventsHttpClientTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import AmplitudeSwift
+
+final class DelayedEventsHttpClientTests: XCTestCase {
+    func testGetUrlDefaultsToUSDelayedHost() {
+        let client = DelayedEventsHttpClient(configuration: Configuration(apiKey: "test-key"))
+        XCTAssertEqual(client.getUrl(), "https://api2.amplitude.com/2/httpapi/delayed")
+    }
+
+    func testGetUrlUsesEUDelayedHost() {
+        let config = Configuration(apiKey: "test-key", serverZone: .EU)
+        XCTAssertEqual(DelayedEventsHttpClient(configuration: config).getUrl(),
+                       "https://api.eu.amplitude.com/2/httpapi/delayed")
+    }
+
+    func testGetUrlAppendsDelayedToCustomServerUrl() {
+        let config = Configuration(apiKey: "test-key", serverUrl: "http://localhost:8123/2/httpapi")
+        XCTAssertEqual(DelayedEventsHttpClient(configuration: config).getUrl(),
+                       "http://localhost:8123/2/httpapi/delayed")
+    }
+
+    func testRequestBodyEncodesContractShape() throws {
+        let event = BaseEvent(eventType: "Video Content Stopped")
+        event.insertId = "ins-1"
+        event.timestamp = 1_752_000_000_000
+        let body = DelayedRequestBody(apiKey: "k", id: "d-1", timeout: 3_600_000,
+                                      events: [event], instantEvents: nil)
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(body)) as! [String: Any]
+        XCTAssertEqual(json["api_key"] as? String, "k")
+        XCTAssertEqual(json["id"] as? String, "d-1")
+        XCTAssertEqual(json["timeout"] as? Int64, 3_600_000)
+        let events = json["events"] as! [[String: Any]]
+        XCTAssertEqual(events[0]["event_type"] as? String, "Video Content Stopped")
+        XCTAssertEqual(events[0]["insert_id"] as? String, "ins-1")
+        XCTAssertEqual(events[0]["time"] as? Int64, 1_752_000_000_000)
+        XCTAssertNil(json["instant_events"])
+    }
+}


### PR DESCRIPTION
Part 1/3 of the trackDelayed transport (SPI-gated, lands in part 3).

Internal-only: `DelayedRequestBody` (Codable, contract shape per [Delayed Events API Contract](https://amplitude.atlassian.net/wiki/spaces/Middleware/pages/3845357571)) + `DelayedEventsHttpClient` for `POST /2/httpapi/delayed` (US/EU hosts, custom serverUrl gets /delayed appended). No behavior change to the existing pipeline; no public API.

Design doc: Video Analytics on Mobile — iOS implementation design (external brain, 2026-07-17). Part 2: snapshot pipeline. Part 3: @_spi trackDelayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)