### PR TITLE
fix: tvOS should use cache directory for storage

### DIFF
--- a/Sources/Amplitude/Storages/PersistentStorage.swift
+++ b/Sources/Amplitude/Storages/PersistentStorage.swift
@@ -400,8 +400,13 @@ extension PersistentStorage {
     }
 
     internal func getEventsStorageDirectory(createDirectory: Bool = true) -> URL {
-        let storageUrl = getEventsStorageDirectory(searchPathDirectory: .applicationSupportDirectory,
-                                                  createDirectory: createDirectory)
+        #if os(tvOS)
+            let searchPathDirectory = FileManager.SearchPathDirectory.cachesDirectory
+        #else
+            let searchPathDirectory = FileManager.SearchPathDirectory.applicationSupportDirectory
+        #endif
+        let storageUrl = getEventsStorageDirectory(searchPathDirectory: searchPathDirectory,
+                                                   createDirectory: createDirectory)
 
         // This call is prohibitively expensive to be called at each event, run it once per instance lifetime.
         if createDirectory, !didExcludeStorageFromBackup {
@@ -422,9 +427,12 @@ extension PersistentStorage {
     }
 
     internal func getLegacyEventsStorageDirectory(createDirectory: Bool = true) -> URL {
-        // tvOS doesn't have access to document
+        // tvOS used Application Support briefly in 1.18.2-1.18.6. Earlier
+        // versions already used Caches, which is now the active directory.
+        #if os(tvOS)
+            let searchPathDirectory = FileManager.SearchPathDirectory.applicationSupportDirectory
         // macOS /Documents dir might be synced with iCloud
-        #if os(tvOS) || os(macOS)
+        #elseif os(macOS)
             let searchPathDirectory = FileManager.SearchPathDirectory.cachesDirectory
         #else
             let searchPathDirectory = FileManager.SearchPathDirectory.documentDirectory

--- a/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
+++ b/Tests/AmplitudeTests/Storages/PersistentStorageTests.swift
@@ -371,16 +371,39 @@ final class PersistentStorageTests: XCTestCase {
         persistentStorage.reset()
     }
 
-    func testDefaultStorageDirectoryUsesApplicationSupport() {
+    func testDefaultStorageDirectoryUsesPlatformAppropriateLocation() {
         let persistentStorage = PersistentStorage(storagePrefix: "application-support-instance", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
         persistentStorage.reset()
 
         let storageUrl = persistentStorage.getEventsStorageDirectory(createDirectory: false)
+        #if os(tvOS)
+        let expectedStorageUrl = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        #else
         let applicationSupportUrl = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let expectedStorageUrl = applicationSupportUrl
+        #endif
 
-        XCTAssertTrue(storageUrl.path.hasPrefix(applicationSupportUrl.path))
+        XCTAssertTrue(storageUrl.path.hasPrefix(expectedStorageUrl.path))
         persistentStorage.reset()
     }
+
+    #if os(tvOS)
+    func testTVOSWritesEventsToCachesDirectory() throws {
+        let persistentStorage = PersistentStorage(storagePrefix: "tvos-caches-instance-\(UUID().uuidString)", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)
+        persistentStorage.reset()
+        defer { persistentStorage.reset() }
+
+        try persistentStorage.write(key: StorageKey.EVENTS, value: BaseEvent(eventType: "tvos-event"))
+
+        let eventFiles = persistentStorage.getEventFiles()
+        let eventFile = try XCTUnwrap(eventFiles.first)
+        let cachesUrl = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        XCTAssertTrue(eventFile.path.hasPrefix(cachesUrl.path))
+
+        let eventString = try XCTUnwrap(persistentStorage.getEventsString(eventBlock: eventFile))
+        XCTAssertEqual(BaseEvent.fromArrayString(jsonString: eventString)?.first?.eventType, "tvos-event")
+    }
+    #endif
 
     func testStorageDirectoryIsExcludedFromBackupWhenCreated() throws {
         let persistentStorage = PersistentStorage(storagePrefix: "excluded-from-backup-instance-\(UUID().uuidString)", logger: self.logger, diagonostics: self.diagonostics, diagnosticsClient: self.diagnosticsClient)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fixes https://github.com/amplitude/Amplitude-Swift/issues/424. tvOS should use the caches directory as the Application Support directory is not available.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where analytics events are stored on tvOS and how 1.18.2–1.18.6 data is migrated; scope is platform-specific with dedicated tests.
> 
> **Overview**
> **tvOS event files** now persist under **Caches** instead of Application Support, which is not a reliable storage location on that platform (fixes Amplitude-Swift #424).
> 
> **Legacy migration** on tvOS is updated so `getLegacyEventsStorageDirectory` points at Application Support (events written in 1.18.2–1.18.6) while the active directory is Caches again (matching pre-1.18.2 behavior). tvOS is no longer lumped with macOS in the legacy-path `#if` branch.
> 
> Tests rename the default-directory assertion to be platform-aware and add a tvOS-only test that writes an event and asserts the file lives under Caches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6e3545706634a79d55a3c02ff4c72ef8002d26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->