### PR TITLE
ci: drop test retries and dump runner hardware info for flake repro

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -212,25 +212,31 @@ jobs:
             echo "no test output captured"
             exit 0
           fi
-          # xcodebuild prints exactly one of these per iteration.
+          # xcodebuild prints exactly one 'All tests' marker per iteration.
           total="$(grep -cE "Test Suite 'All tests' (passed|failed)" "$LOG" || true)"
+          # Two metrics, because they disagree: run 33670018561's iOS 18.5 leg
+          # logged two failing test cases but only one red 'All tests' marker,
+          # so the marker is a floor on how many iterations were bad. The
+          # test-case count is the reliable signal of how often a given test
+          # misbehaves.
           red="$(grep -cE "Test Suite 'All tests' failed" "$LOG" || true)"
+          cases="$(grep -cE "Test Case '-\[.*\]' failed" "$LOG" || true)"
           {
             echo "### ${{ matrix.platform }} ${{ matrix.test-destination-os }}"
             echo
-            echo "| iterations | red | flake rate |"
-            echo "|---:|---:|---:|"
+            echo "| iterations | red iterations | flake rate | failing test cases |"
+            echo "|---:|---:|---:|---:|"
             if [ "${total:-0}" -gt 0 ]; then
               # Values via -v, not interpolated into the program: the runner's
               # /bin/bash is 3.2, which mis-parses an escaped double quote
               # inside $( ) inside a double-quoted string and silently hands
               # awk a truncated program.
               rate="$(awk -v r="$red" -v t="$total" 'BEGIN{ printf "%.1f%%", r * 100 / t }')"
-              echo "| $total | $red | $rate |"
+              echo "| $total | $red | $rate | $cases |"
             else
-              echo "| 0 | 0 | n/a — bundle never ran |"
+              echo "| 0 | 0 | n/a — no iteration markers found | $cases |"
             fi
-            if [ "${red:-0}" -gt 0 ]; then
+            if [ "${cases:-0}" -gt 0 ]; then
               echo
               echo "Failures by test (count over $total iterations):"
               echo

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -5,8 +5,8 @@ name: Unit Test
 # Differences from main, all in service of reproducing the UT flakiness:
 #   1. `-retry-tests-on-failure` removed from every leg, so a flake shows up as
 #      a red run instead of being papered over by the retry.
-#   2. The test bundle can be run N times per leg, stopping at the first
-#      failure, via TEST_ITERATIONS below.
+#   2. The test bundle can be run N independent times per leg via
+#      TEST_ITERATIONS below, to measure a flake rate.
 #   3. A "Runner info" step dumps the runner's hardware/OS/toolchain and some
 #      micro benchmarks (scripts/ci_runner_info.sh), so we can try to mirror the
 #      runner locally.
@@ -34,7 +34,7 @@ on:
   workflow_dispatch:
     inputs:
       test_iterations:
-        description: "Run the test bundle this many times per leg, stopping at the first failure (1 = normal single run)"
+        description: "Run the test bundle this many independent times per leg to measure a flake rate (1 = normal single run)"
         required: false
         default: "1"
 
@@ -45,6 +45,9 @@ jobs:
   unit-test:
     name: Unit ${{ matrix.platform }} - Xcode ${{ matrix.xcode }} - OS ${{ matrix.test-destination-os }}
     runs-on: ${{ matrix.runs-on }}
+    # A high TEST_ITERATIONS run is long by design; cap it well under the 6h
+    # default so a hung simulator does not hold a runner all day.
+    timeout-minutes: 180
 
     strategy:
       fail-fast: false
@@ -124,16 +127,37 @@ jobs:
       - name: ${{ matrix.platform }} Tests
         run: |
           # -retry-tests-on-failure is deliberately absent -- see header.
-          # -run-tests-until-failure stops at the first failing iteration, which
-          # is what we want when hunting a flake.
           echo "TEST_ITERATIONS=${TEST_ITERATIONS:-1}"
           EXTRA_FLAGS=()
           if [ "${TEST_ITERATIONS:-1}" -gt 1 ]; then
-            EXTRA_FLAGS+=(-test-iterations "$TEST_ITERATIONS" -run-tests-until-failure)
+            # Every iteration runs to completion. -run-tests-until-failure would
+            # stop at the first red one, measuring time-to-first-failure rather
+            # than a rate.
+            #
+            # -test-repetition-relaunch-enabled YES gives each iteration a fresh
+            # process, making it an independent sample of what one real CI run
+            # does. Without it iterations share a process, the suite's static
+            # state (e.g. DefaultEventUtils.instanceNamesThatSentAppUpdated-
+            # Installed) carries across them, and 2..N stop resembling a real
+            # run.
+            #
+            # Diagnostics off: on-failure collects a sysdiagnose per failure,
+            # which is why the two red legs uploaded 66 MB and 38 MB bundles.
+            # Times 25 iterations that is unmanageable, and for a rate we only
+            # need the counts.
+            EXTRA_FLAGS+=(
+              -test-iterations "$TEST_ITERATIONS"
+              -test-repetition-relaunch-enabled YES
+              -collect-test-diagnostics never
+            )
           fi
           RESULT_BUNDLE="results/${{ matrix.platform }}-${{ matrix.test-destination-os }}.xcresult"
           mkdir -p results
 
+          # tee so the flake summary step can count iterations; pipefail so a
+          # test failure still fails this step.
+          set -o pipefail
+          {
           case "${{ matrix.platform }}" in
             iOS)
               xcodebuild test \
@@ -179,6 +203,39 @@ jobs:
                 test
               ;;
           esac
+          } 2>&1 | tee results/test-output.log
+      - name: Flake summary
+        if: always()
+        run: |
+          LOG="results/test-output.log"
+          if [ ! -f "$LOG" ]; then
+            echo "no test output captured"
+            exit 0
+          fi
+          # xcodebuild prints exactly one of these per iteration.
+          total="$(grep -cE "Test Suite 'All tests' (passed|failed)" "$LOG" || true)"
+          red="$(grep -cE "Test Suite 'All tests' failed" "$LOG" || true)"
+          {
+            echo "### ${{ matrix.platform }} ${{ matrix.test-destination-os }}"
+            echo
+            echo "| iterations | red | flake rate |"
+            echo "|---:|---:|---:|"
+            if [ "${total:-0}" -gt 0 ]; then
+              echo "| $total | $red | $(awk "BEGIN{printf \"%.1f%%\", $red * 100 / $total}") |"
+            else
+              echo "| 0 | 0 | n/a — bundle never ran |"
+            fi
+            if [ "${red:-0}" -gt 0 ]; then
+              echo
+              echo "Failures by test (count over $total iterations):"
+              echo
+              echo '```'
+              grep -oE "Test Case '-\[[A-Za-z_.]+ [A-Za-z_0-9]+\]' failed" "$LOG" \
+                | sed -E "s/Test Case '-\[(.*)\]' failed/\1/" \
+                | sort | uniq -c | sort -rn
+              echo '```'
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"
       - name: Runner info (post-test)
         if: always()
         run: |
@@ -228,7 +285,11 @@ jobs:
           # -retry-tests-on-failure deliberately absent -- see header.
           EXTRA_FLAGS=()
           if [ "${TEST_ITERATIONS:-1}" -gt 1 ]; then
-            EXTRA_FLAGS+=(-test-iterations "$TEST_ITERATIONS" -run-tests-until-failure)
+            EXTRA_FLAGS+=(
+              -test-iterations "$TEST_ITERATIONS"
+              -test-repetition-relaunch-enabled YES
+              -collect-test-diagnostics never
+            )
           fi
           mkdir -p "$GITHUB_WORKSPACE/results"
           xcodebuild test \

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,11 +1,45 @@
 name: Unit Test
 
+# REPRO BRANCH -- do not merge.
+#
+# Differences from main, all in service of reproducing the UT flakiness:
+#   1. `-retry-tests-on-failure` removed from every leg, so a flake shows up as
+#      a red run instead of being papered over by the retry.
+#   2. The test bundle can be run N times per leg, stopping at the first
+#      failure, via TEST_ITERATIONS below.
+#   3. A "Runner info" step dumps the runner's hardware/OS/toolchain and some
+#      micro benchmarks (scripts/ci_runner_info.sh), so we can try to mirror the
+#      runner locally.
+#   4. Every leg writes an .xcresult bundle and uploads it, so a failure can be
+#      inspected (per-test timings, attachments, os_log) after the fact.
+#
+# How to get runs out of this branch: open a draft PR, which makes every push
+# trigger `pull_request`, then `gh run rerun <id>` to replay the same commit as
+# many times as you like. Note that `workflow_dispatch` and its inputs are only
+# offered by GitHub once the workflow file is on the *default* branch, so the
+# input below is unusable from here -- use the `vars` fallback instead:
+#
+#   gh variable set TEST_ITERATIONS --body 25 --repo amplitude/Amplitude-Swift
+#   gh variable delete TEST_ITERATIONS --repo amplitude/Amplitude-Swift
+#
+# main's copy of this workflow does not read that variable, so setting it only
+# affects this branch.
+
 on:
   pull_request:
   push:
     branches:
       - main
   workflow_call:
+  workflow_dispatch:
+    inputs:
+      test_iterations:
+        description: "Run the test bundle this many times per leg, stopping at the first failure (1 = normal single run)"
+        required: false
+        default: "1"
+
+env:
+  TEST_ITERATIONS: ${{ inputs.test_iterations || vars.TEST_ITERATIONS || '1' }}
 
 jobs:
   unit-test:
@@ -27,7 +61,7 @@ jobs:
             xcode: 16.4
             test-destination-os: 18.5
             device: "iPhone 16"
-          
+
           - runs-on: macos-15
             platform: macOS
             xcode: 16.4
@@ -81,28 +115,48 @@ jobs:
       - name: List Project Configuration
         run: |
           xcodebuild -list
+      - name: Runner info
+        # Deliberately the last step before the tests: the simulator runtimes
+        # are installed by now and the load/thermal snapshot reflects the state
+        # the test bundle actually starts in.
+        run: |
+          scripts/ci_runner_info.sh runner-info
       - name: ${{ matrix.platform }} Tests
         run: |
+          # -retry-tests-on-failure is deliberately absent -- see header.
+          # -run-tests-until-failure stops at the first failing iteration, which
+          # is what we want when hunting a flake.
+          echo "TEST_ITERATIONS=${TEST_ITERATIONS:-1}"
+          EXTRA_FLAGS=()
+          if [ "${TEST_ITERATIONS:-1}" -gt 1 ]; then
+            EXTRA_FLAGS+=(-test-iterations "$TEST_ITERATIONS" -run-tests-until-failure)
+          fi
+          RESULT_BUNDLE="results/${{ matrix.platform }}-${{ matrix.test-destination-os }}.xcresult"
+          mkdir -p results
+
           case "${{ matrix.platform }}" in
             iOS)
               xcodebuild test \
                 -scheme Amplitude-Swift-Package \
                 -sdk iphonesimulator \
-                -retry-tests-on-failure \
+                -resultBundlePath "$RESULT_BUNDLE" \
+                "${EXTRA_FLAGS[@]}" \
                 -destination 'platform=iOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}'
               ;;
             macOS)
               xcodebuild test \
                 -scheme Amplitude-Swift-Package \
                 -sdk macosx \
-                -retry-tests-on-failure \
+                -resultBundlePath "$RESULT_BUNDLE" \
+                "${EXTRA_FLAGS[@]}" \
                 -destination 'platform=macOS'
               ;;
             tvOS)
               xcodebuild \
                 -scheme Amplitude-Swift-Package \
                 -sdk appletvsimulator \
-                -retry-tests-on-failure \
+                -resultBundlePath "$RESULT_BUNDLE" \
+                "${EXTRA_FLAGS[@]}" \
                 -destination 'platform=tvOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
                 test
               ;;
@@ -110,7 +164,8 @@ jobs:
               xcodebuild \
                 -scheme Amplitude-Swift-Package \
                 -sdk watchsimulator \
-                -retry-tests-on-failure \
+                -resultBundlePath "$RESULT_BUNDLE" \
+                "${EXTRA_FLAGS[@]}" \
                 -destination 'platform=watchOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
                 test
               ;;
@@ -118,11 +173,38 @@ jobs:
               xcodebuild \
                 -scheme Amplitude-Swift-Package \
                 -sdk xrsimulator \
-                -retry-tests-on-failure \
+                -resultBundlePath "$RESULT_BUNDLE" \
+                "${EXTRA_FLAGS[@]}" \
                 -destination 'platform=visionOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
                 test
               ;;
           esac
+      - name: Runner info (post-test)
+        if: always()
+        run: |
+          # Second snapshot: load, free disk and thermals after the bundle ran,
+          # so we can tell a leg that was starved from one that was not.
+          echo "::group::load / disk / thermals after tests"
+          sysctl -n vm.loadavg
+          df -h /
+          vm_stat
+          pmset -g therm || true
+          echo "::endgroup::"
+      - name: Upload runner info
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runner-info-${{ matrix.platform }}-${{ matrix.test-destination-os }}
+          path: runner-info/
+          if-no-files-found: warn
+      - name: Upload xcresult bundle
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: xcresult-${{ matrix.platform }}-${{ matrix.test-destination-os }}
+          path: results/
+          if-no-files-found: warn
+
   objc-example-test:
     runs-on: macos-15
     steps:
@@ -137,11 +219,35 @@ jobs:
           # https://github.com/actions/runner-images/issues/12862#issuecomment-3239326872
           xcrun simctl list > /dev/null
           sudo xcodebuild -downloadPlatform iOS
+      - name: Runner info
+        run: |
+          scripts/ci_runner_info.sh runner-info
       - name: Objective-C Example Tests (iOS)
         working-directory: Examples/AmplitudeObjCExample
         run: |
