### PR TITLE
chore(tests): move test only InMemoryStorage class to tests target

### DIFF
--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -112,7 +112,6 @@
 		EAED9A112EE7B47E00A5FC08 /* IOSLifecycleMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* IOSLifecycleMonitor.swift */; };
 		EAED9A122EE7B47E00A5FC08 /* WatchOSLifecycleMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* WatchOSLifecycleMonitor.swift */; };
 		EAED9A132EE7B47E00A5FC08 /* ObjCNetworkConnectivityCheckerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6CCC6CC2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift */; };
-		EAED9A142EE7B47E00A5FC08 /* InMemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* InMemoryStorage.swift */; };
 		EAED9A152EE7B47E00A5FC08 /* DispatchQueueHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E281B902B9BCC14009D913B /* DispatchQueueHolder.swift */; };
 		EAED9A162EE7B47E00A5FC08 /* DefaultEventUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60539692BB767390027FC24 /* DefaultEventUtils.swift */; };
 		EAED9A172EE7B47E00A5FC08 /* PersistentStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* PersistentStorage.swift */; };
@@ -177,6 +176,7 @@
 		EAF7B54B2E09446F00E6E61A /* FrustrationInteractions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF7B54A2E09445600E6E61A /* FrustrationInteractions.swift */; };
 		EAF7B5512E0CAEAE00E6E61A /* FrustrationIgnoreExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF7B5502E0CAEAE00E6E61A /* FrustrationIgnoreExtensions.swift */; };
 		EAF7B5582E0F1C1D00E6E61A /* ObjCInteractionsOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF7B5572E0F1C1000E6E61A /* ObjCInteractionsOptions.swift */; };
+		F01A983E30448A32008A7D79 /* InMemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* InMemoryStorage.swift */; };
 		OBJ_100 /* Mediator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* Mediator.swift */; };
 		OBJ_101 /* AmplitudeDestinationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* AmplitudeDestinationPlugin.swift */; };
 		OBJ_102 /* ContextPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* ContextPlugin.swift */; };
@@ -187,7 +187,6 @@
 		OBJ_107 /* VendorSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* VendorSystem.swift */; };
 		OBJ_108 /* IOSLifecycleMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* IOSLifecycleMonitor.swift */; };
 		OBJ_109 /* WatchOSLifecycleMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* WatchOSLifecycleMonitor.swift */; };
-		OBJ_111 /* InMemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* InMemoryStorage.swift */; };
 		OBJ_112 /* PersistentStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* PersistentStorage.swift */; };
 		OBJ_113 /* Timeline.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_40 /* Timeline.swift */; };
 		OBJ_114 /* TrackingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* TrackingOptions.swift */; };
@@ -560,7 +559,6 @@
 		OBJ_37 /* Storages */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_38 /* InMemoryStorage.swift */,
 				OBJ_39 /* PersistentStorage.swift */,
 			);
 			path = Storages;
@@ -660,6 +658,7 @@
 			isa = PBXGroup;
 			children = (
 				EAE891862DA83B6600AB97D0 /* FakeURLProtocol.swift */,
+				OBJ_38 /* InMemoryStorage.swift */,
 				OBJ_67 /* TestUtilities.swift */,
 			);
 			path = Supports;
@@ -936,7 +935,6 @@
 				EAED9A112EE7B47E00A5FC08 /* IOSLifecycleMonitor.swift in Sources */,
 				EAED9A122EE7B47E00A5FC08 /* WatchOSLifecycleMonitor.swift in Sources */,
 				EAED9A132EE7B47E00A5FC08 /* ObjCNetworkConnectivityCheckerPlugin.swift in Sources */,
-				EAED9A142EE7B47E00A5FC08 /* InMemoryStorage.swift in Sources */,
 				EAED9A152EE7B47E00A5FC08 /* DispatchQueueHolder.swift in Sources */,
 				EAED9A162EE7B47E00A5FC08 /* DefaultEventUtils.swift in Sources */,
 				4ED02BB92F299298001AE863 /* Data+Gzip.swift in Sources */,
