### PR TITLE
fix(frustration-interactions): suppress dead clicks in web views and apply ignore flags to subviews

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		6C04FC452C58978900EA8667 /* AutocaptureOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C04FC442C58978900EA8667 /* AutocaptureOptions.swift */; };
 		6C04FC482C589C8100EA8667 /* AutocaptureOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C04FC462C5897AC00EA8667 /* AutocaptureOptionsTests.swift */; };
 		6C23EF162C38AD31000DC8C8 /* UIKitUserInteractionPluginTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C23EF142C38AC32000DC8C8 /* UIKitUserInteractionPluginTest.swift */; };
+		AB03FE202E58AC34000DC8CA /* WebViewDeadClickTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB03FE1F2E58AC34000DC8CA /* WebViewDeadClickTests.swift */; };
 		8EDEC02B99EE2092B567A61D /* ObjCIngestionMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDEC500EBDA8B813056E2DB /* ObjCIngestionMetadata.swift */; };
 		8EDEC1073A308B12B5CCD975 /* AnalyticsConnectorPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDECD39BAA97DD4320C0AA5 /* AnalyticsConnectorPlugin.swift */; };
 		8EDEC10C56FA7F7DEEB48B6F /* ObjCBaseEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EDECCFD935A0C5A6FE85E87 /* ObjCBaseEvent.swift */; };
@@ -259,6 +260,7 @@
 		6C04FC442C58978900EA8667 /* AutocaptureOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocaptureOptions.swift; sourceTree = "<group>"; };
 		6C04FC462C5897AC00EA8667 /* AutocaptureOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutocaptureOptionsTests.swift; sourceTree = "<group>"; };
 		6C23EF142C38AC32000DC8C8 /* UIKitUserInteractionPluginTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitUserInteractionPluginTest.swift; sourceTree = "<group>"; };
+		AB03FE1F2E58AC34000DC8CA /* WebViewDeadClickTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewDeadClickTests.swift; sourceTree = "<group>"; };
 		8EDEC0630C3B587334275D9B /* AmplitudeSessionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmplitudeSessionTests.swift; sourceTree = "<group>"; };
 		8EDEC1160D95DC3F0E48DDF7 /* ObjCPlugin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCPlugin.swift; sourceTree = "<group>"; };
 		8EDEC1576C95A2EB2FEF00A8 /* ObjCAmplitude.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObjCAmplitude.swift; sourceTree = "<group>"; };
@@ -472,6 +474,7 @@
 			isa = PBXGroup;
 			children = (
 				6C23EF142C38AC32000DC8C8 /* UIKitUserInteractionPluginTest.swift */,
+				AB03FE1F2E58AC34000DC8CA /* WebViewDeadClickTests.swift */,
 				B6F338A22B685793006179E2 /* NetworkConnectivityCheckerPluginTests.swift */,
 				4E2B646A2BA127460010E6F8 /* UIKitScreenViewsPluginTests.swift */,
 				EAE989282DA831F200835345 /* NetworkTrackingPluginTest.swift */,
@@ -1016,6 +1019,7 @@
 				4E654DE12D9B60E700BCAA85 /* IdentityTests.swift in Sources */,
 				OBJ_152 /* TestUtilities.swift in Sources */,
 				6C23EF162C38AD31000DC8C8 /* UIKitUserInteractionPluginTest.swift in Sources */,
+				AB03FE202E58AC34000DC8CA /* WebViewDeadClickTests.swift in Sources */,
 				OBJ_153 /* TimelineTests.swift in Sources */,
 				OBJ_154 /* TypesTests.swift in Sources */,
 				4ED02BBB2F29958D001AE863 /* GzipTests.swift in Sources */,