+          # -retry-tests-on-failure deliberately absent -- see header.
+          EXTRA_FLAGS=()
+          if [ "${TEST_ITERATIONS:-1}" -gt 1 ]; then
+            EXTRA_FLAGS+=(-test-iterations "$TEST_ITERATIONS" -run-tests-until-failure)
+          fi
+          mkdir -p "$GITHUB_WORKSPACE/results"
           xcodebuild test \
             -scheme AmplitudeObjCExample \
             -sdk iphonesimulator \
-            -retry-tests-on-failure \
+            -resultBundlePath "$GITHUB_WORKSPACE/results/objc-example.xcresult" \
+            "${EXTRA_FLAGS[@]}" \
             -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16'
+      - name: Upload runner info
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: runner-info-objc-example
+          path: runner-info/
+          if-no-files-found: warn
+      - name: Upload xcresult bundle
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: xcresult-objc-example
+          path: results/
+          if-no-files-found: warn

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -221,7 +221,12 @@ jobs:
             echo "| iterations | red | flake rate |"
             echo "|---:|---:|---:|"
             if [ "${total:-0}" -gt 0 ]; then
-              echo "| $total | $red | $(awk "BEGIN{printf \"%.1f%%\", $red * 100 / $total}") |"
+              # Values via -v, not interpolated into the program: the runner's
+              # /bin/bash is 3.2, which mis-parses an escaped double quote
+              # inside $( ) inside a double-quoted string and silently hands
+              # awk a truncated program.
+              rate="$(awk -v r="$red" -v t="$total" 'BEGIN{ printf "%.1f%%", r * 100 / t }')"
+              echo "| $total | $red | $rate |"
             else
               echo "| 0 | 0 | n/a — bundle never ran |"
             fi

--- a/Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist
+++ b/Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist
@@ -20,6 +20,6 @@
   <key>CFBundleVersion</key>
   <string>$(CURRENT_PROJECT_VERSION)</string>
   <key>NSPrincipalClass</key>
-  <string></string>
+  <string>AMPTestBundlePrincipal</string>
 </dict>
 </plist>

--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		OBJ_150 /* RevenueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* RevenueTests.swift */; };
 		OBJ_151 /* PersistentStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_65 /* PersistentStorageTests.swift */; };
 		OBJ_152 /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_67 /* TestUtilities.swift */; };
+		A7C0FF1E2E6F0001000000A2 /* RemoteConfigMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C0FF1E2E6F0001000000A1 /* RemoteConfigMockServer.swift */; };
 		OBJ_153 /* TimelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_68 /* TimelineTests.swift */; };
 		OBJ_154 /* TypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_69 /* TypesTests.swift */; };
 		OBJ_155 /* EventPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* EventPipelineTests.swift */; };
@@ -367,6 +368,7 @@
 		OBJ_63 /* RevenueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevenueTests.swift; sourceTree = "<group>"; };
 		OBJ_65 /* PersistentStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentStorageTests.swift; sourceTree = "<group>"; };
 		OBJ_67 /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
+		A7C0FF1E2E6F0001000000A1 /* RemoteConfigMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigMockServer.swift; sourceTree = "<group>"; };
 		OBJ_68 /* TimelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineTests.swift; sourceTree = "<group>"; };
 		OBJ_69 /* TypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypesTests.swift; sourceTree = "<group>"; };
 		OBJ_71 /* EventPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPipelineTests.swift; sourceTree = "<group>"; };
@@ -661,6 +663,7 @@
 			children = (
 				EAE891862DA83B6600AB97D0 /* FakeURLProtocol.swift */,
 				OBJ_67 /* TestUtilities.swift */,
+				A7C0FF1E2E6F0001000000A1 /* RemoteConfigMockServer.swift */,
 			);
 			path = Supports;
 			sourceTree = "<group>";
@@ -1018,6 +1021,7 @@
 				OBJ_151 /* PersistentStorageTests.swift in Sources */,
 				4E654DE12D9B60E700BCAA85 /* IdentityTests.swift in Sources */,
 				OBJ_152 /* TestUtilities.swift in Sources */,
+				A7C0FF1E2E6F0001000000A2 /* RemoteConfigMockServer.swift in Sources */,
 				6C23EF162C38AD31000DC8C8 /* UIKitUserInteractionPluginTest.swift in Sources */,
 				AB03FE202E58AC34000DC8CA /* WebViewDeadClickTests.swift in Sources */,
 				OBJ_153 /* TimelineTests.swift in Sources */,

--- a/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
+++ b/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
@@ -8,38 +8,29 @@
 import AmplitudeCore
 @testable
 import AmplitudeSwift
-import ObjectiveC
 import XCTest
 
+// Each test follows the same shape, and the order matters:
+//
+//   1. queue the remote config for this test's API key -- the mock holds it;
+//   2. init Amplitude and assert the *local* defaults -- the remote config provably
+//      has not arrived, because nothing has released it;
+//   3. register `remoteConfigAppliedExpectation()`, release the mock, wait;
+//   4. assert the remote values.
+//
+// Nothing here depends on how long any step takes. See RemoteConfigMockServer.
 class AutocaptureRemoteConfigTests: XCTestCase {
-
-    private static func swizzleEphemeral() {
-        let metaClass: AnyClass = object_getClass(URLSessionConfiguration.self)!
-        let originalSel = #selector(getter: URLSessionConfiguration.ephemeral)
-        let swizzledSel = #selector(URLSessionConfiguration.amp_ephemeral)
-
-        guard let original = class_getClassMethod(metaClass, originalSel),
-              let swizzled = class_getClassMethod(metaClass, swizzledSel) else {
-            return
-        }
-
-        method_exchangeImplementations(original, swizzled)
-    }
 
     override class func setUp() {
         super.setUp()
-        swizzleEphemeral()
-    }
-
-    override class func tearDown() {
-        // Swizzle again to restore original behavior
-        swizzleEphemeral()
-        super.tearDown()
+        // Already done by TestBundlePrincipal under xcodebuild; idempotent safety net
+        // for runners that ignore NSPrincipalClass, such as `swift test`.
+        RemoteConfigMockServer.install()
     }
 
     private func uniqueApiKey(_ function: String = #function) -> String {
         let cleanName = function.replacingOccurrences(of: "()", with: "")
-        return "\(RemoteConfigUrlProtocol.testApiKeyPrefix)\(cleanName)"
+        return "\(RemoteConfigMockServer.testApiKeyPrefix)\(cleanName)"
     }
 
     private func uniqueInstanceName(_ function: String = #function) -> String {
@@ -68,7 +59,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: []))
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be on from remote config")
     }
@@ -89,7 +82,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: [.sessions]))
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be off from remote config")
     }
@@ -121,7 +116,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be on from remote config")
     }
@@ -152,7 +149,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be off from remote config")
     }
@@ -183,7 +182,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be on from remote config")
     }
@@ -214,7 +215,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be off from remote config")
     }
@@ -263,7 +266,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertFalse(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be off by default")
         XCTAssertFalse(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on from remote config")
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on from remote config")
@@ -308,7 +313,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")
         XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be off from remote config")
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should still be on from local config")
@@ -358,7 +365,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")
         XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on by default")
         XCTAssertFalse(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be off from remote config")
@@ -396,7 +405,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertTrue(networkTrackingPlugin.optOut, "Network tracking should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(networkTrackingPlugin.optOut, "Network tracking should be on from remote config")
     }
@@ -431,7 +442,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertFalse(networkTrackingPlugin.optOut, "Network tracking should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(networkTrackingPlugin.optOut, "Network tracking should be on from remote config")
     }
@@ -491,7 +504,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         // Verify the plugin is enabled
         XCTAssertFalse(networkTrackingPlugin.optOut)
@@ -575,7 +590,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         // Verify the plugin is enabled from remote config
         XCTAssertFalse(networkTrackingPlugin.optOut)
@@ -591,122 +608,4 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertEqual(networkTrackingPlugin.originalOptions?.ignoreAmplitudeRequests, false)
     }
 #endif
-}
-
-extension RemoteConfigClient {
-
-    private final class SubscriptionHolder: @unchecked Sendable {
-        @AtomicRef var subscription: Any?
-    }
-
-    nonisolated var didFetchRemoteExpectation: XCTestExpectation {
-        let expectation = XCTestExpectation(description: "didFetchRemote")
-
-        let subscriptionHolder = SubscriptionHolder()
-        subscriptionHolder.subscription = subscribe(deliveryMode: .waitForRemote(timeout: 1.8)) { [weak self] _, _, _ in
-            if let subscription = subscriptionHolder.subscription {
-                self?.unsubscribe(subscription)
-            }
-            // Add a small delay to ensure other subscription callbacks complete.
-            // Callbacks are processed asynchronously, so even though this subscription
-            // was registered after the plugin's subscription, there's no guarantee
-            // about callback execution order.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                expectation.fulfill()
-            }
-        }
-
-        return expectation
-    }
-
-    static func setNextFetchedRemoteConfig(_ remoteConfig: RemoteConfigClient.RemoteConfig, forApiKey apiKey: String) {
-        RemoteConfigUrlProtocol.setConfig(remoteConfig, forApiKey: apiKey)
-    }
-
-    static func resetStorage(instanceName: String) {
-        let suiteName = "com.amplitude.remoteconfig.cache.\(instanceName)"
-        UserDefaults.standard.removePersistentDomain(forName: suiteName)
-    }
-}
-
-extension URLSessionConfiguration {
-
-    @objc class func amp_ephemeral() -> URLSessionConfiguration {
-        // This is swizzled, so amp_ephemeral actually calls the original ephemeral
-        let config = amp_ephemeral()
-        config.protocolClasses = [RemoteConfigUrlProtocol.self] + (config.protocolClasses ?? [])
-        return config
-    }
-}
-
-class RemoteConfigUrlProtocol: URLProtocol {
-
-    static let testApiKeyPrefix = "remote-config-test-"
-    // Configs keyed by API key for test isolation
-    static var configsByApiKey: [String: [RemoteConfigClient.RemoteConfig]] = [:]
-
-    private static let responseQueue = DispatchQueue(label: "RemoteConfigUrlProtocol.responseQueue")
-
-    static func setConfig(_ config: RemoteConfigClient.RemoteConfig, forApiKey apiKey: String) {
-        configsByApiKey[apiKey, default: []].append(config)
-    }
-
-    static func popConfig(forApiKey apiKey: String) -> RemoteConfigClient.RemoteConfig? {
-        guard var configs = configsByApiKey[apiKey], !configs.isEmpty else {
-            return nil
-        }
-        let config = configs.removeFirst()
-        configsByApiKey[apiKey] = configs
-        return config
-    }
-
-    private static func extractApiKey(from url: URL) -> String? {
-        // URL format: https://sr-client-cfg.amplitude.com/config/{apiKey}
-        return url.pathComponents.last?.components(separatedBy: "?").first
-    }
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        guard let url = request.url,
-              url.absoluteString.hasPrefix("https://sr-client-cfg."),
-              let apiKey = extractApiKey(from: url) else {
-            return false
-        }
-        // Only intercept requests with our test API key prefix
-        return apiKey.hasPrefix(testApiKeyPrefix)
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        return request
-    }
-
-    override func startLoading() {
-        guard let url = request.url,
-              let apiKey = Self.extractApiKey(from: url),
-              let config = Self.popConfig(forApiKey: apiKey) else {
-            client?.urlProtocol(self, didFailWithError: NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown))
-            return
-        }
-
-        print("RemoteConfigUrlProtocol: Starting to load \(url)")
-
-        let response = HTTPURLResponse(url: url,
-                                       statusCode: 200,
-                                       httpVersion: nil,
-                                       headerFields: ["Content-Type": "application/json"])!
-        let data = try? JSONSerialization.data(withJSONObject: ["configs": config])
-
-        Self.responseQueue.asyncAfter(deadline: .now() + DispatchTimeInterval.milliseconds(500)) { [self] in
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            if let data {
-                client?.urlProtocol(self, didLoad: data)
-            }
-            client?.urlProtocolDidFinishLoading(self)
-
-            print("RemoteConfigUrlProtocol: Finished loading \(url): \(config)")
-        }
-    }
-
-    override func stopLoading() {
-        // no-op
-    }
 }

--- a/Tests/AmplitudeTests/Plugins/NetworkConnectivityCheckerPluginTests.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkConnectivityCheckerPluginTests.swift
@@ -17,7 +17,12 @@ final class NetworkConnectivityCheckerPluginTests: XCTestCase {
     override func setUp() {
         super.setUp()
         mockPathCreation = MockPathCreation()
-        amplitude = Amplitude(configuration: Configuration(apiKey: "test-api-key"))
+        // Disabled keeps Amplitude.init from installing its own NetworkConnectivityCheckerPlugin,
+        // whose real NWPathMonitor also writes configuration.offline from the tracking queue --
+        // a second writer racing the mock-driven plugin under test, which on a busy runner
+        // flipped the value back between simulateNetworkChange and the assertion.
+        amplitude = Amplitude(configuration: Configuration(apiKey: "test-api-key",
+                                                           offline: NetworkConnectivityCheckerPlugin.Disabled))
         plugin = NetworkConnectivityCheckerPlugin(pathCreation: mockPathCreation)
         plugin.setup(amplitude: amplitude)
     }

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -450,8 +450,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: [expectation3], timeout: 30)
 
         try waitForCollectedEvents(2)
