### PR TITLE
ci: retry unit tests on failure

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -88,18 +88,21 @@ jobs:
               xcodebuild test \
                 -scheme Amplitude-Swift-Package \
                 -sdk iphonesimulator \
+                -retry-tests-on-failure \
                 -destination 'platform=iOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}'
               ;;
             macOS)
               xcodebuild test \
                 -scheme Amplitude-Swift-Package \
                 -sdk macosx \
+                -retry-tests-on-failure \
                 -destination 'platform=macOS'
               ;;
             tvOS)
               xcodebuild \
                 -scheme Amplitude-Swift-Package \
                 -sdk appletvsimulator \
+                -retry-tests-on-failure \
                 -destination 'platform=tvOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
                 test
               ;;
@@ -107,6 +110,7 @@ jobs:
               xcodebuild \
                 -scheme Amplitude-Swift-Package \
                 -sdk watchsimulator \
+                -retry-tests-on-failure \
                 -destination 'platform=watchOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
                 test
               ;;
@@ -114,6 +118,7 @@ jobs:
               xcodebuild \
                 -scheme Amplitude-Swift-Package \
                 -sdk xrsimulator \
+                -retry-tests-on-failure \
                 -destination 'platform=visionOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
                 test
               ;;
@@ -138,4 +143,5 @@ jobs:
           xcodebuild test \
             -scheme AmplitudeObjCExample \
             -sdk iphonesimulator \
+            -retry-tests-on-failure \
             -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16'


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

We've had a few attempts to improve test reliability that we've never quite completed. As a quick fix, I think we should just retry the tests. By default it should retry 3x.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no production code or test logic modifications; only affects how failures are retried in GitHub Actions.
> 
> **Overview**
> Improves CI stability for flaky simulator/Xcode test failures by enabling **automatic test retries** on every `xcodebuild test` in the unit test workflow.
> 
> Each platform job (iOS, macOS, tvOS, watchOS, visionOS) and the **Objective-C example** iOS test step now pass `-retry-tests-on-failure`, which uses Xcode’s default behavior (typically up to three retries) when a test fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce8b2a029cfe4a5ea37c2f4898abdc224ea239f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->