--- a/Sources/Amplitude/Plugins/iOS/FrustrationIgnoreExtensions.swift
+++ b/Sources/Amplitude/Plugins/iOS/FrustrationIgnoreExtensions.swift
@@ -15,17 +15,39 @@ extension UIView {
     private static var amp_ignoreRageClickKey: UInt8 = 0
     private static var amp_ignoreDeadClickKey: UInt8 = 0
 
+    // The flags are looked up on the view and on every view it is inside of, because the view the
+    // SDK checks is rarely the view an app can mark. Interactions are attributed to the gesture
+    // recognizer's view, and inside a `WKWebView` that is the private `WKContentView`, two levels
+    // below the web view itself:
+    //
+    //     WKContentView -> WKScrollView -> WKWebView
+    //
+    // A leaf-only lookup therefore made `webView.amp_ignoreInteractionEvent()` a silent no-op — the
+    // flag landed on the `WKWebView` and was never read. The same held for any container: marking a
+    // view did not cover the subviews the taps actually land on.
+    //
+    // Marking is monotonic: once a view is ignored, nothing inside it can opt back in. Re-enabling a
+    // subtree would need to tell "never set" apart from "set to false", which the `Bool` associated
+    // object cannot express.
+
     var amp_ignoreRageClick: Bool {
-        return objc_getAssociatedObject(self, &UIView.amp_ignoreRageClickKey) as? Bool ?? false
+        return sequence(first: self, next: \.superview).contains {
+            objc_getAssociatedObject($0, &UIView.amp_ignoreRageClickKey) as? Bool ?? false
+        }
     }
 
     var amp_ignoreDeadClick: Bool {
-        return objc_getAssociatedObject(self, &UIView.amp_ignoreDeadClickKey) as? Bool ?? false
+        return sequence(first: self, next: \.superview).contains {
+            objc_getAssociatedObject($0, &UIView.amp_ignoreDeadClickKey) as? Bool ?? false
+        }
     }
 
-    /// Mark this view to be ignored for specific interaction events
-    /// - Parameter rageClick: Whether to ignore rage click detection for this view
-    /// - Parameter deadClick: Whether to ignore dead click detection for this view
+    /// Mark this view, and everything inside it, to be ignored for specific interaction events.
+    ///
+    /// Marking a view controller's root view therefore covers a whole screen, and marking a
+    /// `WKWebView` covers the web content inside it.
+    /// - Parameter rageClick: Whether to ignore rage click detection for this view and its subviews
+    /// - Parameter deadClick: Whether to ignore dead click detection for this view and its subviews
     @objc public func amp_ignoreInteractionEvent(rageClick: Bool = true, deadClick: Bool = true) {
         objc_setAssociatedObject(self, &UIView.amp_ignoreRageClickKey, rageClick, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         objc_setAssociatedObject(self, &UIView.amp_ignoreDeadClickKey, deadClick, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)

--- a/Sources/Amplitude/Plugins/iOS/FrustrationIgnoreExtensions.swift
+++ b/Sources/Amplitude/Plugins/iOS/FrustrationIgnoreExtensions.swift
@@ -29,6 +29,10 @@ extension UIView {
     // Marking is monotonic: once a view is ignored, nothing inside it can opt back in. Re-enabling a
     // subtree would need to tell "never set" apart from "set to false", which the `Bool` associated
     // object cannot express.
+    //
+    // The lookup runs at interaction time against the live hierarchy, so marking a view before or
+    // after it is added to a superview both work, and a view that has been detached by the time it
+    // is checked no longer sees its former ancestors' marks.
 
     var amp_ignoreRageClick: Bool {
         return sequence(first: self, next: \.superview).contains {

--- a/Sources/Amplitude/Plugins/iOS/FrustrationIgnoreExtensions.swift
+++ b/Sources/Amplitude/Plugins/iOS/FrustrationIgnoreExtensions.swift
@@ -30,6 +30,16 @@ extension UIView {
         objc_setAssociatedObject(self, &UIView.amp_ignoreRageClickKey, rageClick, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         objc_setAssociatedObject(self, &UIView.amp_ignoreDeadClickKey, deadClick, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     }
+
+    /// Whether this view is a web view, or lives inside one.
+    ///
+    /// `WKWebView` is resolved by name so that the SDK does not have to link WebKit, and per call
+    /// rather than cached so that WebKit loaded late (a lazily loaded feature framework) is still
+    /// found. On platforms without WKWebView the lookup returns nil and behaviour is unchanged.
+    var amp_isInsideWebView: Bool {
+        guard let webViewClass = NSClassFromString("WKWebView") else { return false }
+        return sequence(first: self, next: \.superview).contains { $0.isKind(of: webViewClass) }
+    }
 }
 
 // MARK: - Frustration Click Ignore Extension for SwiftUI

--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -215,11 +215,21 @@ class UIKitElementInteractions {
     }
 
     /// Dead click detection needs to know whether the interface responded to what the user touched.
-    /// Session Replay does not capture web content — `Snapshotter` never walks into a `WKWebView`'s
-    /// layer subtree — and `InterfaceChangeSignal` carries no region, only a timestamp. So inside a
-    /// web view a tap is reported dead whenever nothing else in the app happens to change within the
-    /// timeout, and cleared whenever something unrelated does. Suppress it there until web content
-    /// can be observed. Rage click does not depend on interface signals and stays enabled.
+    /// Inside a `WKWebView` no such signal exists, for two independent reasons:
+    ///
+    /// - Session Replay's snapshotter never walks into a web view's layer subtree, so web content
+    ///   never moves the native layer tree whose diff produces an interface signal.
+    /// - Web content *is* captured when Session Replay is configured to do so, but it arrives as
+    ///   rrweb events on a separate channel that only stores them — it never notifies interface
+    ///   signal receivers. And `InterfaceChangeSignal` carries no region, only a timestamp, so even
+    ///   if it did, a signal could not be tied to the view that was touched.
+    ///
+    /// So inside a web view a tap is reported dead whenever nothing else in the app happens to
+    /// change within the timeout, and cleared whenever something unrelated does. Suppress it there
+    /// until web content changes can raise an interface signal of their own — wiring the web view
+    /// event channel into that notification is what makes this suppression unnecessary.
+    ///
+    /// Rage click does not depend on interface signals and stays enabled.
     static func shouldProcessDeadClick(for view: UIView) -> Bool {
         return !view.amp_ignoreDeadClick && !view.amp_isInsideWebView
     }

--- a/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
+++ b/Sources/Amplitude/Plugins/iOS/UIKitElementInteractions.swift
@@ -207,6 +207,22 @@ class UIKitElementInteractions {
     static func resetPhysicalTapDedupCandidates() {
         physicalTapDedupCandidates.removeAll()
     }
+
+    // MARK: - Which detectors a view is eligible for
+
+    static func shouldProcessRageClick(for view: UIView) -> Bool {
+        return !view.amp_ignoreRageClick
+    }
+
+    /// Dead click detection needs to know whether the interface responded to what the user touched.
+    /// Session Replay does not capture web content — `Snapshotter` never walks into a `WKWebView`'s
+    /// layer subtree — and `InterfaceChangeSignal` carries no region, only a timestamp. So inside a
+    /// web view a tap is reported dead whenever nothing else in the app happens to change within the
+    /// timeout, and cleared whenever something unrelated does. Suppress it there until web content
+    /// can be observed. Rage click does not depend on interface signals and stays enabled.
+    static func shouldProcessDeadClick(for view: UIView) -> Bool {
+        return !view.amp_ignoreDeadClick && !view.amp_isInsideWebView
+    }
 }
 
 extension Configuration {
@@ -244,10 +260,11 @@ extension UIApplication {
             }
         }
 
-        let shouldProcessRageClick = !control.amp_ignoreRageClick
-        let shouldProcessDeadClick = !control.amp_ignoreDeadClick
+        if actionEvent == "touch" {
+            let shouldProcessRageClick = UIKitElementInteractions.shouldProcessRageClick(for: control)
+            let shouldProcessDeadClick = UIKitElementInteractions.shouldProcessDeadClick(for: control)
+            guard shouldProcessRageClick || shouldProcessDeadClick else { return sendActionResult }
 
-        if actionEvent == "touch", shouldProcessRageClick || shouldProcessDeadClick {
             var location = CGPoint.zero
 
             if let event = event, let touch = event.allTouches?.first {
@@ -351,10 +368,12 @@ extension UIGestureRecognizer {
             }
         }
 
-        let shouldProcessRageClick = !view.amp_ignoreRageClick
-        let shouldProcessDeadClick = !view.amp_ignoreDeadClick
+        guard isTap else { return }
 
-        if isTap, shouldProcessDeadClick || shouldProcessRageClick {
+        let shouldProcessRageClick = UIKitElementInteractions.shouldProcessRageClick(for: view)
+        let shouldProcessDeadClick = UIKitElementInteractions.shouldProcessDeadClick(for: view)
+
+        if shouldProcessDeadClick || shouldProcessRageClick {
             let clickData = FrustrationClickData(
                 eventData: view.eventData,
                 location: location(in: nil),

--- a/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
+++ b/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
@@ -207,33 +207,143 @@ final class WebViewDeadClickTests: XCTestCase {
                        "The positive control must produce a dead click")
     }
 
-    // MARK: - Known gap: the public ignore hook does not reach a webview's recognizer view
+    /// The ancestor lookup only matters if the capture path consults it. Every other ignore-hook
+    /// test reads the flags or the helpers directly and would stay green if the wiring were
+    /// reverted; this one drives the real swizzled `setState:` and checks what the SDK emits.
+    func testGesturePathEmitsNoRageClickWhenTheWebViewIsIgnored() throws {
+        let (amplitude, collector) = makeAmplitude()
+        defer { UIKitElementInteractions.unregister(amplitude) }
 
-    /// `amp_ignoreRageClick` / `amp_ignoreDeadClick` read an associated object on *that view only*.
-    /// Inside a `WKWebView` the recognizers belong to `WKContentView`, two levels below the
-    /// `WKWebView` an app can actually reach, so the documented workaround
-    /// `webView.amp_ignoreInteractionEvent(...)` never reaches the view the SDK checks.
-    /// This test pins the current behaviour; it should be inverted when the lookup walks ancestors.
-    func testIgnoreHookOnWebViewDoesNotReachTheRecognizerView() throws {
+        let webView = WKWebView(frame: window.bounds)
+        window.addSubview(webView)
+        let nestedInWebView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        webView.addSubview(nestedInWebView)
+
+        let plainView = UIView(frame: CGRect(x: 0, y: 600, width: 100, height: 100))
+        window.addSubview(plainView)
+        window.makeKeyAndVisible()
+        amplitude.waitForTrackingQueue()
+
+        // What a customer would write to silence one noisy web view.
+        webView.amp_ignoreInteractionEvent(rageClick: true, deadClick: false)
+
+        // Four rapid taps on web content the customer marked: enough to cross the rage threshold.
+        for _ in 0..<4 {
+            fireTap(on: nestedInWebView, at: CGPoint(x: 50, y: 50))
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        RunLoop.current.run(until: Date().addingTimeInterval(1.3))
+        amplitude.waitForTrackingQueue()
+
+        XCTAssertEqual(events(in: collector, ofType: Constants.AMP_RAGE_CLICK_EVENT).count, 0,
+                       "The marked web view must produce no rage click")
+
+        // Positive control: the same taps on an unmarked view still do, proving the detector was
+        // live and the taps really reached the swizzled path.
+        for _ in 0..<4 {
+            fireTap(on: plainView, at: CGPoint(x: 50, y: 650))
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        RunLoop.current.run(until: Date().addingTimeInterval(1.3))
+        amplitude.waitForTrackingQueue()
+
+        XCTAssertEqual(events(in: collector, ofType: Constants.AMP_RAGE_CLICK_EVENT).count, 1,
+                       "The unmarked view must still produce a rage click")
+    }
+
+    // MARK: - The ignore hook reaches the view the SDK actually checks
+
+    /// The reason the hook exists: an app can only reach the `WKWebView`, while the SDK attributes
+    /// interactions to the private `WKContentView` two levels below it. Before the lookup walked
+    /// ancestors, `webView.amp_ignoreInteractionEvent()` was a silent no-op.
+    func testIgnoreHookOnWebViewReachesTheRecognizerView() throws {
         let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
         RunLoop.current.run(until: Date().addingTimeInterval(1.0))
 
-        webView.amp_ignoreInteractionEvent(rageClick: true, deadClick: true)
-        XCTAssertTrue(webView.amp_ignoreDeadClick, "The flag is set on the WKWebView itself")
-
         let qualifying = allRecognizers(in: webView).filter { qualifiesAsPhysicalTap($0.recognizer) }
         XCTAssertFalse(qualifying.isEmpty)
+
+        // Rage click only, which is what a customer suppressing a noisy web view would ask for.
+        webView.amp_ignoreInteractionEvent(rageClick: true, deadClick: false)
 
         for (view, recognizer) in qualifying {
             let chain = sequence(first: view, next: \.superview).map { $0.descriptiveTypeName }
                 .joined(separator: " -> ")
             print("=== \(recognizer.descriptiveTypeName): \(chain)")
 
-            XCTAssertFalse(view.amp_ignoreDeadClick,
-                           "Known gap: the flag set on WKWebView does not reach \(view.descriptiveTypeName)")
-            XCTAssertFalse(view.amp_ignoreRageClick,
-                           "Known gap: the flag set on WKWebView does not reach \(view.descriptiveTypeName)")
+            XCTAssertTrue(view.amp_ignoreRageClick,
+                          "The flag set on WKWebView must reach \(view.descriptiveTypeName)")
+            XCTAssertFalse(UIKitElementInteractions.shouldProcessRageClick(for: view),
+                           "rage click must be suppressed for \(view.descriptiveTypeName)")
+            // `deadClick: false` was passed, so nothing here marks dead click — it is suppressed
+            // only because this is web content.
+            XCTAssertFalse(view.amp_ignoreDeadClick)
         }
+    }
+
+    /// Marking a view controller's root view covers the whole screen — the shape a customer would
+    /// use to silence one noisy surface such as a webview-hosting view controller.
+    func testIgnoreOnAViewControllerRootViewCoversTheWholeScreen() {
+        let viewController = UIViewController()
+        viewController.title = "Noisy Screen"
+        window.rootViewController = viewController
+        window.makeKeyAndVisible()
+
+        let webView = WKWebView(frame: viewController.view.bounds)
+        viewController.view.addSubview(webView)
+        let nestedInWebView = UIView()
+        webView.addSubview(nestedInWebView)
+        let nativeButton = UIButton(type: .system)
+        viewController.view.addSubview(nativeButton)
+
+        viewController.view.amp_ignoreInteractionEvent(rageClick: true, deadClick: false)
+
+        for view in [viewController.view!, webView, nestedInWebView, nativeButton] {
+            XCTAssertTrue(view.amp_ignoreRageClick,
+                          "\(view.descriptiveTypeName) is on the ignored screen")
+            XCTAssertFalse(UIKitElementInteractions.shouldProcessRageClick(for: view))
+        }
+    }
+
+    /// The gap was never webview-specific: marking any container has to cover the subviews the taps
+    /// actually land on.
+    func testIgnoreOnAContainerCoversItsSubviews() {
+        let container = UIView(frame: window.bounds)
+        window.addSubview(container)
+
+        var leaf: UIView = container
+        for _ in 0..<5 {
+            let next = UIView()
+            leaf.addSubview(next)
+            leaf = next
+        }
+
+        let sibling = UIView()
+        window.addSubview(sibling)
+
+        container.amp_ignoreInteractionEvent(rageClick: true, deadClick: true)
+
+        XCTAssertTrue(leaf.amp_ignoreRageClick, "A descendant five levels down is covered")
+        XCTAssertTrue(leaf.amp_ignoreDeadClick)
+        XCTAssertFalse(UIKitElementInteractions.shouldProcessRageClick(for: leaf))
+
+        XCTAssertFalse(sibling.amp_ignoreRageClick, "A view outside the marked subtree is not")
+        XCTAssertTrue(UIKitElementInteractions.shouldProcessRageClick(for: sibling))
+    }
+
+    /// Marking is monotonic: a subview cannot opt back in, because the stored `Bool` cannot tell
+    /// "never set" from "set to false". This pins that decision.
+    func testASubviewCannotOptBackIntoAnIgnoredSubtree() {
+        let container = UIView(frame: window.bounds)
+        window.addSubview(container)
+        let child = UIView()
+        container.addSubview(child)
+
+        container.amp_ignoreInteractionEvent(rageClick: true, deadClick: true)
+        child.amp_ignoreInteractionEvent(rageClick: false, deadClick: false)
+
+        XCTAssertTrue(child.amp_ignoreRageClick, "The ancestor's marking still wins")
+        XCTAssertTrue(child.amp_ignoreDeadClick)
     }
 
     // MARK: - Helpers

--- a/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
+++ b/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
@@ -1,0 +1,309 @@
+//
+//  WebViewDeadClickTests.swift
+//  Amplitude-Swift
+//
+//  Dead click detection cannot work inside a `WKWebView`. Session Replay's `Snapshotter` never walks
+//  into a web view's layer subtree (`captureChildren = false`, regardless of block status), and
+//  `InterfaceChangeSignal` carries only a timestamp — no region. So a tap on web content produces no
+//  signal about whether the page responded: it is reported dead whenever nothing else in the app
+//  happens to change within the 3.5 s timeout, and cleared whenever something unrelated does.
+//
+//  Rage click does not depend on interface signals, so it stays enabled inside web views.
+//
+
+import XCTest
+
+@testable import AmplitudeSwift
+
+// WebKit does not exist in the tvOS and watchOS SDKs, so the import has to sit inside the guard.
+#if os(iOS)
+import WebKit
+import UIKit.UIGestureRecognizerSubclass
+@_spi(Internal) import AmplitudeCore
+
+final class WebViewDeadClickTests: XCTestCase {
+
+    private var window: UIWindow!
+    /// `WKWebView.navigationDelegate` is weak; the delegate must outlive the navigation.
+    private var navigationDelegate: NavigationDelegate?
+
+    override func setUp() {
+        super.setUp()
+        UIKitElementInteractions.resetPhysicalTapDedupCandidates()
+        window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.isHidden = false
+    }
+
+    override func tearDown() {
+        UIKitElementInteractions.resetPhysicalTapDedupCandidates()
+        navigationDelegate = nil
+        window = nil
+        super.tearDown()
+    }
+
+    // MARK: - What a web view looks like to the SDK
+
+    /// Replicates the SDK's gate in `UIGestureRecognizer.amp_setState`.
+    private func qualifiesAsPhysicalTap(_ recognizer: UIGestureRecognizer) -> Bool {
+        guard let tap = recognizer as? UITapGestureRecognizer else { return false }
+        return tap.numberOfTapsRequired == 1 && tap.numberOfTouchesRequired == 1
+    }
+
+    private func allRecognizers(in root: UIView) -> [(view: UIView, recognizer: UIGestureRecognizer)] {
+        var result: [(UIView, UIGestureRecognizer)] = []
+        for recognizer in root.gestureRecognizers ?? [] {
+            result.append((root, recognizer))
+        }
+        for subview in root.subviews {
+            result.append(contentsOf: allRecognizers(in: subview))
+        }
+        return result
+    }
+
+    /// WebKit installs several single-tap recognizers on the same `WKContentView`, all of which pass
+    /// the SDK's physical-tap gate. Measured with a real touch, two of them fire per tap
+    /// (`WKSyntheticTapGestureRecognizer` then `UITextTapRecognizer`, under a millisecond apart).
+    func testWebKitInstallsMultipleQualifyingTapRecognizersOnSameView() throws {
+        let webView = try loadedWebView(
+            "<html><body style='font-size:64px'><p>tap here</p>"
+            + "<div id='btn' onclick='void 0'>BUTTON</div></body></html>")
+
+        // Give WebKit a beat to install its text/selection interactions.
+        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+
+        let qualifying = allRecognizers(in: webView).filter { qualifiesAsPhysicalTap($0.recognizer) }
+        print("=== recognizers the SDK would treat as a physical tap: \(qualifying.count) ===")
+        for (view, recognizer) in qualifying {
+            print(" - \(recognizer.descriptiveTypeName) on \(view.descriptiveTypeName)")
+        }
+
+        XCTAssertGreaterThan(qualifying.count, 1,
+                             "Expected WebKit to install more than one single-tap recognizer")
+    }
+
+    // MARK: - Dead click is suppressed inside web views
+
+    func testDeadClickSuppressedInsideWebViewWhileRageClickStaysOn() throws {
+        let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
+        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+
+        XCTAssertTrue(webView.amp_isInsideWebView, "The web view itself counts as web content")
+        XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: webView))
+        XCTAssertTrue(UIKitElementInteractions.shouldProcessRageClick(for: webView))
+
+        let qualifying = allRecognizers(in: webView).filter { qualifiesAsPhysicalTap($0.recognizer) }
+        XCTAssertFalse(qualifying.isEmpty)
+
+        for (view, recognizer) in qualifying {
+            XCTAssertTrue(view.amp_isInsideWebView,
+                          "\(recognizer.descriptiveTypeName) on \(view.descriptiveTypeName) is web content")
+            XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: view),
+                           "dead click must be off for \(view.descriptiveTypeName)")
+            XCTAssertTrue(UIKitElementInteractions.shouldProcessRageClick(for: view),
+                          "rage click must stay on for \(view.descriptiveTypeName)")
+        }
+    }
+
+    func testDeadClickStaysEnabledOutsideWebViews() {
+        let container = UIView(frame: window.bounds)
+        window.addSubview(container)
+        let nested = UIView()
+        container.addSubview(nested)
+
+        for view in [container, nested] {
+            XCTAssertFalse(view.amp_isInsideWebView)
+            XCTAssertTrue(UIKitElementInteractions.shouldProcessDeadClick(for: view))
+            XCTAssertTrue(UIKitElementInteractions.shouldProcessRageClick(for: view))
+        }
+    }
+
+    /// Apps routinely subclass `WKWebView`, so the check has to be class-kind, not class-name.
+    func testWebViewSubclassIsRecognisedAsWebContent() {
+        final class CustomWebView: WKWebView {}
+
+        let webView = CustomWebView(frame: window.bounds)
+        window.addSubview(webView)
+        let nested = UIView()
+        webView.addSubview(nested)
+
+        XCTAssertTrue(webView.amp_isInsideWebView)
+        XCTAssertTrue(nested.amp_isInsideWebView)
+        XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: nested))
+        XCTAssertTrue(UIKitElementInteractions.shouldProcessRageClick(for: nested))
+    }
+
+    /// A view detached from any web view must not be suppressed just because it once was inside one.
+    func testDetachedViewIsNotTreatedAsWebContent() {
+        let webView = WKWebView(frame: window.bounds)
+        window.addSubview(webView)
+        let nested = UIView()
+        webView.addSubview(nested)
+        XCTAssertTrue(nested.amp_isInsideWebView)
+
+        nested.removeFromSuperview()
+        XCTAssertFalse(nested.amp_isInsideWebView)
+        XCTAssertTrue(UIKitElementInteractions.shouldProcessDeadClick(for: nested))
+    }
+
+    /// The explicit opt-out keeps working for both detectors outside web views.
+    func testExplicitIgnoreStillSuppressesBothDetectors() {
+        let view = UIView(frame: window.bounds)
+        window.addSubview(view)
+
+        view.amp_ignoreInteractionEvent(rageClick: true, deadClick: true)
+        XCTAssertFalse(UIKitElementInteractions.shouldProcessRageClick(for: view))
+        XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: view))
+    }
+
+    // MARK: - End-to-end wiring through the swizzled gesture path
+
+    /// The suppression only exists if the call sites in `amp_setState` actually consult
+    /// `shouldProcessDeadClick` — every other test in this file calls the helpers directly and
+    /// would stay green if the wiring were reverted. This one drives the real swizzled setter.
+    ///
+    /// Slow by necessity: a dead click is only reported 3.5 s after the tap, and the test needs a
+    /// negative (web view) and a positive control (plain view) to prove the detector was live.
+    func testGesturePathEmitsNoDeadClickInsideWebViewButStillDetectsRageClicks() throws {
+        let (amplitude, collector) = makeAmplitude()
+        defer { UIKitElementInteractions.unregister(amplitude) }
+
+        let provider = FakeInterfaceSignalProvider()
+        amplitude.interfaceSignalProvider = provider
+        defer { amplitude.interfaceSignalProvider = nil }
+
+        let webView = WKWebView(frame: window.bounds)
+        window.addSubview(webView)
+        let nestedInWebView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+        webView.addSubview(nestedInWebView)
+
+        let plainView = UIView(frame: CGRect(x: 0, y: 300, width: 100, height: 100))
+        window.addSubview(plainView)
+        window.makeKeyAndVisible()
+        amplitude.waitForTrackingQueue()
+
+        // Four rapid taps inside the web view: rage click must still fire, dead click must not,
+        // even though no interface change signal ever arrives.
+        for _ in 0..<4 {
+            fireTap(on: nestedInWebView)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        // Past the rage debounce (1 s) and the dead click timeout (3.5 s).
+        RunLoop.current.run(until: Date().addingTimeInterval(4.2))
+        amplitude.waitForTrackingQueue()
+
+        XCTAssertEqual(events(in: collector, ofType: Constants.AMP_RAGE_CLICK_EVENT).count, 1,
+                       "Rage click stays enabled inside the web view")
+        XCTAssertEqual(events(in: collector, ofType: Constants.AMP_DEAD_CLICK_EVENT).count, 0,
+                       "No dead click may be reported for web content")
+
+        // Positive control: the same tap on a plain view IS reported dead, proving the detector
+        // and provider wiring in this test are live.
+        fireTap(on: plainView)
+        RunLoop.current.run(until: Date().addingTimeInterval(4.2))
+        amplitude.waitForTrackingQueue()
+
+        XCTAssertEqual(events(in: collector, ofType: Constants.AMP_DEAD_CLICK_EVENT).count, 1,
+                       "The positive control must produce a dead click")
+    }
+
+    // MARK: - Known gap: the public ignore hook does not reach a webview's recognizer view
+
+    /// `amp_ignoreRageClick` / `amp_ignoreDeadClick` read an associated object on *that view only*.
+    /// Inside a `WKWebView` the recognizers belong to `WKContentView`, two levels below the
+    /// `WKWebView` an app can actually reach, so the documented workaround
+    /// `webView.amp_ignoreInteractionEvent(...)` never reaches the view the SDK checks.
+    /// This test pins the current behaviour; it should be inverted when the lookup walks ancestors.
+    func testIgnoreHookOnWebViewDoesNotReachTheRecognizerView() throws {
+        let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
+        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+
+        webView.amp_ignoreInteractionEvent(rageClick: true, deadClick: true)
+        XCTAssertTrue(webView.amp_ignoreDeadClick, "The flag is set on the WKWebView itself")
+
+        let qualifying = allRecognizers(in: webView).filter { qualifiesAsPhysicalTap($0.recognizer) }
+        XCTAssertFalse(qualifying.isEmpty)
+
+        for (view, recognizer) in qualifying {
+            let chain = sequence(first: view, next: \.superview).map { $0.descriptiveTypeName }
+                .joined(separator: " -> ")
+            print("=== \(recognizer.descriptiveTypeName): \(chain)")
+
+            XCTAssertFalse(view.amp_ignoreDeadClick,
+                           "Known gap: the flag set on WKWebView does not reach \(view.descriptiveTypeName)")
+            XCTAssertFalse(view.amp_ignoreRageClick,
+                           "Known gap: the flag set on WKWebView does not reach \(view.descriptiveTypeName)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Real recognizers report a centroid only while they hold touches; without them the location
+    /// is unusable garbage, so the test recognizer pins it.
+    private final class FixedLocationTapRecognizer: UITapGestureRecognizer {
+        var fixedLocation: CGPoint = .zero
+        override func location(in view: UIView?) -> CGPoint { fixedLocation }
+        /// Runs the swizzled `setState:` the way UIKit does when a tap completes.
+        func fireEnded() { state = .ended }
+    }
+
+    private final class FakeInterfaceSignalProvider: InterfaceSignalProvider {
+        var isProviding: Bool = true
+        func addInterfaceSignalReceiver(_ receiver: any InterfaceSignalReceiver) {}
+        func removeInterfaceSignalReceiver(_ receiver: any InterfaceSignalReceiver) {}
+    }
+
+    private func fireTap(on view: UIView, at location: CGPoint = CGPoint(x: 50, y: 50)) {
+        let recognizer = FixedLocationTapRecognizer()
+        recognizer.fixedLocation = location
+        view.addGestureRecognizer(recognizer)
+        recognizer.fireEnded()
+        view.removeGestureRecognizer(recognizer)
+    }
+
+    private func events(in collector: EventCollectorPlugin, ofType eventType: String) -> [BaseEvent] {
+        return collector.events.filter { $0.eventType == eventType }
+    }
+
+    private func makeAmplitude() -> (Amplitude, EventCollectorPlugin) {
+        let configuration = Configuration(
+            apiKey: "test-api-key",
+            instanceName: "webview-dead-click-\(UUID().uuidString)",
+            storageProvider: FakeInMemoryStorage(),
+            identifyStorageProvider: FakeInMemoryStorage(),
+            autocapture: [.frustrationInteractions],
+            enableAutoCaptureRemoteConfig: false,
+            interactionsOptions: InteractionsOptions(rageClick: .init(enabled: true),
+                                                     deadClick: .init(enabled: true)))
+        let amplitude = Amplitude(configuration: configuration)
+        let collector = EventCollectorPlugin()
+        amplitude.add(plugin: collector)
+        return (amplitude, collector)
+    }
+
+    private func loadedWebView(_ html: String) throws -> WKWebView {
+        let webView = WKWebView(frame: window.bounds)
+        window.addSubview(webView)
+        window.makeKeyAndVisible()
+
+        let loaded = expectation(description: "html loaded")
+        let delegate = NavigationDelegate { loaded.fulfill() }
+        navigationDelegate = delegate
+        webView.navigationDelegate = delegate
+        webView.loadHTMLString(html, baseURL: nil)
+        wait(for: [loaded], timeout: 10)
+        return webView
+    }
+
+    private final class NavigationDelegate: NSObject, WKNavigationDelegate {
+        private let onFinish: () -> Void
+        init(onFinish: @escaping () -> Void) {
+            self.onFinish = onFinish
+        }
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            onFinish()
+        }
+    }
+}
+
+#endif

--- a/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
+++ b/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
@@ -26,6 +26,8 @@ final class WebViewDeadClickTests: XCTestCase {
     private var window: UIWindow!
     /// `WKWebView.navigationDelegate` is weak; the delegate must outlive the navigation.
     private var navigationDelegate: NavigationDelegate?
+    /// `Amplitude.interfaceSignalProvider` is weak too.
+    private var interfaceSignalProvider: FakeInterfaceSignalProvider?
 
     override func setUp() {
         super.setUp()
@@ -37,11 +39,18 @@ final class WebViewDeadClickTests: XCTestCase {
     override func tearDown() {
         UIKitElementInteractions.resetPhysicalTapDedupCandidates()
         navigationDelegate = nil
+        interfaceSignalProvider = nil
         window = nil
         super.tearDown()
     }
 
-    // MARK: - What a web view looks like to the SDK
+    // MARK: - Finding the recognizers a tap on web content actually reaches
+    //
+    // WebKit installs five single-tap recognizers on the same `WKContentView`, all of which pass
+    // the SDK's physical-tap gate. Measured with real touches on an iPhone 16 Pro Max, two of them
+    // fire per tap — `WKSyntheticTapGestureRecognizer` and `UITextTapRecognizer`, in either order,
+    // 0.10-2.64 ms apart. That is not asserted here: it is an Apple implementation detail that a
+    // future iOS may change without any Amplitude regression.
 
     /// Replicates the SDK's gate in `UIGestureRecognizer.amp_setState`.
     private func qualifiesAsPhysicalTap(_ recognizer: UIGestureRecognizer) -> Bool {
@@ -58,27 +67,6 @@ final class WebViewDeadClickTests: XCTestCase {
             result.append(contentsOf: allRecognizers(in: subview))
         }
         return result
-    }
-
-    /// WebKit installs several single-tap recognizers on the same `WKContentView`, all of which pass
-    /// the SDK's physical-tap gate. Measured with a real touch, two of them fire per tap
-    /// (`WKSyntheticTapGestureRecognizer` then `UITextTapRecognizer`, under a millisecond apart).
-    func testWebKitInstallsMultipleQualifyingTapRecognizersOnSameView() throws {
-        let webView = try loadedWebView(
-            "<html><body style='font-size:64px'><p>tap here</p>"
-            + "<div id='btn' onclick='void 0'>BUTTON</div></body></html>")
-
-        // Give WebKit a beat to install its text/selection interactions.
-        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
-
-        let qualifying = allRecognizers(in: webView).filter { qualifiesAsPhysicalTap($0.recognizer) }
-        print("=== recognizers the SDK would treat as a physical tap: \(qualifying.count) ===")
-        for (view, recognizer) in qualifying {
-            print(" - \(recognizer.descriptiveTypeName) on \(view.descriptiveTypeName)")
-        }
-
-        XCTAssertGreaterThan(qualifying.count, 1,
-                             "Expected WebKit to install more than one single-tap recognizer")
     }
 
     // MARK: - Dead click is suppressed inside web views
@@ -167,7 +155,11 @@ final class WebViewDeadClickTests: XCTestCase {
         let (amplitude, collector) = makeAmplitude()
         defer { UIKitElementInteractions.unregister(amplitude) }
 
+        // `Amplitude.interfaceSignalProvider` is weak; without a strong reference here ARC may
+        // release the provider immediately, `isProviding` goes nil, and the positive control fails
+        // for a reason unrelated to the feature.
         let provider = FakeInterfaceSignalProvider()
+        interfaceSignalProvider = provider
         amplitude.interfaceSignalProvider = provider
         defer { amplitude.interfaceSignalProvider = nil }
 
@@ -251,6 +243,39 @@ final class WebViewDeadClickTests: XCTestCase {
                        "The unmarked view must still produce a rage click")
     }
 
+    /// The other capture path, `UIApplication.amp_sendAction`, gates on the same two helpers. Its
+    /// inputs are pinned here; the call site itself is not, and cannot be from this target — the
+    /// unit test bundle has no `UIApplication`, so `sendActions(for:)` never reaches the swizzled
+    /// `sendAction:`. That wiring is exercised by the Frustration Interactions screen in the
+    /// Session Replay example app, which runs in a real application process.
+    ///
+    /// The subject is deliberately a native `UIButton` hosted inside the web view's scroll view:
+    /// the case the subtree-wide suppression knowingly gives up. It is native and would raise a
+    /// real interface signal, and it still loses dead click detection.
+    func testNativeControlInsideAWebViewIsNotEligibleForDeadClick() {
+        let webView = WKWebView(frame: window.bounds)
+        window.addSubview(webView)
+        let buttonInWebView = UIButton(type: .system)
+        webView.scrollView.addSubview(buttonInWebView)
+
+        let plainButton = UIButton(type: .system)
+        window.addSubview(plainButton)
+
+        XCTAssertTrue(buttonInWebView.amp_isInsideWebView)
+        XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: buttonInWebView),
+                       "A native control inside a web view loses dead click, by design")
+        XCTAssertTrue(UIKitElementInteractions.shouldProcessRageClick(for: buttonInWebView),
+                      "but keeps rage click")
+
+        XCTAssertTrue(UIKitElementInteractions.shouldProcessDeadClick(for: plainButton))
+        XCTAssertTrue(UIKitElementInteractions.shouldProcessRageClick(for: plainButton))
+
+        // The ignore flag reaches a control through its container on this path too.
+        window.amp_ignoreInteractionEvent(rageClick: true, deadClick: true)
+        XCTAssertFalse(UIKitElementInteractions.shouldProcessRageClick(for: plainButton))
+        XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: plainButton))
+    }
+
     // MARK: - The ignore hook reaches the view the SDK actually checks
 
     /// The reason the hook exists: an app can only reach the `WKWebView`, while the SDK attributes
@@ -269,10 +294,10 @@ final class WebViewDeadClickTests: XCTestCase {
         for (view, recognizer) in qualifying {
             let chain = sequence(first: view, next: \.superview).map { $0.descriptiveTypeName }
                 .joined(separator: " -> ")
-            print("=== \(recognizer.descriptiveTypeName): \(chain)")
 
             XCTAssertTrue(view.amp_ignoreRageClick,
-                          "The flag set on WKWebView must reach \(view.descriptiveTypeName)")
+                          "The flag set on WKWebView must reach \(recognizer.descriptiveTypeName) "
+                          + "on \(chain)")
             XCTAssertFalse(UIKitElementInteractions.shouldProcessRageClick(for: view),
                            "rage click must be suppressed for \(view.descriptiveTypeName)")
             // `deadClick: false` was passed, so nothing here marks dead click — it is suppressed


### PR DESCRIPTION
### Summary

Two corrections to frustration click capture, both surfaced while investigating a customer report of high Rage Click and Dead Click volume inside `WKWebView`s.

**1. Dead click is no longer reported inside a web view** (`bfc60a3`)

Dead click detection asks whether the interface responded to what the user touched. Inside a `WKWebView` no such signal exists:

- Session Replay's snapshotter never walks into a web view's layer subtree, so web content cannot move the native layer tree whose diff produces an interface signal.
- Web content *is* captured when Session Replay is configured to do so, but those rrweb events arrive on a separate channel that only stores them — it never notifies interface signal receivers.
- `InterfaceChangeSignal` carries only a timestamp, no region, so even if it did fire, a signal could not be tied to the view that was touched.

The result today is that a tap on web content is reported dead whenever nothing else in the app happens to change within the 3.5 s timeout, and cleared whenever something unrelated does — anti-correlated with what the metric is supposed to mean. This suppresses it for views inside a web view. Rage click does not depend on interface signals and is unaffected.

`WKWebView` is resolved with `NSClassFromString` so the SDK still does not link WebKit, per call so late-loaded WebKit is found, and by class kind so subclasses are covered.

**2. `amp_ignoreInteractionEvent` now covers a view's subtree** (`c84b95f`)

`amp_ignoreRageClick` / `amp_ignoreDeadClick` read their associated object on that view only, but interactions are attributed to the gesture recognizer's view — which is rarely a view an app can reach. Inside a `WKWebView` the recognizers belong to the private `WKContentView`, two levels down:

```
WKContentView -> WKScrollView -> WKWebView
```

So `webView.amp_ignoreInteractionEvent(rageClick: true)` set the flag on the web view and the SDK never read it. The public opt-out was a silent no-op for web views, and equally for any container — marking a view did not cover the subviews taps actually land on. The lookup now walks the superview chain, so marking a view controller's root view covers a whole screen.

### Behavior changes that need release notes

- **A public `@objc` API changes meaning**, from "this view" to "this view and everything inside it". That is what callers already expected, but an integrator who marked a container and relied on its subviews still being captured will see a change, with no compile error.
- **Dead clicks inside web views stop being reported.** For apps with webview-heavy screens this can be a large drop in event volume. It is deliberate — those events were not measuring anything — but it will look like data loss if unannounced.
- Marking is monotonic: nothing inside an ignored subtree can opt back in, because the stored `Bool` cannot distinguish "never set" from "set to false". A test pins this.
- The suppression is subtree-wide, so a native control hosted inside a web view also loses dead click detection. Deliberate tradeoff for a simple rule; pinned by a test.
- Both the flags and the suppression are process-global, not per-`Amplitude` instance.

### Scope: this is mitigation, not a root cause fix

The customer report was about Rage Click over-counting inside web views. **No over-counting was reproduced.** On an iPhone 16 Pro Max, one physical tap reaches the SDK through exactly two recognizers 0.10–2.64 ms apart, comfortably inside the existing 5 ms dedup window, and none of these widened it: non-passive touch listeners, a saturated web content process, a zoomable viewport, enabled text selection, or a host main thread stalled 13 ms at a time (verified with a heartbeat, not by eye).

So the leading explanation for the Rage Click volume is that those are genuine rapid taps, and what the customer needs is a targeted opt-out — which is what change 2 restores. This PR does not claim to fix an over-count.

### Follow-ups deliberately not in this PR

- **No remote-config gate on the dead click suppression.** `InteractionsOptions.deadClick.enabled` and `AutocaptureManager` already have the plumbing; without a gate the only way to reverse this is a new SDK version plus an app-store release for every affected app. Worth adding before this ships widely.
- **`amp_ignoreInteractionEvent` is undocumented** — it appears nowhere in `README.md`, `CHANGELOG.md`, or `Examples/`. It should be documented, including that `deadClick` defaults to `true`.
- **The real fix for change 1** is to raise an interface signal from the web view event channel; the suppression becomes unnecessary then. Noted in the source comment.

### Tests

12 tests in `Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift`, against a real `WKWebView` and its real WebKit-installed recognizers. Two drive the swizzled `setState:` end to end with negative and positive controls, so neither can pass vacuously. Verified by reverting each change and confirming the relevant tests go red.

Not covered: the `UIApplication.sendAction` call site. The unit test bundle has no `UIApplication`, so `sendActions(for:)` never reaches the swizzled method; its inputs are pinned and the wiring is exercised by the Session Replay example app instead.

Full suite passes on iOS (349 tests); the test target compiles for tvOS and watchOS, where `NSClassFromString("WKWebView")` returns nil and behavior is byte-identical to v1.18.7.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No API break, but two behavior changes that need release notes — see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public `@objc` ignore semantics and materially reduces dead-click volume on webview-heavy screens without a compile-time break; release notes are important.
> 
> **Overview**
> Fixes frustration autocapture for **WKWebView** and container opt-outs: dead clicks are no longer emitted for taps inside a web view (rage clicks unchanged), and **`amp_ignoreInteractionEvent`** now applies to the marked view’s subtree via superview-chain lookup.
> 
> **Dead click in web views:** `shouldProcessDeadClick` skips views where `amp_isInsideWebView` is true (`WKWebView` resolved with `NSClassFromString` so WebKit is not linked). Gesture and `sendAction` paths use shared `shouldProcessRageClick` / `shouldProcessDeadClick` helpers and early-exit when both are off.
> 
> **Ignore flags:** `amp_ignoreRageClick` / `amp_ignoreDeadClick` walk ancestors so flags set on a `WKWebView` or screen root reach the gesture recognizer’s view (e.g. private `WKContentView`). Marking is monotonic—descendants cannot opt back in.
> 
> Adds **`WebViewDeadClickTests`** (iOS) with unit and end-to-end swizzled-gesture coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0b848d73b2cb5af3562a0a6c8859acc6a108216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->