-        plugin.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2)
@@ -542,9 +541,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 30)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(1)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1, "Should capture only matching URLs")
@@ -682,9 +680,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 30)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(4)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 4, "Should capture only URLs matching the anchored regex patterns")
@@ -736,8 +733,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(1)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1, "URL patterns should take priority over host patterns")

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -47,6 +47,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
     override func tearDown() {
         super.tearDown()
         eventCollector.events.removeAll()
+        FakeURLProtocol.clearMockResponses()
         // Only invalidate custom timeout sessions - shared session is reused
         customTimeoutSessions.forEach { $0.invalidateAndCancel() }
         customTimeoutSessions.removeAll()
@@ -159,7 +160,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
     func testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude() throws {
         setupAmplitude()
 
-        FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
+        FakeURLProtocol.amplitudeResponses = [.init(statusCode: 500)]
 
         amplitude.track(eventType: "Test")
         amplitude.flush()
@@ -178,7 +179,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         options.ignoreAmplitudeRequests = false
         setupAmplitude(with: options)
 
-        FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
+        FakeURLProtocol.amplitudeResponses = [.init(statusCode: 500)]
 
         // Two events reach the collector: the tracked "Test" event, then the network event for
         // the flush that uploads it (ignoreAmplitudeRequests is off; flushMaxRetries is 0, so

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -155,9 +155,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation], timeout: 30)
 
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 0, "Should not capture network request event with status code 200")
@@ -166,14 +164,17 @@ final class NetworkTrackingPluginTest: XCTestCase {
     func testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude() throws {
         setupAmplitude()
 
+        // A 500 would be captured if the upload were not ignored, so this test only proves
+        // anything once that upload has actually been answered.
         FakeURLProtocol.amplitudeResponses = [.init(statusCode: 500)]
+        let uploaded = expectAmplitudeUpload()
 
         amplitude.track(eventType: "Test")
         amplitude.flush()
 
+        wait(for: [uploaded], timeout: 30)
         try waitForCollectedEvents(1)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -193,6 +194,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         amplitude.track(eventType: "Test")
         amplitude.flush()
         try waitForCollectedEvents(2)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2)
@@ -217,8 +219,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: expectations, timeout: 30)
 
-        amplitude.waitForTrackingQueue()
-        wait()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 0)
@@ -278,8 +279,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: expectations, timeout: 30)
 
-        amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(2)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture two network requests")
@@ -606,9 +607,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 30)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(3)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 3, "Should capture only regex matching URLs")
@@ -790,8 +790,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(2)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture only GET and POST requests")
@@ -936,8 +935,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(2)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture only requests matching both URL and method criteria")
@@ -1203,8 +1201,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(3)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 3, "Should capture requests matching any of the rules")
@@ -1221,12 +1218,35 @@ final class NetworkTrackingPluginTest: XCTestCase {
     }
 #endif
 
-    /// Fixed sleep. Only for asserting that *nothing* was captured -- a sleep that is too short
-    /// can make such a test pass wrongly, but cannot make it fail. For "N events captured" use
-    /// `waitForCollectedEvents`.
+    /// Fixed sleep. Only needed for requests a test expects NOT to be captured -- a sleep
+    /// that is too short can make such an assertion pass wrongly, but cannot make it fail. For
+    /// "N events captured" use `waitForCollectedEvents`; a test that has both waits for the N
+    /// first and then calls `settleUncapturedRequests`.
     func wait(for interval: TimeInterval = 0.1) {
         let expectation = XCTestExpectation(description: "Wait for time interval")
         XCTWaiter().wait(for: [expectation], timeout: interval)
+    }
+
+    /// Call before asserting that some request was NOT captured. The plugin records a request
+    /// from its `setState(.completed)` hook, and URLSession runs that after the completion
+    /// handler that fulfilled the test's expectation -- so when every expected event has
+    /// arrived, the event for a wrongly captured request may still be a few hops away. The
+    /// queue drains alone cannot help (they only flush work already enqueued); the sleep
+    /// gives that work time to be enqueued, the drains then push it through to the collector.
+    func settleUncapturedRequests() {
+        wait()
+        networkTrackingPlugin?.waitforNetworkTrackingQueue()
+        amplitude.waitForTrackingQueue()
+    }
+
+    /// Expectation fulfilled once the mock has answered the SDK's own upload to api2. A test
+    /// asserting that this upload was NOT captured must wait for it first: before the request
+    /// has completed, "no network event yet" proves nothing.
+    func expectAmplitudeUpload() -> XCTestExpectation {
+        let uploaded = XCTestExpectation(description: "amplitude upload answered")
+        uploaded.assertForOverFulfill = false
+        FakeURLProtocol.onAmplitudeRequestFinished = { _ in uploaded.fulfill() }
+        return uploaded
     }
 
     private struct CollectedEventsTimeout: Error {}

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -173,25 +173,32 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertFalse(events[0] is NetworkRequestEvent)
     }
 
-    func testNetworkTrackingOptionsIgnoreAmplitudeRequestsFalse() {
+    func testNetworkTrackingOptionsIgnoreAmplitudeRequestsFalse() throws {
         var options = NetworkTrackingOptions.default
         options.ignoreAmplitudeRequests = false
         setupAmplitude(with: options)
 
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
 
+        // Two events reach the collector: the tracked "Test" event, then the network event for
+        // the flush that uploads it (ignoreAmplitudeRequests is off; flushMaxRetries is 0, so
+        // exactly one request). Wait for both rather than sleeping -- this used to be
+        // `wait(for: 0.1)` followed by `events[1] as!`, which on a slow runner found one event
+        // and took the whole test bundle down with an index-out-of-range trap.
+        let collected = expectation(description: "test event and network event collected")
+        collected.expectedFulfillmentCount = 2
+        collected.assertForOverFulfill = false
+        eventCollector.onEvent = { _ in collected.fulfill() }
+
         amplitude.track(eventType: "Test")
         amplitude.flush()
-
-        wait(for: 0.1)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        wait(for: [collected], timeout: 10)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2)
-        let event = events[1] as! NetworkRequestEvent
-        XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://api2.amplitude.com/2/httpapi")
+        let event = try XCTUnwrap(events.compactMap { $0 as? NetworkRequestEvent }.first)
+        XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as? String,
+                       "https://api2.amplitude.com/2/httpapi")
     }
 
     func testNetworkTrackingOptionsIgnoreHosts() {

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -108,7 +108,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
     }
 
 #if !os(watchOS)
-    func testDefaultNetworkTrackingOptionsShouldCapture500() {
+    func testDefaultNetworkTrackingOptionsShouldCapture500() throws {
         setupAmplitude()
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
 
@@ -118,7 +118,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation], timeout: 2)
 
-        wait()
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -156,7 +156,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(events.count, 0, "Should not capture network request event with status code 200")
     }
 
-    func testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude() {
+    func testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude() throws {
         setupAmplitude()
 
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
@@ -164,7 +164,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         amplitude.track(eventType: "Test")
         amplitude.flush()
 
-        wait()
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -182,17 +182,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         // Two events reach the collector: the tracked "Test" event, then the network event for
         // the flush that uploads it (ignoreAmplitudeRequests is off; flushMaxRetries is 0, so
-        // exactly one request). Wait for both rather than sleeping -- this used to be
-        // `wait(for: 0.1)` followed by `events[1] as!`, which on a slow runner found one event
-        // and took the whole test bundle down with an index-out-of-range trap.
-        let collected = expectation(description: "test event and network event collected")
-        collected.expectedFulfillmentCount = 2
-        collected.assertForOverFulfill = false
-        eventCollector.onEvent = { _ in collected.fulfill() }
-
+        // exactly one request).
         amplitude.track(eventType: "Test")
         amplitude.flush()
-        wait(for: [collected], timeout: 10)
+        try waitForCollectedEvents(2)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2)
@@ -224,7 +217,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(events.count, 0)
     }
 
-    func testNetworkTrackingOptionsCaptureHosts() {
+    func testNetworkTrackingOptionsCaptureHosts() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [.init(hosts: ["*.example.com", "example2.com"])]
         setupAmplitude(with: options)
@@ -245,7 +238,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
 
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(2)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture two network requests")
@@ -258,7 +251,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(urls.contains(url1), "Should capture requests to the specified hosts")
     }
 
-    func testNetworkTrackingOptionsCaptureStatusCode() {
+    func testNetworkTrackingOptionsCaptureStatusCode() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [.init(hosts: ["*"], statusCodeRange: "413,500-599")]
         setupAmplitude(with: options)
@@ -279,7 +272,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
 
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(2)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture two network requests")
@@ -292,7 +285,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(statusCodes.contains(500), "Should capture requests with status codes inside the specified range")
     }
 
-    func testNetworkTrackingOptionsCaptureLocalError() {
+    func testNetworkTrackingOptionsCaptureLocalError() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [.init(hosts: ["*"], statusCodeRange: "0")]
         setupAmplitude(with: options)
@@ -306,7 +299,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: [expectation], timeout: 2)
 
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(1)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -318,7 +311,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_ERROR_MESSAGE_PROPERTY] as! String, "The request timed out.")
     }
 
-    func testCapturingAsyncTasks() {
+    func testCapturingAsyncTasks() throws {
         setupAmplitude()
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
 
@@ -329,10 +322,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
+        try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
-
-        wait(for: 1)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -346,7 +337,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(event.eventProperties?[Constants.AMP_DURATION_PROPERTY] as! Int64 > 0)
     }
 
-    func testCapturingUploadTask() {
+    func testCapturingUploadTask() throws {
         setupAmplitude()
         let responseBodyData = "Bar".data(using: .utf8)!
         FakeURLProtocol.mockResponses = [.init(statusCode: 500, data: responseBodyData)]
@@ -362,7 +353,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }).resume()
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
+        try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -375,7 +366,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_RESPONSE_BODY_SIZE_PROPERTY] as! Int64, Int64(responseBodyData.count))
     }
 
-    func testCapturingDownloadTask() {
+    func testCapturingDownloadTask() throws {
         setupAmplitude()
 
         let responseBodyData = "Bar".data(using: .utf8)!
@@ -391,7 +382,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }).resume()
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
+        try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -401,7 +392,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_RESPONSE_BODY_SIZE_PROPERTY] as! Int64, Int64(responseBodyData.count))
     }
 
-    func testRuleForHost() {
+    func testRuleForHost() throws {
         let options = NetworkTrackingOptions(captureRules: [
             .init(hosts: ["*.example.com"], statusCodeRange: "0,500-599"),
             .init(hosts: ["api.example.com"], statusCodeRange: "400-499"),
@@ -450,7 +441,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation3], timeout: 2)
 
-        wait()
+        try waitForCollectedEvents(2)
         plugin.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -466,7 +457,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(event2.eventProperties?[Constants.AMP_NETWORK_STATUS_CODE_PROPERTY] as! Int, 500)
     }
 
-    func testCaptureHeaderFields() {
+    func testCaptureHeaderFields() throws {
         let requestHeaders = ["custom-header-1": "value1", "custom-header-2": "value2", "other-header": "value-other"]
         let responseHeaders = ["custom-header-3": "value3", "custom-header-4": "value4", "other-header": "value-other"]
         let expectedRequestHeaders = requestHeaders.filter { ["custom-header-1", "custom-header-2"].contains($0.key) }
@@ -486,7 +477,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
         let events = eventCollector.events
@@ -509,7 +500,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
     // MARK: - URL Pattern Matching Tests
 
-    func testURLExactMatching() {
+    func testURLExactMatching() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -545,7 +536,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(1)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1, "Should capture only matching URLs")
@@ -559,7 +550,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }
     }
 
-    func testURLRegexMatching() {
+    func testURLRegexMatching() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -610,7 +601,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(3)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 3, "Should capture only regex matching URLs")
@@ -624,7 +615,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(capturedURLs.contains("https://monitoring.example.com/health/status"))
     }
 