@@ -1036,6 +1034,7 @@
 				OBJ_158 /* UrlExtensionTests.swift in Sources */,
 				EAE989292DA831F200835345 /* NetworkTrackingPluginTest.swift in Sources */,
 				8EDEC4EE0DE1C89889F451B5 /* QueueTimeTests.swift in Sources */,
+				F01A983E30448A32008A7D79 /* InMemoryStorage.swift in Sources */,
 				BA1EC0F62A9F63FD00C2D547 /* AmplitudeIOSTests.swift in Sources */,
 				4E5F89452F2AB9B60015FBC6 /* Data+Gzip.swift in Sources */,
 				8EDEC14255F82E24CEE00B36 /* AmplitudeSessionTests.swift in Sources */,
@@ -1077,7 +1076,6 @@
 				OBJ_108 /* IOSLifecycleMonitor.swift in Sources */,
 				OBJ_109 /* WatchOSLifecycleMonitor.swift in Sources */,
 				B6CCC6CD2B6B14510004B203 /* ObjCNetworkConnectivityCheckerPlugin.swift in Sources */,
-				OBJ_111 /* InMemoryStorage.swift in Sources */,
 				3E281B912B9BCC14009D913B /* DispatchQueueHolder.swift in Sources */,
 				B605396A2BB767390027FC24 /* DefaultEventUtils.swift in Sources */,
 				4ED02BB82F299298001AE863 /* Data+Gzip.swift in Sources */,

--- a/Tests/AmplitudeTests/Supports/InMemoryStorage.swift
+++ b/Tests/AmplitudeTests/Supports/InMemoryStorage.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+@testable import AmplitudeSwift
+
 class InMemoryStorage: Storage {
     typealias EventBlock = URL
 
@@ -44,6 +46,6 @@ class InMemoryStorage: Storage {
         eventBlock: EventBlock,
         eventsString: String
     ) -> ResponseHandler {
-        abort()
+        fatalError()
     }
 }


### PR DESCRIPTION
### Summary

Move the `InMemoryStorage` class from the SDK target to the tests target. This class is non public and unused in the SDK, it is only used for tests, so it is better located there.

At the same time we replace `abort()` with `fatalError()` which is the standard "Swift" way of terminating execution.

Another motivation for this change is that we noticed that symbolication of `abort()` calls made in other places were attributed to Amplitude, which was creating confusion.
```
Thread 10 Crashed:
0   libsystem_kernel.dylib   0x4844ad1d0  __pthread_kill
1   libsystem_c.dylib        0x33c7cefc8  abort
2   <redacted>               0x20918bd34  _RNvNtNtNtCs5DN45LDO9iv_3std3sys3pal4unix14abort_internal (InMemoryStorage.swift:47)
3   <redacted>               0x204a74f48  _RNvNtCs5DN45LDO9iv_3std7process5abort
4   <redacted>               0x2091b4bcc  std::alloc::rust_oom::{closure#0} (alloc.rs:441)
...
87  <redacted>               0x207ae787c  std::sys::thread::unix::Thread::new::thread_start (unix.rs:123)
88  libsystem_pthread.dylib  0x3e43b8434  _pthread_start
```

Note that tests seem to be using `FakeInMemoryStorage` almost everywhere, so `InMemoryStorage` class could also be removed and replaced by that one.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-target and Xcode wiring only; no public SDK API or runtime behavior change for integrators.
> 
> **Overview**
> Moves the internal **`InMemoryStorage`** test double out of the shipped **Amplitude-Swift** / **NoUIKit** targets so it only compiles with **Amplitude-SwiftTests**, grouped under `Tests/AmplitudeTests/Supports` in the Xcode project.
> 
> The helper now **`@testable import AmplitudeSwift`** so it can still implement the SDK **`Storage`** protocol from the test bundle. **`getResponseHandler`** uses **`fatalError()`** instead of **`abort()`**, which avoids crash stacks incorrectly pointing at Amplitude when unrelated **`abort()`** paths are symbolicated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98947642e924226d3b09b76d381f30bf04bab097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->