-    func testURLRegexAnchors() {
+    func testURLRegexAnchors() throws {
         // Test regex patterns with ^ (start) and $ (end) anchors
         var options = NetworkTrackingOptions.default
         options.captureRules = [
@@ -686,7 +677,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(4)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 4, "Should capture only URLs matching the anchored regex patterns")
@@ -708,7 +699,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertFalse(capturedURLs.contains("https://other.exact.example.com/path"), "Should not match different subdomain")
     }
 
-    func testURLPatternPriority() {
+    func testURLPatternPriority() throws {
         // Test that URL patterns take priority over host patterns when both are specified
         var options = NetworkTrackingOptions.default
         options.captureRules = [
@@ -737,7 +728,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -750,7 +741,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
     // MARK: - HTTP Method Matching Tests
 
-    func testHTTPMethodMatching() {
+    func testHTTPMethodMatching() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -791,7 +782,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -806,7 +797,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(capturedMethods.contains("POST"))
     }
 
-    func testHTTPMethodWildcard() {
+    func testHTTPMethodWildcard() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -839,7 +830,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -847,7 +838,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(events.count, 3, "Should capture all HTTP methods with wildcard")
     }
 
-    func testHTTPMethodCaseInsensitive() {
+    func testHTTPMethodCaseInsensitive() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -880,7 +871,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -888,7 +879,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(events.count, 3, "Method matching should be case-insensitive")
     }
 
-    func testCombinedURLAndMethodFiltering() {
+    func testCombinedURLAndMethodFiltering() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -937,7 +928,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -958,7 +949,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(capturedRequests.contains { $0.url == "https://store.example.com/products/123" && $0.method == "PUT" })
     }
 
-    func testResponseBodyCapture() {
+    func testResponseBodyCapture() throws {
         // Setup network tracking with response body capture
         let options = NetworkTrackingOptions(
             captureRules: [
@@ -1018,7 +1009,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         task.resume()
 
         wait(for: [expectation], timeout: 2.0)
-        wait(for: 0.2)
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -1056,7 +1047,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }
     }
 
-    func testResponseBodyCaptureWithURL() {
+    func testResponseBodyCaptureWithURL() throws {
         // Test response body capture with dataTask(with: URL, completionHandler:)
         let options = NetworkTrackingOptions(
             captureRules: [
@@ -1109,7 +1100,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         task.resume()
 
         wait(for: [expectation], timeout: 2.0)
-        wait()
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -1151,7 +1142,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }
     }
 
-    func testMultipleRulesWithDifferentPatterns() {
+    func testMultipleRulesWithDifferentPatterns() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             // Rule 1: Specific API endpoints with POST only
@@ -1204,7 +1195,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -1223,9 +1214,32 @@ final class NetworkTrackingPluginTest: XCTestCase {
     }
 #endif
 
+    /// Fixed sleep. Only for asserting that *nothing* was captured -- a sleep that is too short
+    /// can make such a test pass wrongly, but cannot make it fail. For "N events captured" use
+    /// `waitForCollectedEvents`.
     func wait(for interval: TimeInterval = 0.1) {
         let expectation = XCTestExpectation(description: "Wait for time interval")
         XCTWaiter().wait(for: [expectation], timeout: interval)
+    }
+
+    private struct CollectedEventsTimeout: Error {}
+
+    /// Waits until the collector holds at least `count` events, then returns. On timeout it
+    /// records a failure and throws, so the caller never reaches `events[i]` with too few
+    /// events. This replaces the fixed `wait()` sleeps that, on a slow CI runner, let a test
+    /// index past the end of the array and take the whole bundle down.
+    func waitForCollectedEvents(_ count: Int,
+                                timeout: TimeInterval = 10,
+                                file: StaticString = #filePath,
+                                line: UInt = #line) throws {
+        let collected = XCTestExpectation(description: "\(count) events collected")
+        eventCollector.fulfill(collected, whenCollected: count)
+        guard XCTWaiter().wait(for: [collected], timeout: timeout) == .completed else {
+            XCTFail("Timed out after \(timeout)s waiting for \(count) collected events; have \(eventCollector.events.count)",
+                    file: file,
+                    line: line)
+            throw CollectedEventsTimeout()
+        }
     }
 }
 // swiftlint:enable force_cast

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -12,7 +12,13 @@ import XCTest
 // swiftlint:disable force_cast
 final class NetworkTrackingPluginTest: XCTestCase {
 
-    private static let defaultTimeout: TimeInterval = 2
+    // Request timeout for the shared session, and the budget every test gives its requests to
+    // complete. Loose on purpose: the mock answers in ~10 ms, so a green run never waits, but on
+    // a 3-vCPU CI simulator the URL loading system has stalled for over 2 s mid-test -- the
+    // session then timed the requests out, the error events carried no status code, matched no
+    // capture rule, and the test came up short. The one test that needs a timeout to fire passes
+    // its own short value to taskForRequest, which builds a separate session.
+    private static let defaultTimeout: TimeInterval = 30
     private var amplitude: Amplitude!
     private var storageMem: FakeInMemoryStorage!
     private var eventCollector = EventCollectorPlugin()
@@ -117,7 +123,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://example.com?test=1#hash") { _, _, _ in
             expectation.fulfill()
         }.resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
@@ -147,7 +153,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest { _, _, _ in
             expectation.fulfill()
         }.resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         wait()
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
@@ -209,7 +215,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://example2.com/api") { _, _, _ in
             expectations[1].fulfill()
         }.resume()
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
 
         amplitude.waitForTrackingQueue()
         wait()
@@ -236,7 +242,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest(url1) { _, _, _ in
             expectations[1].fulfill()
         }.resume()
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
 
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(2)
@@ -270,7 +276,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest { _, _, _ in
             expectations[2].fulfill()
         }.resume()
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
 
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(2)
@@ -297,7 +303,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest(timeout: 0.1) { _, _, _ in
             expectation.fulfill()
         }.resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(1)
@@ -321,7 +327,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             try await request("https://example.com")
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
@@ -352,7 +358,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         Self.sharedSession.uploadTask(with: request, from: requestBodyData, completionHandler: { _, _, _ in
             expectation.fulfill()
         }).resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
@@ -381,7 +387,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         Self.sharedSession.downloadTask(with: request, completionHandler: { _, _, _ in
             expectation.fulfill()
         }).resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
@@ -424,7 +430,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://api.example.com") { _, _, _ in
             expectation1.fulfill()
         }.resume()
-        wait(for: [expectation1], timeout: 2)
+        wait(for: [expectation1], timeout: 30)
 
         // Request 2: api.example.com with 500 -> should NOT be captured (rule only allows 400-499)
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
@@ -432,7 +438,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://api.example.com") { _, _, _ in
             expectation2.fulfill()
         }.resume()
-        wait(for: [expectation2], timeout: 2)
+        wait(for: [expectation2], timeout: 30)
 
         // Request 3: api2.example.com with 500 -> should be captured (matches wildcard rule for 0,500-599)
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
@@ -440,7 +446,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://api2.example.com") { _, _, _ in
             expectation3.fulfill()
         }.resume()
-        wait(for: [expectation3], timeout: 2)
+        wait(for: [expectation3], timeout: 30)
 
         try waitForCollectedEvents(2)
         plugin.waitforNetworkTrackingQueue()
@@ -476,7 +482,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://example.com?test=1#hash", requestHeaders: requestHeaders) { _, _, _ in
             expectation.fulfill()
         }.resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
@@ -534,7 +540,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[2].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(1)
@@ -599,7 +605,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[4].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(3)
@@ -675,7 +681,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[7].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(4)
@@ -728,7 +734,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[1].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -782,7 +788,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[3].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -830,7 +836,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[2].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -871,7 +877,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[2].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -928,7 +934,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[5].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -1009,7 +1015,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         task.resume()
 
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 30)
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -1100,7 +1106,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         task.resume()
 
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 30)
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -1195,7 +1201,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[4].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()

--- a/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
+++ b/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
@@ -171,13 +171,13 @@ final class WebViewDeadClickTests: XCTestCase {
 
         // Four rapid taps inside the web view: rage click must still fire, dead click must not,
         // even though no interface change signal ever arrives.
-        for _ in 0..<4 {
-            fireTap(on: nestedInWebView)
-            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        }
+        let burstEnd = try fireRageClickBurst(on: nestedInWebView)
 
-        // Past the rage debounce (1 s) and the dead click timeout (3.5 s).
-        RunLoop.current.run(until: Date().addingTimeInterval(4.2))
+        // The rage click is reported by the detector's 1 s debounce timer: wait for the event, not
+        // for a fixed time. Then stay past the dead click timeout (3.5 s after the tap) so a dead
+        // click, had one been reported, would be in the collector as well.
+        runLoop(until: collector, has: 1, ofType: Constants.AMP_RAGE_CLICK_EVENT)
+        RunLoop.current.run(until: burstEnd.addingTimeInterval(4.2))
         amplitude.waitForTrackingQueue()
 
         XCTAssertEqual(events(in: collector, ofType: Constants.AMP_RAGE_CLICK_EVENT).count, 1,
@@ -188,7 +188,7 @@ final class WebViewDeadClickTests: XCTestCase {
         // Positive control: the same tap on a plain view IS reported dead, proving the detector
         // and provider wiring in this test are live.
         fireTap(on: plainView)
-        RunLoop.current.run(until: Date().addingTimeInterval(4.2))
+        runLoop(until: collector, has: 1, ofType: Constants.AMP_DEAD_CLICK_EVENT)
         amplitude.waitForTrackingQueue()
 
         XCTAssertEqual(events(in: collector, ofType: Constants.AMP_DEAD_CLICK_EVENT).count, 1,
@@ -216,11 +216,9 @@ final class WebViewDeadClickTests: XCTestCase {
         webView.amp_ignoreInteractionEvent(rageClick: true, deadClick: false)
 
         // Four rapid taps on web content the customer marked: enough to cross the rage threshold.
-        for _ in 0..<4 {
-            fireTap(on: nestedInWebView, at: CGPoint(x: 50, y: 50))
-            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        }
-        RunLoop.current.run(until: Date().addingTimeInterval(1.3))
+        let burstEnd = try fireRageClickBurst(on: nestedInWebView, at: CGPoint(x: 50, y: 50))
+        // Past the 1 s debounce, so a rage click, had one been detected, would have been reported.
+        RunLoop.current.run(until: burstEnd.addingTimeInterval(1.5))
         amplitude.waitForTrackingQueue()
 
         XCTAssertEqual(events(in: collector, ofType: Constants.AMP_RAGE_CLICK_EVENT).count, 0,
@@ -228,11 +226,8 @@ final class WebViewDeadClickTests: XCTestCase {
 
         // Positive control: the same taps on an unmarked view still do, proving the detector was
         // live and the taps really reached the swizzled path.
-        for _ in 0..<4 {
-            fireTap(on: plainView, at: CGPoint(x: 50, y: 650))
-            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        }
-        RunLoop.current.run(until: Date().addingTimeInterval(1.3))
+        try fireRageClickBurst(on: plainView, at: CGPoint(x: 50, y: 650))
+        runLoop(until: collector, has: 1, ofType: Constants.AMP_RAGE_CLICK_EVENT)
         amplitude.waitForTrackingQueue()
 
         XCTAssertEqual(events(in: collector, ofType: Constants.AMP_RAGE_CLICK_EVENT).count, 1,
@@ -389,6 +384,50 @@ final class WebViewDeadClickTests: XCTestCase {
         view.addGestureRecognizer(recognizer)
         recognizer.fireEnded()
         view.removeGestureRecognizer(recognizer)
+    }
+
+    /// Four taps on `view`, 10 ms apart: past the SDK's 5 ms physical-tap dedup window and well
+    /// inside the rage click detector's 1 s window. Click timestamps are taken synchronously in
+    /// `amp_setState`, so the spacing is exactly this loop's pacing and no run-loop turn is needed
+    /// between taps. Turning the run loop there let unrelated work (WebKit IPC, layout) stretch a
+    /// burst past 1 s on a loaded CI runner, and the detector then correctly saw no rage click.
+    /// Returns when the last tap was fired. Skips the test if the host stalled so badly that even
+    /// this burst exceeded the window: the SDK was then never given four taps within a second.
+    @discardableResult
+    private func fireRageClickBurst(on view: UIView,
+                                    at location: CGPoint = CGPoint(x: 50, y: 50),
+                                    file: StaticString = #filePath,
+                                    line: UInt = #line) throws -> Date {
+        let start = Date()
+        for i in 0..<4 {
+            if i > 0 {
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+            fireTap(on: view, at: location)
+        }
+        let end = Date()
+        let elapsed = end.timeIntervalSince(start)
+        if elapsed > 0.9 {
+            throw XCTSkip("Host stalled: four taps took \(elapsed) s, longer than the 1 s rage click window",
+                          file: file, line: line)
+        }
+        return end
+    }
+
+    /// Turns the main run loop until `collector` holds `count` events of `eventType`, or `timeout`
+    /// passes. The detectors report from main-run-loop timers (rage click 1 s after the last tap,
+    /// dead click 3.5 s after the tap), so the loop has to turn while waiting; a fixed turn read
+    /// the collector before a late timer had fired on a loaded CI runner. The caller's assertion
+    /// still reports a missing event; this only removes the fixed budget.
+    private func runLoop(until collector: EventCollectorPlugin,
+                         has count: Int,
+                         ofType eventType: String,
+                         timeout: TimeInterval = 15) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline, events(in: collector, ofType: eventType).count < count {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            Thread.sleep(forTimeInterval: 0.01)
+        }
     }
 
     private func events(in collector: EventCollectorPlugin, ofType eventType: String) -> [BaseEvent] {

--- a/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
+++ b/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
@@ -73,7 +73,7 @@ final class WebViewDeadClickTests: XCTestCase {
 
     func testDeadClickSuppressedInsideWebViewWhileRageClickStaysOn() throws {
         let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
-        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+        waitForTapRecognizers(in: webView)
 
         XCTAssertTrue(webView.amp_isInsideWebView, "The web view itself counts as web content")
         XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: webView))
@@ -283,7 +283,7 @@ final class WebViewDeadClickTests: XCTestCase {
     /// ancestors, `webView.amp_ignoreInteractionEvent()` was a silent no-op.
     func testIgnoreHookOnWebViewReachesTheRecognizerView() throws {
         let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
-        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+        waitForTapRecognizers(in: webView)
 
         let qualifying = allRecognizers(in: webView).filter { qualifiesAsPhysicalTap($0.recognizer) }
         XCTAssertFalse(qualifying.isEmpty)
@@ -416,6 +416,13 @@ final class WebViewDeadClickTests: XCTestCase {
         return (amplitude, collector)
     }
 
+    /// How long a load may take before the test gives up. A warm load finishes in ~0.4 s and a
+    /// cold one (first WebContent process of the test run) in ~1.3 s, on CI and locally alike --
+    /// but on a starved 3-vCPU CI simulator the same load has been seen to exceed 10 s, both
+    /// cold and warm, and load speed is not something any test here asserts. Generous on
+    /// purpose: a green run never comes near it, a red one stops being red for the wrong reason.
+    private static let loadTimeout: TimeInterval = 60
+
     private func loadedWebView(_ html: String) throws -> WKWebView {
         let webView = WKWebView(frame: window.bounds)
         window.addSubview(webView)
@@ -426,8 +433,21 @@ final class WebViewDeadClickTests: XCTestCase {
         navigationDelegate = delegate
         webView.navigationDelegate = delegate
         webView.loadHTMLString(html, baseURL: nil)
-        wait(for: [loaded], timeout: 10)
+        wait(for: [loaded], timeout: Self.loadTimeout)
         return webView
+    }
+
+    /// WebKit attaches its tap recognizers to `WKContentView` asynchronously, some time after
+    /// `didFinish`. Poll for the first qualifying one instead of sleeping a fixed second; the
+    /// caller's `XCTAssertFalse(qualifying.isEmpty)` still reports clearly if they never appear.
+    private func waitForTapRecognizers(in webView: WKWebView, timeout: TimeInterval = 30) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if allRecognizers(in: webView).contains(where: { qualifiesAsPhysicalTap($0.recognizer) }) {
+                return
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
     }
 
     private final class NavigationDelegate: NSObject, WKNavigationDelegate {

--- a/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
+++ b/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
@@ -24,9 +24,7 @@ import UIKit.UIGestureRecognizerSubclass
 final class WebViewDeadClickTests: XCTestCase {
 
     private var window: UIWindow!
-    /// `WKWebView.navigationDelegate` is weak; the delegate must outlive the navigation.
-    private var navigationDelegate: NavigationDelegate?
-    /// `Amplitude.interfaceSignalProvider` is weak too.
+    /// `Amplitude.interfaceSignalProvider` is weak; the provider must outlive the test body.
     private var interfaceSignalProvider: FakeInterfaceSignalProvider?
 
     override func setUp() {
@@ -38,7 +36,6 @@ final class WebViewDeadClickTests: XCTestCase {
 
     override func tearDown() {
         UIKitElementInteractions.resetPhysicalTapDedupCandidates()
-        navigationDelegate = nil
         interfaceSignalProvider = nil
         window = nil
         super.tearDown()
@@ -72,8 +69,7 @@ final class WebViewDeadClickTests: XCTestCase {
     // MARK: - Dead click is suppressed inside web views
 
     func testDeadClickSuppressedInsideWebViewWhileRageClickStaysOn() throws {
-        let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
-        waitForTapRecognizers(in: webView)
+        let webView = try attachedWebView()
 
         XCTAssertTrue(webView.amp_isInsideWebView, "The web view itself counts as web content")
         XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: webView))
@@ -282,8 +278,7 @@ final class WebViewDeadClickTests: XCTestCase {
     /// interactions to the private `WKContentView` two levels below it. Before the lookup walked
     /// ancestors, `webView.amp_ignoreInteractionEvent()` was a silent no-op.
     func testIgnoreHookOnWebViewReachesTheRecognizerView() throws {
-        let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
-        waitForTapRecognizers(in: webView)
+        let webView = try attachedWebView()
 
         let qualifying = allRecognizers(in: webView).filter { qualifiesAsPhysicalTap($0.recognizer) }
         XCTAssertFalse(qualifying.isEmpty)
@@ -416,31 +411,31 @@ final class WebViewDeadClickTests: XCTestCase {
         return (amplitude, collector)
     }
 
-    /// How long a load may take before the test gives up. A warm load finishes in ~0.4 s and a
-    /// cold one (first WebContent process of the test run) in ~1.3 s, on CI and locally alike --
-    /// but on a starved 3-vCPU CI simulator the same load has been seen to exceed 10 s, both
-    /// cold and warm, and load speed is not something any test here asserts. Generous on
-    /// purpose: a green run never comes near it, a red one stops being red for the wrong reason.
-    private static let loadTimeout: TimeInterval = 60
-
-    private func loadedWebView(_ html: String) throws -> WKWebView {
+    /// A web view in the key window with WebKit's tap recognizers attached to its `WKContentView`.
+    ///
+    /// Nothing is loaded into it. The tests using this only inspect the view hierarchy WebKit
+    /// builds in this process, and `WKContentView` gets its recognizers in `didMoveToWindow`, so
+    /// they are present within milliseconds of `addSubview` (measured 0.1-6 ms on an iPhone 16 Pro
+    /// simulator). Earlier versions loaded an HTML string and waited for `didFinish`, which made
+    /// these tests depend on WebKit's WebContent and GPU processes launching. On a CI simulator
+    /// that has taken over six minutes (`GPU process took 366 seconds to launch`), so every load
+    /// timed out whatever the budget, while nothing here ever asserted on page content.
+    private func attachedWebView() throws -> WKWebView {
         let webView = WKWebView(frame: window.bounds)
         window.addSubview(webView)
         window.makeKeyAndVisible()
-
-        let loaded = expectation(description: "html loaded")
-        let delegate = NavigationDelegate { loaded.fulfill() }
-        navigationDelegate = delegate
-        webView.navigationDelegate = delegate
-        webView.loadHTMLString(html, baseURL: nil)
-        wait(for: [loaded], timeout: Self.loadTimeout)
+        try waitForTapRecognizers(in: webView)
         return webView
     }
 
-    /// WebKit attaches its tap recognizers to `WKContentView` asynchronously, some time after
-    /// `didFinish`. Poll for the first qualifying one instead of sleeping a fixed second; the
-    /// caller's `XCTAssertFalse(qualifying.isEmpty)` still reports clearly if they never appear.
-    private func waitForTapRecognizers(in webView: WKWebView, timeout: TimeInterval = 30) {
+    private struct TapRecognizersMissing: Error {}
+
+    /// Polls for the first recognizer that passes the SDK's physical-tap gate. Fails and throws if
+    /// none appears, so a caller never reaches its assertions with an empty hierarchy.
+    private func waitForTapRecognizers(in webView: WKWebView,
+                                       timeout: TimeInterval = 10,
+                                       file: StaticString = #filePath,
+                                       line: UInt = #line) throws {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if allRecognizers(in: webView).contains(where: { qualifiesAsPhysicalTap($0.recognizer) }) {
@@ -448,16 +443,10 @@ final class WebViewDeadClickTests: XCTestCase {
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
-    }
-
-    private final class NavigationDelegate: NSObject, WKNavigationDelegate {
-        private let onFinish: () -> Void
-        init(onFinish: @escaping () -> Void) {
-            self.onFinish = onFinish
-        }
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            onFinish()
-        }
+        let present = allRecognizers(in: webView).map { "\($0.recognizer.descriptiveTypeName) on \($0.view.descriptiveTypeName)" }
+        XCTFail("No single-tap recognizer appeared on the web view within \(timeout)s; present: \(present)",
+                file: file, line: line)
+        throw TapRecognizersMissing()
     }
 }
 

--- a/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
+++ b/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
@@ -8,7 +8,49 @@
 import Foundation
 
 class FakeURLProtocol: URLProtocol {
-    static var mockResponses: [MockResponse] = []
+
+    /// Scripted responses for the requests a test issues itself, consumed in order.
+    static var mockResponses: [MockResponse] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _mockResponses
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _mockResponses = newValue
+        }
+    }
+
+    /// Scripted responses for the SDK's own uploads to api2 / api.eu.amplitude.com. Kept apart
+    /// from `mockResponses` because those uploads are not under the current test's control: an
+    /// Amplitude instance from an earlier test is still flushing while the next test runs, and
+    /// with one shared queue such a stray upload consumed a response the next test had queued
+    /// for its own request -- which then failed with "No mock responses available", carried
+    /// no status code, matched no capture rule, and left the test one event short. Uploads get
+    /// a plain 200 when nothing is queued here, and never touch `mockResponses`.
+    static var amplitudeResponses: [MockResponse] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _amplitudeResponses
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _amplitudeResponses = newValue
+        }
+    }
+
+    private static let amplitudeHosts: Set<String> = ["api2.amplitude.com", "api.eu.amplitude.com"]
+    private static let defaultAmplitudeResponse = MockResponse(statusCode: 200)
+
+    // startLoading runs on the URL loading system's threads, one per in-flight request, and a
+    // test with three parallel requests reaches the queue from three of them at once.
+    private static let lock = NSLock()
+    private static var _mockResponses: [MockResponse] = []
+    private static var _amplitudeResponses: [MockResponse] = []
 
     private static let responseQueue = DispatchQueue(label: "FakeURLProtocol.responseQueue")
 
@@ -43,6 +85,16 @@ class FakeURLProtocol: URLProtocol {
         return request
     }
 
+    /// Pops the next response for `url` under the lock; nil when a test request has nothing queued.
+    private static func dequeueResponse(for url: URL) -> MockResponse? {
+        lock.lock()
+        defer { lock.unlock() }
+        if amplitudeHosts.contains(url.host ?? "") {
+            return _amplitudeResponses.isEmpty ? defaultAmplitudeResponse : _amplitudeResponses.removeFirst()
+        }
+        return _mockResponses.isEmpty ? nil : _mockResponses.removeFirst()
+    }
+
     override func startLoading() {
         guard let url = request.url else {
             client?.urlProtocol(self, didFailWithError: NSError(domain: "FakeURLProtocol", code: -1, userInfo: nil))
@@ -51,12 +103,10 @@ class FakeURLProtocol: URLProtocol {
 
         print("FakeURLProtocol: Starting to load \(url)")
 
-        guard !Self.mockResponses.isEmpty else {
+        guard let mockResponse = Self.dequeueResponse(for: url) else {
             client?.urlProtocol(self, didFailWithError: NSError(domain: "FakeURLProtocol", code: -2, userInfo: [NSLocalizedDescriptionKey: "No mock responses available"]))
             return
         }
-
-        let mockResponse = Self.mockResponses.removeFirst()
 
         let response = HTTPURLResponse(
             url: url,
@@ -90,8 +140,13 @@ class FakeURLProtocol: URLProtocol {
         // Nothing to do here
     }
 
+    /// Call from tearDown: responses a test queued but never consumed would otherwise be served
+    /// to the next test's requests.
     static func clearMockResponses() {
-        mockResponses.removeAll()
+        lock.lock()
+        defer { lock.unlock() }
+        _mockResponses.removeAll()
+        _amplitudeResponses.removeAll()
     }
 }
 

--- a/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
+++ b/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
@@ -43,6 +43,22 @@ class FakeURLProtocol: URLProtocol {
         }
     }
 
+    /// Called, off the main thread, once a response to an SDK upload has been fully delivered.
+    /// A test that asserts its upload was *not* captured has to wait for this first: until the
+    /// request has completed, "no network event yet" proves nothing.
+    static var onAmplitudeRequestFinished: ((URL) -> Void)? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _onAmplitudeRequestFinished
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _onAmplitudeRequestFinished = newValue
+        }
+    }
+
     private static let amplitudeHosts: Set<String> = ["api2.amplitude.com", "api.eu.amplitude.com"]
     private static let defaultAmplitudeResponse = MockResponse(statusCode: 200)
 
@@ -51,6 +67,7 @@ class FakeURLProtocol: URLProtocol {
     private static let lock = NSLock()
     private static var _mockResponses: [MockResponse] = []
     private static var _amplitudeResponses: [MockResponse] = []
+    private static var _onAmplitudeRequestFinished: ((URL) -> Void)?
 
     private static let responseQueue = DispatchQueue(label: "FakeURLProtocol.responseQueue")
 
@@ -133,6 +150,10 @@ class FakeURLProtocol: URLProtocol {
             self.client?.urlProtocolDidFinishLoading(self)
 
             print("FakeURLProtocol: Finished loading \(url), response: \(mockResponse)")
+
+            if Self.amplitudeHosts.contains(url.host ?? "") {
+                Self.onAmplitudeRequestFinished?(url)
+            }
         }
     }
 
@@ -141,12 +162,13 @@ class FakeURLProtocol: URLProtocol {
     }
 
     /// Call from tearDown: responses a test queued but never consumed would otherwise be served
-    /// to the next test's requests.
+    /// to the next test's requests, and its upload hook would fire for the next test's uploads.
     static func clearMockResponses() {
         lock.lock()
         defer { lock.unlock() }
         _mockResponses.removeAll()
         _amplitudeResponses.removeAll()
+        _onAmplitudeRequestFinished = nil
     }
 }
 

--- a/Tests/AmplitudeTests/Supports/RemoteConfigMockServer.swift
+++ b/Tests/AmplitudeTests/Supports/RemoteConfigMockServer.swift
@@ -1,0 +1,263 @@
+//
+//  RemoteConfigMockServer.swift
+//  Amplitude-Swift
+//
+
+import AmplitudeCore
+@testable import AmplitudeSwift
+import Foundation
+import ObjectiveC
+import XCTest
+
+/// Process-wide, in-memory stand-in for the remote-config and diagnostics endpoints.
+///
+/// Installed once per test process by `TestBundlePrincipal`, it answers every
+/// `https://sr-client-cfg.*` and `https://diagnostics.prod.*` request made from a
+/// `URLSession` built on `URLSessionConfiguration.ephemeral` -- which is what
+/// `RemoteConfigClient` and `DiagnosticsClient` use -- so no test reaches the real
+/// services. `Configuration.init` constructs both clients unconditionally, so without
+/// this every `Configuration(...)` in the bundle (about a hundred) started a real
+/// HTTPS fetch with a made-up API key, got a 4xx, and retried with backoff in the
+/// background while later tests ran.
+///
+/// Two behaviours, keyed on the API key in the request path:
+///
+/// - Keys with `testApiKeyPrefix` (see `RemoteConfigClient.setNextFetchedRemoteConfig`):
+///   serve the config the test queued, but **hold the response until the test calls
+///   `release(apiKey:)`**. That gives a test a point at which the remote config
+///   provably has not arrived (assert defaults there) and a point after which it is on
+///   its way -- with no wall-clock delay to lose a race against. The previous mock
+///   answered after a fixed 500 ms, which the CI runners regularly beat.
+/// - Any other key: `200 {"configs":{}}` immediately. Subscribers see the same `nil`
+///   they saw when the real fetch failed; nothing else in the bundle observes remote
+///   config.
+enum RemoteConfigMockServer {
+
+    static let testApiKeyPrefix = "remote-config-test-"
+
+    private struct Entry {
+        var queued: [RemoteConfigClient.RemoteConfig] = []
+        var released = false
+        var waiting: [RemoteConfigUrlProtocol] = []
+    }
+
+    private static let lock = NSLock()
+    private static var entries: [String: Entry] = [:]
+    private static var installed = false
+
+    /// Puts `RemoteConfigUrlProtocol` in front of every `URLSession` created from
+    /// `URLSessionConfiguration.ephemeral` from now on. Idempotent: swizzling with
+    /// `method_exchangeImplementations` toggles, so a second call must be a no-op.
+    static func install() {
+        lock.withLock {
+            guard !installed else { return }
+            installed = true
+
+            let metaClass: AnyClass = object_getClass(URLSessionConfiguration.self)!
+            guard let original = class_getClassMethod(metaClass, #selector(getter: URLSessionConfiguration.ephemeral)),
+                  let swizzled = class_getClassMethod(metaClass, #selector(URLSessionConfiguration.amp_ephemeral)) else {
+                preconditionFailure("RemoteConfigMockServer: could not swizzle URLSessionConfiguration.ephemeral")
+            }
+            method_exchangeImplementations(original, swizzled)
+        }
+    }
+
+    /// Queue `config` as the next response for `apiKey`, held until `release(apiKey:)`.
+    static func enqueue(_ config: RemoteConfigClient.RemoteConfig, apiKey: String) {
+        lock.withLock {
+            var entry = entries[apiKey] ?? Entry()
+            entry.queued.append(config)
+            entry.released = false
+            entries[apiKey] = entry
+        }
+    }
+
+    /// Let the queued response for `apiKey` go out. Safe to call before the SDK has
+    /// started the request: the response is delivered as soon as it does.
+    static func release(apiKey: String) {
+        let toDeliver: [RemoteConfigUrlProtocol] = lock.withLock {
+            var entry = entries[apiKey] ?? Entry()
+            entry.released = true
+            let waiting = entry.waiting
+            entry.waiting = []
+            entries[apiKey] = entry
+            return waiting
+        }
+        toDeliver.forEach { $0.deliver() }
+    }
+
+    /// Called from `startLoading`. Non-test keys and released test keys deliver at
+    /// once; unreleased test keys park the protocol until `release(apiKey:)`.
+    fileprivate static func handle(_ urlProtocol: RemoteConfigUrlProtocol, apiKey: String) {
+        let deliverNow: Bool = lock.withLock {
+            guard apiKey.hasPrefix(testApiKeyPrefix) else {
+                return true
+            }
+            var entry = entries[apiKey] ?? Entry()
+            if entry.released {
+                return true
+            }
+            entry.waiting.append(urlProtocol)
+            entries[apiKey] = entry
+            return false
+        }
+        if deliverNow {
+            urlProtocol.deliver()
+        }
+    }
+
+    /// The config to serve, consumed at delivery time rather than at `startLoading`
+    /// so that a request retried before delivery still finds it. Non-test keys get an
+    /// empty config; a test key with nothing queued gets nil (a test-setup error).
+    fileprivate static func dequeue(apiKey: String) -> RemoteConfigClient.RemoteConfig? {
+        lock.withLock {
+            guard apiKey.hasPrefix(testApiKeyPrefix) else {
+                return [:]
+            }
+            guard var entry = entries[apiKey], !entry.queued.isEmpty else {
+                return nil
+            }
+            let config = entry.queued.removeFirst()
+            entries[apiKey] = entry
+            return config
+        }
+    }
+}
+
+/// Serves `RemoteConfigMockServer`'s responses. Consulted first by every ephemeral
+/// session once `RemoteConfigMockServer.install()` has run; declines everything that
+/// is not a remote-config or diagnostics request, so other protocols (`FakeURLProtocol`)
+/// and the network are unaffected.
+final class RemoteConfigUrlProtocol: URLProtocol {
+
+    private static let remoteConfigPrefix = "https://sr-client-cfg."
+    private static let diagnosticsPrefix = "https://diagnostics.prod."
+
+    // Deliveries hop through a queue so the URL loading system is never re-entered
+    // from inside startLoading, and so a delivery from the test thread (release) and
+    // one from the loading thread (immediate) never interleave.
+    private static let deliveryQueue = DispatchQueue(label: "com.amplitude.tests.RemoteConfigUrlProtocol")
+
+    private var stopped = false
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        guard let url = request.url?.absoluteString else {
+            return false
+        }
+        return url.hasPrefix(remoteConfigPrefix) || url.hasPrefix(diagnosticsPrefix)
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    private var isRemoteConfig: Bool {
+        request.url?.absoluteString.hasPrefix(Self.remoteConfigPrefix) ?? false
+    }
+
+    // https://sr-client-cfg.amplitude.com/config/{apiKey}?config_keys=...
+    // pathComponents already excludes the query.
+    private var apiKey: String? {
+        request.url?.pathComponents.last
+    }
+
+    override func startLoading() {
+        guard isRemoteConfig, let apiKey else {
+            deliver()
+            return
+        }
+        RemoteConfigMockServer.handle(self, apiKey: apiKey)
+    }
+
+    override func stopLoading() {
+        Self.deliveryQueue.async { [self] in
+            stopped = true
+        }
+    }
+
+    fileprivate func deliver() {
+        Self.deliveryQueue.async { [self] in
+            guard !stopped, let url = request.url else {
+                return
+            }
+
+            let body: [String: Any]
+            if isRemoteConfig {
+                guard let config = RemoteConfigMockServer.dequeue(apiKey: apiKey ?? "") else {
+                    client?.urlProtocol(self, didFailWithError: NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown))
+                    return
+                }
+                body = ["configs": config]
+            } else {
+                body = [:]
+            }
+
+            let response = HTTPURLResponse(url: url,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: ["Content-Type": "application/json"])!
+            let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+}
+
+extension URLSessionConfiguration {
+
+    // Swizzled with `ephemeral`, so calling amp_ephemeral here runs the original.
+    @objc class func amp_ephemeral() -> URLSessionConfiguration {
+        let config = amp_ephemeral()
+        config.protocolClasses = [RemoteConfigUrlProtocol.self] + (config.protocolClasses ?? [])
+        return config
+    }
+}
+
+extension RemoteConfigClient {
+
+    static func setNextFetchedRemoteConfig(_ remoteConfig: RemoteConfig, forApiKey apiKey: String) {
+        RemoteConfigMockServer.enqueue(remoteConfig, apiKey: apiKey)
+    }
+
+    static func resetStorage(instanceName: String) {
+        let suiteName = "com.amplitude.remoteconfig.cache.\(instanceName)"
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+}
+
+extension Amplitude {
+
+    /// Fulfilled once a non-nil autocapture remote config has been applied to this
+    /// instance's `AutocaptureManager` *and* handed to every plugin that registered an
+    /// `onChange` callback before this call. `AutocaptureManager.handleRemoteConfig`
+    /// updates its state, then runs the callbacks synchronously in registration order,
+    /// so by the time this fires `NetworkTrackingPlugin` and the lifecycle monitor have
+    /// consumed the config -- no sleep needed to "let other callbacks finish".
+    ///
+    /// Register after `init` (so the plugins are ahead of it) and before releasing the
+    /// mock response.
+    func remoteConfigAppliedExpectation() -> XCTestExpectation {
+        let expectation = XCTestExpectation(description: "autocapture remote config applied")
+        expectation.assertForOverFulfill = false
+        autocaptureManager.onChange { config in
+            if config != nil {
+                expectation.fulfill()
+            }
+        }
+        return expectation
+    }
+}
+
+/// Named as `NSPrincipalClass` in `Amplitude_SwiftTests_Info.plist`. XCTest instantiates
+/// it once, before any test class is loaded -- the only point early enough to put a
+/// URLProtocol in front of the sessions that `Configuration.init` creates.
+@objc(AMPTestBundlePrincipal)
+final class TestBundlePrincipal: NSObject {
+
+    override init() {
+        super.init()
+        RemoteConfigMockServer.install()
+    }
+}

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -34,15 +34,68 @@ class OutputReaderPlugin: DestinationPlugin {
 }
 
 class EventCollectorPlugin: DestinationPlugin {
-    var events: [BaseEvent] = Array()
-    /// Called on the tracking queue after each event is appended, so a test can wait
-    /// on a signal for "N events arrived" instead of sleeping and hoping.
-    var onEvent: ((BaseEvent) -> Void)?
+    private let lock = NSLock()
+    private var _events: [BaseEvent] = []
+    /// Returns true once it has fulfilled its expectation, so `execute` can drop it.
+    private var onCollected: ((Int) -> Bool)?
+
+    /// Appended on the tracking queue, read from wherever the test is -- so both go through
+    /// the lock.
+    var events: [BaseEvent] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _events
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _events = newValue
+        }
+    }
 
     override func execute(event: BaseEvent) -> BaseEvent? {
-        events.append(event)
-        onEvent?(event)
+        lock.lock()
+        _events.append(event)
+        let count = _events.count
+        let callback = onCollected
+        lock.unlock()
+
+        if let callback, callback(count) {
+            lock.lock()
+            onCollected = nil
+            lock.unlock()
+        }
         return event
+    }
+
+    /// Fulfils `expectation` once at least `count` events have been collected: immediately if
+    /// they already have, otherwise from the tracking queue as they arrive. The check and the
+    /// registration happen under one lock, so an event landing in between cannot be missed.
+    /// Lets a test wait on "N events arrived" instead of sleeping and hoping.
+    func fulfill(_ expectation: XCTestExpectation, whenCollected count: Int) {
+        lock.lock()
+        if _events.count >= count {
+            lock.unlock()
+            expectation.fulfill()
+            return
+        }
+        onCollected = { collected in
+            guard collected >= count else {
+                return false
+            }
+            expectation.fulfill()
+            return true
+        }
+        lock.unlock()
+    }
+}
+
+extension Array {
+    /// nil instead of a trap when `index` is out of range -- for assertions on arrays whose
+    /// length is itself under test, so a wrong length fails the test rather than the bundle.
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }
 

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -35,9 +35,13 @@ class OutputReaderPlugin: DestinationPlugin {
 
 class EventCollectorPlugin: DestinationPlugin {
     var events: [BaseEvent] = Array()
+    /// Called on the tracking queue after each event is appended, so a test can wait
+    /// on a signal for "N events arrived" instead of sleeping and hoping.
+    var onEvent: ((BaseEvent) -> Void)?
 
     override func execute(event: BaseEvent) -> BaseEvent? {
         events.append(event)
+        onEvent?(event)
         return event
     }
 }

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -57,15 +57,13 @@ class EventCollectorPlugin: DestinationPlugin {
     override func execute(event: BaseEvent) -> BaseEvent? {
         lock.lock()
         _events.append(event)
-        let count = _events.count
-        let callback = onCollected
-        lock.unlock()
-
-        if let callback, callback(count) {
-            lock.lock()
+        // The callback only fulfils an expectation, so it can run under the lock. Clearing it in
+        // the same critical section means a callback the test registers in the meantime can
+        // never be wiped by this one's clean-up.
+        if let callback = onCollected, callback(_events.count) {
             onCollected = nil
-            lock.unlock()
         }
+        lock.unlock()
         return event
     }
 

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -12,6 +12,12 @@ import XCTest
 final class EventPipelineTests: XCTestCase {
     private static let FLUSH_INTERVAL_SECONDS = 10.0
 
+    // Wait budgets here are deliberately loose (10 s; 15 s where the SDK's own 1 s + 2 s retry
+    // backoff is being waited out). Everything goes through FakeHttpClient in-process, so a
+    // green run returns as soon as the expectation fires; the budget only decides how long a
+    // genuinely broken run takes to report. The original 1-2 s budgets were exceeded on a
+    // 3-vCPU CI simulator, and the indexing that followed turned that into a bundle crash.
+
     private var configuration: Configuration!
     private var pipeline: EventPipeline!
     private var httpClient: FakeHttpClient!
@@ -56,12 +62,12 @@ final class EventPipelineTests: XCTestCase {
         }
         XCTAssertEqual(testEvent.attempts, 1)
 
-        let waitResult = XCTWaiter.wait(for: [eventExpectation], timeout: 1)
+        let waitResult = XCTWaiter.wait(for: [eventExpectation], timeout: 10)
         XCTAssertNotEqual(waitResult, .timedOut)
         XCTAssertEqual(pipeline.eventCount, 1)
     }
 
-    func testFlush() {
+    func testFlush() throws {
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
 
@@ -69,12 +75,12 @@ final class EventPipelineTests: XCTestCase {
         pipeline.flush {
             flushExpectation.fulfill()
         }
-        let waitResult = XCTWaiter.wait(for: [flushExpectation], timeout: 1)
+        let waitResult = XCTWaiter.wait(for: [flushExpectation], timeout: 10)
         XCTAssertNotEqual(waitResult, .timedOut)
         XCTAssertEqual(httpClient.uploadCount, 1)
-        let uploadedEvents = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
+        let uploadedEvents = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents.first))
         XCTAssertEqual(uploadedEvents?.count, 1)
-        XCTAssertEqual(uploadedEvents![0].eventType, "testEvent")
+        XCTAssertEqual(uploadedEvents?.first?.eventType, "testEvent")
     }
 
     func testFlushWhenOffline() {
@@ -93,7 +99,7 @@ final class EventPipelineTests: XCTestCase {
         XCTAssertEqual(httpClient.uploadCount, 0, "There should be no uploads when offline")
     }
 
-    func testSimultaneousFlush() {
+    func testSimultaneousFlush() throws {
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
 
@@ -108,13 +114,13 @@ final class EventPipelineTests: XCTestCase {
             return expectation
         }
 
-        wait(for: flushExpectations, timeout: 1)
-        wait(for: [httpResponseExpectation], timeout: 1)
+        wait(for: flushExpectations, timeout: 10)
+        wait(for: [httpResponseExpectation], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 1)
-        let uploadedEvents = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
+        let uploadedEvents = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents.first))
         XCTAssertEqual(uploadedEvents?.count, 1)
-        XCTAssertEqual(uploadedEvents![0].eventType, "testEvent")
+        XCTAssertEqual(uploadedEvents?.first?.eventType, "testEvent")
     }
 
     func testOneUploadAtATime() {
@@ -137,16 +143,16 @@ final class EventPipelineTests: XCTestCase {
             flushExpectation.fulfill()
         }
 
-        wait(for: [httpResponseExpectation1], timeout: 1)
+        wait(for: [httpResponseExpectation1], timeout: 10)
 
         httpResponseExpectation2.isInverted = false
 
-        wait(for: [httpResponseExpectation2, flushExpectation], timeout: 1)
+        wait(for: [httpResponseExpectation2, flushExpectation], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 2)
     }
 
-    func testInvalidEventUpload() {
+    func testInvalidEventUpload() throws {
         let invalidResponseData = "{\"events_with_invalid_fields\": {\"user_id\": [0]}}".data(using: .utf8)!
 
         httpClient.uploadResults = [
@@ -165,24 +171,24 @@ final class EventPipelineTests: XCTestCase {
         pipeline.flush {
             flushExpectation1.fulfill()
         }
-        wait(for: [uploadExpectations[0], flushExpectation1], timeout: 1)
+        wait(for: [uploadExpectations[0], flushExpectation1], timeout: 10)
 
         let flushExpectation2 = expectation(description: "flush-2")
         pipeline.flush {
             flushExpectation2.fulfill()
         }
-        wait(for: [uploadExpectations[1], flushExpectation2], timeout: 1)
+        wait(for: [uploadExpectations[1], flushExpectation2], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 2)
 
-        let uploadedEvents0 = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
+        let uploadedEvents0 = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents[safe: 0]))
         XCTAssertEqual(uploadedEvents0?.count, 2)
-        XCTAssertEqual(uploadedEvents0?[0].eventType, "testEvent-0")
-        XCTAssertEqual(uploadedEvents0?[1].eventType, "testEvent-1")
+        XCTAssertEqual(uploadedEvents0?[safe: 0]?.eventType, "testEvent-0")
+        XCTAssertEqual(uploadedEvents0?[safe: 1]?.eventType, "testEvent-1")
 
-        let uploadedEvents1 = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[1])
+        let uploadedEvents1 = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents[safe: 1]))
         XCTAssertEqual(uploadedEvents1?.count, 1)
-        XCTAssertEqual(uploadedEvents1?[0].eventType, "testEvent-1")
+        XCTAssertEqual(uploadedEvents1?[safe: 0]?.eventType, "testEvent-1")
     }
 
     // test continues to fail until the event is uploaded
@@ -205,13 +211,13 @@ final class EventPipelineTests: XCTestCase {
 
         pipeline.flush()
         // Expected: upload 0 (instant) + upload 1 (1s retry delay)
-        wait(for: [uploadExpectations[0], uploadExpectations[1]], timeout: 5)
+        wait(for: [uploadExpectations[0], uploadExpectations[1]], timeout: 15)
 
         XCTAssertEqual(httpClient.uploadCount, 2)
         XCTAssertEqual(pipeline.configuration.offline, false)
 
         // Expected: upload 2 (2s retry delay)
-        wait(for: [uploadExpectations[2]], timeout: 5)
+        wait(for: [uploadExpectations[2]], timeout: 15)
 
         XCTAssertEqual(httpClient.uploadCount, 3)
         XCTAssertEqual(pipeline.configuration.offline, true)
@@ -221,7 +227,7 @@ final class EventPipelineTests: XCTestCase {
         pipeline.flush {
             flushExpectation.fulfill()
         }
-        wait(for: [uploadExpectations[3], flushExpectation], timeout: 2)
+        wait(for: [uploadExpectations[3], flushExpectation], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 4)
     }
@@ -256,13 +262,13 @@ final class EventPipelineTests: XCTestCase {
         pipeline.flush {
             flushExpectation.fulfill()
         }
-        wait(for: [flushExpectation], timeout: 2)
+        wait(for: [flushExpectation], timeout: 10)
 
         // Pipeline must have walked past the two corrupt files and uploaded the third.
         XCTAssertEqual(httpClient.uploadCount, 1, "Pipeline should not stall on corrupt files")
-        let uploaded = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
+        let uploaded = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents.first))
         XCTAssertEqual(uploaded?.count, 1)
-        XCTAssertEqual(uploaded?[0].eventType, "marker-2")
+        XCTAssertEqual(uploaded?.first?.eventType, "marker-2")
     }
 
     func testFlushKeepsSkippingUnreadableFilesAfterUpload() throws {
@@ -342,11 +348,11 @@ final class EventPipelineTests: XCTestCase {
         spyPipeline.flush {
             flushExpectation.fulfill()
         }
-        wait(for: [flushExpectation], timeout: 2)
+        wait(for: [flushExpectation], timeout: 10)
 
         XCTAssertEqual(spyHttp.uploadCount, 2, "Both good files should upload exactly once")
-        let uploaded0 = BaseEvent.fromArrayString(jsonString: spyHttp.uploadedEvents[0])
-        let uploaded1 = BaseEvent.fromArrayString(jsonString: spyHttp.uploadedEvents[1])
+        let uploaded0 = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(spyHttp.uploadedEvents[safe: 0]))
+        let uploaded1 = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(spyHttp.uploadedEvents[safe: 1]))
         XCTAssertEqual(uploaded0?.first?.eventType, "marker-1")
         XCTAssertEqual(uploaded1?.first?.eventType, "marker-3")
 
@@ -398,7 +404,7 @@ final class EventPipelineTests: XCTestCase {
             flushExpectation.fulfill()
         }
 
-        wait(for: uploadExpectations + [flushExpectation], timeout: 1)
+        wait(for: uploadExpectations + [flushExpectation], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 3)
         XCTAssertEqual(pipeline.configuration.offline, false)

--- a/scripts/ci_runner_info.sh
+++ b/scripts/ci_runner_info.sh
@@ -1,0 +1,408 @@
+#!/bin/bash
+#
+# Dump everything we can learn about a GitHub Actions macOS runner, so that the
+# environment our unit tests are flaky in can be reproduced locally.
+#
+# Key facts to print to the log, bulky dumps (sysctl -a, system_profiler,
+# simctl list) to $OUT_DIR so they can be uploaded as a build artifact.
+#
+# Usage: scripts/ci_runner_info.sh [output-dir]
+#
+# Never fails the build: every probe is best-effort.
+
+set +e
+
+OUT_DIR="${1:-runner-info}"
+mkdir -p "$OUT_DIR"
+
+# --- log helpers ------------------------------------------------------------
+# ::group:: makes the section collapsible in the Actions log viewer.
+group() { echo "::group::$*"; }
+endgroup() { echo "::endgroup::"; }
+
+# run <label> <cmd...>: echo the command, run it, never fail.
+run() {
+  local label="$1"; shift
+  echo "--- $label: $* ---"
+  "$@" 2>&1
+  local rc=$?
+  [ $rc -ne 0 ] && echo "(exit $rc)"
+  echo
+  return 0
+}
+
+# sysctls <name...>: print `name = value` for each, skipping missing keys.
+sysctls() {
+  for key in "$@"; do
+    local value
+    value="$(sysctl -n "$key" 2>/dev/null)"
+    [ -n "$value" ] && printf '%-40s %s\n' "$key" "$value"
+  done
+  return 0
+}
+
+# Environment variables we're willing to publish. This is an allowlist, not a
+# filter: artifacts on a public repo are downloadable by anyone, so a variable
+# gets in only if it says something about the runner (image, arch, toolchain,
+# paths) or identifies the run. Anything not named here never leaves the box.
+ENV_ALLOWLIST="
+CI
+DEVELOPER_DIR
+HOME
+LANG
+LC_ALL
+PATH
+SHELL
+TERM
+TMPDIR
+TEST_ITERATIONS
+IMAGE_OS
+IMAGE_VERSION
+ImageOS
+ImageVersion
+RUNNER_ARCH
+RUNNER_ENVIRONMENT
+RUNNER_NAME
+RUNNER_OS
+RUNNER_TEMP
+RUNNER_TOOL_CACHE
+RUNNER_WORKSPACE
+GITHUB_BASE_REF
+GITHUB_EVENT_NAME
+GITHUB_HEAD_REF
+GITHUB_JOB
+GITHUB_REF
+GITHUB_REPOSITORY
+GITHUB_RUN_ATTEMPT
+GITHUB_RUN_ID
+GITHUB_RUN_NUMBER
+GITHUB_SHA
+GITHUB_WORKFLOW
+GITHUB_WORKSPACE
+"
+
+# allowed_env: print `NAME=value` for each allowlisted variable that is set.
+allowed_env() {
+  local name value
+  for name in $ENV_ALLOWLIST; do
+    eval "value=\${$name}"
+    [ -n "$value" ] && printf '%s=%s\n' "$name" "$value"
+  done
+  return 0
+}
+
+echo "=============================================================="
+echo " Runner info  ($(date -u '+%Y-%m-%dT%H:%M:%SZ'))"
+echo "=============================================================="
+
+# --- 1. identity: which machine / image are we on? -------------------------
+group "1. Machine & image identity"
+sysctls \
+  hw.model machdep.cpu.brand_string hw.machine hw.target hw.product \
+  kern.osproductversion kern.osversion kern.version kern.osrelease \
+  kern.hostname kern.uuid kern.bootargs
+echo
+run "arch" arch
+run "uname" uname -a
+run "sw_vers" sw_vers
+echo "--- virtualization ---"
+# hw.model VirtualMac2,1 + kern.hv_vmm_present=1 => Apple Virtualization guest.
+# That is the thing to mirror locally (e.g. Tart/UTM on Apple silicon), not
+# bare metal, and it changes timer/IO behaviour noticeably.
+sysctls kern.hv_vmm_present kern.hv_support hw.optional.arm64 sysctl.proc_translated
+echo
+echo "--- runner image metadata (env) ---"
+allowed_env | grep -E '^(Image|IMAGE_|RUNNER_)'
+for candidate in \
+  /imagegeneration/imagedata.json \
+  "$HOME/image-info" \
+  "$HOME/.image-info" \
+  /usr/local/share/imagegeneration/imagedata.json; do
+  [ -e "$candidate" ] && { echo "--- $candidate ---"; cat "$candidate"; echo; }
+done
+endgroup
+
+# --- 2. CPU topology -------------------------------------------------------
+# Apple silicon runners expose performance (perflevel0) and efficiency
+# (perflevel1) cores. Test code that races on wall-clock timing behaves very
+# differently when a queue lands on an E core, and the P/E split is the single
+# most useful number for reproducing that locally.
+group "2. CPU topology"
+sysctls \
+  hw.ncpu hw.activecpu hw.physicalcpu hw.physicalcpu_max \
+  hw.logicalcpu hw.logicalcpu_max hw.packages hw.nperflevels \
+  hw.perflevel0.name hw.perflevel0.physicalcpu hw.perflevel0.logicalcpu \
+  hw.perflevel0.cpusperl2 hw.perflevel0.l1dcachesize hw.perflevel0.l1icachesize \
+  hw.perflevel0.l2cachesize \
+  hw.perflevel1.name hw.perflevel1.physicalcpu hw.perflevel1.logicalcpu \
+  hw.perflevel1.cpusperl2 hw.perflevel1.l1dcachesize hw.perflevel1.l1icachesize \
+  hw.perflevel1.l2cachesize \
+  hw.cpufrequency hw.cpufrequency_max hw.tbfrequency hw.busfrequency \
+  hw.cachelinesize hw.l1dcachesize hw.l1icachesize hw.l2cachesize hw.l3cachesize \
+  hw.byteorder hw.pagesize hw.pagesize32 \
+  machdep.cpu.core_count machdep.cpu.thread_count machdep.cpu.features
+endgroup
+
+# --- 3. memory & swap ------------------------------------------------------
+group "3. Memory & swap"
+sysctls hw.memsize hw.memsize_usable vm.swapusage vm.page_pageable_internal_count
+echo
+run "vm_stat" vm_stat
+endgroup
+
+# --- 4. disk ---------------------------------------------------------------
+# PersistentStorage writes event blocks as files; a slow or nearly-full volume
+# changes flush timing and is a plausible source of storage-ordering flakes.
+group "4. Disk & filesystem"
+run "df -h" df -h
+run "df -i /" df -i /
+run "mount" mount
+run "diskutil info /" diskutil info /
+diskutil list > "$OUT_DIR/diskutil-list.txt" 2>&1
+echo "(full diskutil list -> $OUT_DIR/diskutil-list.txt)"
+endgroup
+
+# --- 5. limits -------------------------------------------------------------
+# File-descriptor and process limits: the test bundle opens a lot of small
+# files and URLSession connections; hitting a limit shows up as a random
+# unrelated failure.
+group "5. Process & file limits"
+run "ulimit -a" bash -c 'ulimit -a'
+run "launchctl limit" launchctl limit
+sysctls \
+  kern.maxfiles kern.maxfilesperproc kern.maxproc kern.maxprocperuid \
+  kern.num_taskthreads kern.num_threads kern.ipc.somaxconn kern.ipc.maxsockbuf
+endgroup
+
+# --- 6. current load -------------------------------------------------------
+# Snapshot of what else is competing for the runner at test time.
+group "6. Current load"
+sysctls vm.loadavg
+echo
+run "uptime" uptime
+run "top (1 sample, top 20 by cpu)" top -l 1 -n 20 -o cpu -stats pid,command,cpu,mem,th
+# `comm` (executable path), never `command` (full argv): argv of a concurrent
+# step can contain credentials, and both the log and the artifact are public on
+# a public repo. Executable + rss + pcpu is all we need to see who is competing
+# for the runner.
+run "processes (top 40 by rss)" bash -c "ps -Ao pid,rss,pcpu,etime,comm -m | head -40"
+run "thermal state" pmset -g therm
+run "power/AC state" pmset -g ps
+ps -Ao pid,ppid,rss,pcpu,etime,comm > "$OUT_DIR/ps-full.txt" 2>&1
+echo "(full process list -> $OUT_DIR/ps-full.txt)"
+endgroup
+
+# --- 7. network ------------------------------------------------------------
+# HttpClientTests hit real hosts in some cases and assert on error kinds; DNS
+# and egress behaviour are part of the repro.
+group "7. Network"
+run "ifconfig -a" ifconfig -a
+run "route -n get default" route -n get default
+run "scutil --dns" scutil --dns
+run "resolv.conf" cat /etc/resolv.conf
+run "/etc/hosts" cat /etc/hosts
+run "network time" systemsetup -getusingnetworktime
+run "date (local/UTC)" bash -c 'date; date -u; TZ=UTC date'
+sysctls kern.boottime
+echo
+for host in api2.amplitude.com api.lab.amplitude.com localhost; do
+  echo "--- dns: $host ---"
+  dscacheutil -q host -a name "$host" 2>&1 | head -12
+done
+echo "--- egress check (api2.amplitude.com:443, 5s timeout) ---"
+curl -sS -o /dev/null -w 'http=%{http_code} dns=%{time_namelookup}s connect=%{time_connect}s tls=%{time_appconnect}s total=%{time_total}s\n' \
+  --max-time 5 https://api2.amplitude.com/2/httpapi 2>&1
+endgroup
+
+# --- 8. toolchain & simulators --------------------------------------------
+group "8. Toolchain & simulators"
+run "xcode-select -p" xcode-select -p
+run "xcodebuild -version" xcodebuild -version
+run "swift --version" swift --version
+run "clang --version" clang --version
+run "installed Xcodes" bash -c 'ls -d /Applications/Xcode*.app 2>/dev/null'
+run "simctl runtimes" xcrun simctl list runtimes
+run "booted simulators" xcrun simctl list devices booted
+# Full argv here on purpose, unlike section 6: only CoreSimulator-matching
+# processes are listed, they are all Apple system binaries, and the paths are
+# the information -- they show which runtime volumes are actually mounted.
+run "CoreSimulator processes" bash -c 'pgrep -fl -i coresimulator | head -20'
+run "CoreSimulator version" bash -c "defaults read /Library/Developer/PrivateFrameworks/CoreSimulator.framework/Versions/A/Resources/Info.plist CFBundleShortVersionString 2>/dev/null"
+xcrun simctl list > "$OUT_DIR/simctl-list.txt" 2>&1
+xcrun simctl list -j > "$OUT_DIR/simctl-list.json" 2>&1
+echo "(full simctl list -> $OUT_DIR/simctl-list.txt, .json)"
+endgroup
+
+# --- 9. micro benchmarks ---------------------------------------------------
+# Rough numbers so a local machine/VM can be compared against the runner
+# instead of guessing. Total budget ~20s.
+group "9. Micro benchmarks"
+
+BENCH_DIR="$(mktemp -d)"
+
+# timeit <label> <cmd...>: one clean line per benchmark. `time` writes to the
+# shell's stderr, so send it to a file rather than into the shared stream --
+# merging it with a backgrounded child's output mangles the digits.
+timeit() {
+  local label="$1"; shift
+  local tf; tf="$(mktemp)"
+  { time "$@" > /dev/null 2>&1; } 2> "$tf"
+  printf '%-34s %s\n' "$label" \
+    "$(tr '\n' ' ' < "$tf" | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')"
+  rm -f "$tf"
+  return 0
+}
+
+echo "--- disk ---"
+timeit "seq write 512MiB + sync" \
+  bash -c 'dd if=/dev/zero of="$1/bench.bin" bs=1m count=512; sync' _ "$BENCH_DIR"
+dd if=/dev/zero of="$BENCH_DIR/bench2.bin" bs=1m count=512 2>&1 | tail -1
+rm -f "$BENCH_DIR"/bench*.bin
+
+# Mirrors PersistentStorage: lots of small JSON event-block files, written and
+# read back one at a time. Done in-process so the numbers are IO and not fork
+# overhead; the fsync variant is the worst case for flush-ordering flakes.
+if command -v python3 > /dev/null 2>&1; then
+  python3 - "$BENCH_DIR" <<'PY' 2>&1
+import os, sys, time
+d, n = sys.argv[1], 2000
+payload = (b'{"event_type":"bench","event_properties":{"i":%d}}' % 0) * 4
+
+def bench(label, fn):
+    t0 = time.monotonic()
+    fn()
+    dt = time.monotonic() - t0
+    print(f"{label:<34} {dt*1000:8.1f}ms  ({n/dt:,.0f} ops/s)")
+
+def write(fsync=False):
+    def go():
+        for i in range(n):
+            with open(os.path.join(d, f"f{i}.json"), "wb") as f:
+                f.write(payload)
+                if fsync:
+                    f.flush()
+                    os.fsync(f.fileno())
+    return go
+
+def read_back():
+    for i in range(n):
+        with open(os.path.join(d, f"f{i}.json"), "rb") as f:
+            f.read()
+
+def listdir():
+    for _ in range(50):
+        os.listdir(d)
+
+def unlink():
+    for i in range(n):
+        os.unlink(os.path.join(d, f"f{i}.json"))
+
+bench(f"{n} small files write+close", write())
+bench(f"{n} small files read", read_back)
+bench("50x listdir of 2000 entries", listdir)
+bench(f"{n} small files unlink", unlink)
+bench(f"{n} small files write+fsync", write(fsync=True))
+bench(f"{n} small files unlink (2)", unlink)
+PY
+else
+  echo "(python3 not available; skipping small-file benchmark)"
+fi
+rm -rf "$BENCH_DIR"
+echo
+
+# Integer loop in awk: crude but consistent across machines. Comparing the
+# single-thread number to the N-thread number shows P-core vs E-core scheduling
+# (the thing that makes wall-clock test assertions flaky) -- with only P cores
+# the N-thread wall time barely moves, with E cores in the mix it does.
+echo "--- cpu ---"
+CPU_BENCH_AWK="$(mktemp)"
+cat > "$CPU_BENCH_AWK" <<'AWK'
+BEGIN { s = 0; for (i = 0; i < 12000000; i++) s += i % 7; print "checksum", s }
+AWK
+NCPU="$(sysctl -n hw.ncpu 2>/dev/null || echo 2)"
+timeit "awk loop, 1 thread" awk -f "$CPU_BENCH_AWK"
+timeit "awk loop, $NCPU threads" bash -c '
+  for _ in $(seq 1 "$2"); do awk -f "$1" > /dev/null 2>&1 & done
+  wait
+' _ "$CPU_BENCH_AWK" "$NCPU"
+rm -f "$CPU_BENCH_AWK"
+echo
+
+# Timer slop and clock resolution measured in-process: this is what async
+# XCTestExpectation waits are actually racing against. A runner that overshoots
+# a 5 ms timer by 10x is a runner where a 1 s expectation on a 3-hop dispatch
+# chain is a coin flip.
+echo "--- timers ---"
+if command -v python3 > /dev/null 2>&1; then
+  python3 - <<'PY' 2>&1
+import time, statistics
+def slop(target, n):
+    d = []
+    for _ in range(n):
+        t0 = time.monotonic()
+        time.sleep(target)
+        d.append((time.monotonic() - t0 - target) * 1000.0)
+    return d
+for target, n in ((0.005, 200), (0.050, 20)):
+    d = slop(target, n)
+    print(f"sleep({target*1000:.0f}ms) x{n}: overshoot "
+          f"min={min(d):.2f}ms p50={statistics.median(d):.2f}ms "
+          f"mean={statistics.mean(d):.2f}ms max={max(d):.2f}ms")
+# Smallest observable tick of the monotonic clock.
+ticks = []
+for _ in range(2000):
+    a = time.monotonic_ns()
+    while (b := time.monotonic_ns()) == a:
+        pass
+    ticks.append(b - a)
+print(f"monotonic clock granularity: min={min(ticks)}ns "
+      f"p50={int(statistics.median(ticks))}ns")
+print(f"time.get_clock_info('monotonic'): {time.get_clock_info('monotonic')}")
+PY
+else
+  echo "(python3 not available; skipping timer-slop measurement)"
+fi
+endgroup
+
+# --- 10. bulky dumps -> artifact ------------------------------------------
+group "10. Full dumps (written to $OUT_DIR)"
+sysctl -a > "$OUT_DIR/sysctl-a.txt" 2>&1
+echo "sysctl -a                -> $OUT_DIR/sysctl-a.txt ($(wc -l < "$OUT_DIR/sysctl-a.txt" | tr -d ' ') lines)"
+
+system_profiler -json \
+  SPHardwareDataType SPSoftwareDataType SPMemoryDataType \
+  SPStorageDataType SPNVMeDataType SPNetworkDataType SPDeveloperToolsDataType \
+  > "$OUT_DIR/system_profiler.json" 2>"$OUT_DIR/system_profiler.err"
+echo "system_profiler -json    -> $OUT_DIR/system_profiler.json"
+
+allowed_env > "$OUT_DIR/env.txt" 2>&1
+echo "env (allowlisted)        -> $OUT_DIR/env.txt ($(wc -l < "$OUT_DIR/env.txt" | tr -d ' ') vars)"
+
+# Platform expert device only -- carries the VM/board identity. The full
+# `ioreg -l` is tens of MB and not worth the artifact space.
+ioreg -rd1 -c IOPlatformExpertDevice > "$OUT_DIR/ioreg-platform.txt" 2>&1
+echo "ioreg IOPlatformExpert   -> $OUT_DIR/ioreg-platform.txt"
+
+sw_vers > "$OUT_DIR/sw_vers.txt" 2>&1
+xcodebuild -version >> "$OUT_DIR/sw_vers.txt" 2>&1
+
+echo
+echo "--- key facts, one line (grep-able across runs) ---"
+printf 'RUNNER_FACTS model=%s cpu="%s" arch=%s ncpu=%s pcpu=%s p_cores=%s e_cores=%s mem=%s os=%s hv=%s image=%s xcode="%s" free_root=%s loadavg="%s"\n' \
+  "$(sysctl -n hw.model 2>/dev/null)" \
+  "$(sysctl -n machdep.cpu.brand_string 2>/dev/null)" \
+  "$(arch)" \
+  "$(sysctl -n hw.ncpu 2>/dev/null)" \
+  "$(sysctl -n hw.physicalcpu 2>/dev/null)" \
+  "$(sysctl -n hw.perflevel0.physicalcpu 2>/dev/null)" \
+  "$(sysctl -n hw.perflevel1.physicalcpu 2>/dev/null)" \
+  "$(sysctl -n hw.memsize 2>/dev/null)" \
+  "$(sw_vers -productVersion 2>/dev/null)" \
+  "$(sysctl -n kern.hv_vmm_present 2>/dev/null)" \
+  "${ImageVersion:-$IMAGE_VERSION}" \
+  "$(xcodebuild -version 2>/dev/null | tr '\n' ' ')" \
+  "$(df -h / | awk 'NR==2{print $4}')" \
+  "$(sysctl -n vm.loadavg 2>/dev/null)"
+endgroup
+
+exit 0


### PR DESCRIPTION
## ⚠️ Do not merge — diagnostic branch

Scaffolding for investigating the `Unit Test` flakiness. It exists to make flakes
visible and to characterise the runners, not to change the SDK. No `Sources/`
changes.

### What it does

**1. Retries removed.** `-retry-tests-on-failure` is gone from all six matrix legs
and the ObjC example job. On `main` every leg retries, so a flake only shows red
when it survives the retry (or crashes/times out and aborts the bundle) — which
means we currently have no idea what the real flake rate is. Without the retry,
each red leg is one observation.

**2. Runner characterisation.** `scripts/ci_runner_info.sh` runs as the last step
before the tests, when the simulator runtimes are installed and the load snapshot
reflects what the bundle actually starts in. Ten collapsible groups:

| Group | Why it matters for these flakes |
|---|---|
| Machine & image identity, VM detection | `hw.model` + `kern.hv_vmm_present` tell us whether to mirror this as a VM locally rather than bare metal |
| CPU topology, incl. `hw.perflevel0/1` P/E split | A dispatch queue landing on an E core changes wall-clock behaviour — the most likely lever behind the timing-sensitive assertions |
| Memory, swap, disk, filesystem | `PersistentStorage` writes event blocks as files; a slow or full volume shifts flush timing |
| fd / process limits | fd exhaustion surfaces as an unrelated random failure |
| Load, thermals (before **and** after tests) | Distinguishes a starved leg from a genuinely failing one |
| DNS, egress timing to `api2.amplitude.com` | `HttpClientTests.testUploadWithCannotConnectToHostError` waits 15 s on real network behaviour |
| Toolchain, simulator runtimes, CoreSimulator version | |
| Micro benchmarks: sequential + small-file/fsync IO, 1-thread vs N-thread CPU, timer overshoot, clock granularity | A yardstick for comparing a local machine against the runner instead of guessing |

Bulky dumps (`sysctl -a`, `system_profiler`, `simctl list -j`, …) upload as a
per-leg artifact. A single grep-able line goes to the log for cross-run comparison:

```
RUNNER_FACTS model=… cpu="…" arch=… ncpu=… p_cores=… e_cores=… mem=… os=… hv=… image=… xcode="…" free_root=… loadavg="…"
```

**3. Repeat-until-failure.** `TEST_ITERATIONS` > 1 adds
`-test-iterations N -run-tests-until-failure`, hammering a leg within one job.
`workflow_dispatch` inputs are only offered once the workflow is on the default
branch, so from this branch use the repo variable instead:

```sh
gh variable set TEST_ITERATIONS --body 25 --repo amplitude/Amplitude-Swift
gh variable delete TEST_ITERATIONS --repo amplitude/Amplitude-Swift
```

`main`'s copy of the workflow does not read that variable, so setting it only
affects this branch.

**4. `.xcresult` per leg**, uploaded on success and failure — per-test timings,
attachments and `os_log` for after-the-fact inspection.

### Privacy note

Logs and artifacts are public on this repo. The script therefore publishes
environment variables from an explicit allowlist (image/arch/toolchain/run
identity) rather than filtering `env`, and lists processes by executable path
rather than full argv, since a concurrent step's argv can carry credentials.
Verified with canary values that neither the log nor any artifact contains
anything outside the allowlist.

### How to use it

Re-run the workflow repeatedly on the same commit to sample the flake rate:

```sh
gh run list --branch chore/ci-flaky-repro --workflow=unit-test.yml
gh run rerun <run-id>
gh run download <run-id>   # runner-info-* and xcresult-* artifacts
```
