### PR TITLE
feat: set user id and device id from Configuration

### DIFF
--- a/Sources/Amplitude/Amplitude.swift
+++ b/Sources/Amplitude/Amplitude.swift
@@ -170,9 +170,23 @@ public class Amplitude {
         }
         migrateInstanceOnlyStorages()
 
-        _identity = Identity(userId: configuration.storageProvider.read(key: .USER_ID),
-                             deviceId: configuration.storageProvider.read(key: .DEVICE_ID),
-                             userProperties: [:])
+        // Establish identity before any plugin is added, so that events generated
+        // during setup -- a session start, or app installed / opened when the app
+        // is already active -- are stamped with it. An explicitly configured id
+        // wins over the persisted one; both are written back so they persist like
+        // any other identity update.
+        var initialIdentity = Identity(userId: configuration.storageProvider.read(key: .USER_ID),
+                                       deviceId: configuration.storageProvider.read(key: .DEVICE_ID),
+                                       userProperties: [:])
+        if let configuredUserId = configuration.userId, configuredUserId != initialIdentity.userId {
+            initialIdentity.userId = configuredUserId
+            try? configuration.storageProvider.write(key: .USER_ID, value: configuredUserId)
+        }
+        if let configuredDeviceId = configuration.deviceId, configuredDeviceId != initialIdentity.deviceId {
+            initialIdentity.deviceId = configuredDeviceId
+            try? configuration.storageProvider.write(key: .DEVICE_ID, value: configuredDeviceId)
+        }
+        _identity = initialIdentity
 
         // Trigger lazy initialization before plugins are set up (plugins may query it during setup)
         _ = autocaptureManager

--- a/Sources/Amplitude/Configuration.swift
+++ b/Sources/Amplitude/Configuration.swift
@@ -43,6 +43,24 @@ public class Configuration {
     public var flushQueueSize: Int
     public var flushIntervalMillis: Int
     public internal(set) var instanceName: String
+
+    /// User id to identify events with, applied before any autocaptured event is
+    /// generated. Prefer this over calling `setUserId` after `init` when the id is
+    /// already known: `init` may generate events (a session start, or app
+    /// installed / opened when the app is already active), and those events are
+    /// stamped with whatever identity exists at the moment they are created --
+    /// which is before a post-`init` `setUserId` can run.
+    ///
+    /// Takes precedence over a previously persisted user id.
+    public var userId: String?
+
+    /// Device id to identify events with, applied before any autocaptured event is
+    /// generated. See ``userId`` for why this is preferable to `setDeviceId` after
+    /// `init`. When nil, the SDK reuses the persisted device id, falling back to
+    /// the IDFV or a random UUID.
+    ///
+    /// Takes precedence over a previously persisted device id.
+    public var deviceId: String?
     public var optOut: Bool {
         didSet {
             optOutChanged?(optOut)
@@ -189,6 +207,8 @@ public class Configuration {
         interactionsOptions: InteractionsOptions = Defaults.interactionsOptions,
         enableDiagnostics: Bool = Defaults.enableDiagnostics,
         enableRequestBodyCompression: Bool = Defaults.enableRequestBodyCompression,
+        userId: String? = nil,
+        deviceId: String? = nil,
     ) {
         let normalizedInstanceName = Configuration.getNormalizeInstanceName(instanceName)
 
@@ -239,6 +259,8 @@ public class Configuration {
         self.enableAutoCaptureRemoteConfig = enableAutoCaptureRemoteConfig
         self.interactionsOptions = interactionsOptions
         self.enableRequestBodyCompression = enableRequestBodyCompression
+        self.userId = userId
+        self.deviceId = deviceId
     }
 
     func isValid() -> Bool {

--- a/Sources/Amplitude/ObjC/ObjCConfiguration.swift
+++ b/Sources/Amplitude/ObjC/ObjCConfiguration.swift
@@ -335,4 +335,22 @@ public class ObjCConfiguration: NSObject {
             configuration.enableRequestBodyCompression = newValue
         }
     }
+
+    @objc public var userId: String? {
+        get {
+            configuration.userId
+        }
+        set {
+            configuration.userId = newValue
+        }
+    }
+
+    @objc public var deviceId: String? {
+        get {
+            configuration.deviceId
+        }
+        set {
+            configuration.deviceId = newValue
+        }
+    }
 }

--- a/Tests/AmplitudeTests/AmplitudeIOSTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeIOSTests.swift
@@ -250,15 +250,15 @@ final class AmplitudeIOSTests: XCTestCase {
             storageProvider: storageMem,
             identifyStorageProvider: interceptStorageMem,
             autocapture: .sessions,
-            enableAutoCaptureRemoteConfig: false
+            enableAutoCaptureRemoteConfig: false,
+            userId: "test-user",
+            deviceId: "test-device"
         )
 
         // force new session event to fire immediately
         IOSVendorSystem.overrideApplicationState(.active)
 
-        let identity = Identity(userId: "test-user", deviceId: "test-device")
         let amplitude = Amplitude(configuration: configuration)
-        amplitude.identity = identity
         amplitude.waitForTrackingQueue()
         // wait twice for async event generate
         amplitude.waitForTrackingQueue()
@@ -266,8 +266,8 @@ final class AmplitudeIOSTests: XCTestCase {
         let events = storageMem.events()
         XCTAssertEqual(events.count, 1)
         for event in events {
-            XCTAssertEqual(event.userId, identity.userId)
-            XCTAssertEqual(event.deviceId, identity.deviceId)
+            XCTAssertEqual(event.userId, "test-user")
+            XCTAssertEqual(event.deviceId, "test-device")
         }
     }
 

--- a/Tests/AmplitudeTests/AmplitudeTests.swift
+++ b/Tests/AmplitudeTests/AmplitudeTests.swift
@@ -284,6 +284,89 @@ final class AmplitudeTests: XCTestCase {
         XCTAssertEqual(storage.haveBeenCalledWith.last, "write(key: \(StorageKey.DEVICE_ID.rawValue), test-device)")
     }
 
+    func testConfiguredIdentityIsAppliedDuringInitAndPersisted() {
+        let configuration = Configuration(
+            apiKey: "test-api-key",
+            instanceName: #function,
+            storageProvider: storageMem,
+            identifyStorageProvider: interceptStorageMem,
+            userId: "configured-user",
+            deviceId: "configured-device"
+        )
+
+        let amplitude = Amplitude(configuration: configuration)
+
+        XCTAssertEqual(amplitude.getUserId(), "configured-user")
+        // ContextPlugin.initializeDeviceId runs during setup; it must leave a
+        // configured device id alone rather than replacing it with a random UUID.
+        XCTAssertEqual(amplitude.getDeviceId(), "configured-device")
+        // Written back, so a later launch without the configured values keeps them.
+        XCTAssertEqual(storageMem.read(key: StorageKey.USER_ID), "configured-user")
+        XCTAssertEqual(storageMem.read(key: StorageKey.DEVICE_ID), "configured-device")
+    }
+
+    func testConfiguredIdentityOverridesPersistedIdentity() throws {
+        try storageMem.write(key: StorageKey.USER_ID, value: "persisted-user")
+        try storageMem.write(key: StorageKey.DEVICE_ID, value: "persisted-device")
+
+        let configuration = Configuration(
+            apiKey: "test-api-key",
+            instanceName: #function,
+            storageProvider: storageMem,
+            identifyStorageProvider: interceptStorageMem,
+            userId: "configured-user",
+            deviceId: "configured-device"
+        )
+
+        let amplitude = Amplitude(configuration: configuration)
+
+        XCTAssertEqual(amplitude.getUserId(), "configured-user")
+        XCTAssertEqual(amplitude.getDeviceId(), "configured-device")
+    }
+
+    func testPersistedIdentityIsKeptWhenNotConfigured() throws {
+        try storageMem.write(key: StorageKey.USER_ID, value: "persisted-user")
+        try storageMem.write(key: StorageKey.DEVICE_ID, value: "persisted-device")
+
+        let configuration = Configuration(
+            apiKey: "test-api-key",
+            instanceName: #function,
+            storageProvider: storageMem,
+            identifyStorageProvider: interceptStorageMem
+        )
+
+        let amplitude = Amplitude(configuration: configuration)
+
+        XCTAssertEqual(amplitude.getUserId(), "persisted-user")
+        XCTAssertEqual(amplitude.getDeviceId(), "persisted-device")
+    }
+
+    func testConfiguredIdentityIsOnTheFirstEvent() {
+        let configuration = Configuration(
+            apiKey: "test-api-key",
+            instanceName: #function,
+            storageProvider: storageMem,
+            identifyStorageProvider: interceptStorageMem,
+            userId: "configured-user",
+            deviceId: "configured-device"
+        )
+
+        let amplitude = Amplitude(configuration: configuration)
+        let collector = EventCollectorPlugin()
+        amplitude.add(plugin: collector)
+        amplitude.track(event: BaseEvent(eventType: "test-event"))
+        amplitude.waitForTrackingQueue()
+
+        // The default autocapture is .sessions, so a session_start is generated
+        // ahead of the tracked event. Both must carry the configured identity --
+        // session_start is the one a post-init setUserId cannot reliably reach.
+        XCTAssertEqual(collector.events.map(\.eventType), [Constants.AMP_SESSION_START_EVENT, "test-event"])
+        for event in collector.events {
+            XCTAssertEqual(event.userId, "configured-user")
+            XCTAssertEqual(event.deviceId, "configured-device")
+        }
+    }
+
     func testInterceptedIdentifyIsSentOnFlush() {
         let amplitude = Amplitude(configuration: configurationWithFakeMemoryStorage)
 


### PR DESCRIPTION
### Summary

`Configuration` gains `userId` and `deviceId`. They're applied during `init`, before any
plugin is added, so every event `init` generates carries them — a session start, or app
installed / opened when the app is already active.

```swift
let amplitude = Amplitude(configuration: Configuration(
    apiKey: "...",
    userId: "user-123",
    deviceId: "device-456"
))
```

Setting identity *after* `init` can't reliably reach those events. `IOSLifecycleMonitor.setup`
dispatches onto `trackingQueue` during `init` (#295), and `onEnterForeground` snapshots
identity into its own async block through a capture list (#286) — so the snapshot is taken on
the worker thread, racing the caller's next statement. The caller normally wins by
microseconds; under load it doesn't, and `session_start` goes out with a nil user id and a
random device id.

This makes "identity precedes autocaptured events" something the API can express, rather than
something that depends on statement timing. It follows the
[Ensure identify before autocapture events](https://amplitude.atlassian.net/wiki/spaces/GOV/pages/3182690423/Ensure+identify+before+autocapture+events)
proposal and matches the web SDK, where `init` takes a user id and config takes a device id.
It also fills in the user id that Kotlin's `Configuration.deviceId` lacks.

Configured values take precedence over persisted ones and are written back, so a later launch
without them keeps the values. Setting identity after `init` is unchanged, and stays
best-effort.

### Effect on CI flakiness

`AmplitudeIOSTests.testSetIdentityForAutoCapturedEvents` locked in the #295 behaviour and was
the single largest source of unit-test flakiness: 18 of 24 failures over 50 iterations per leg.
Measured on a branch with `-retry-tests-on-failure` removed, 25 independent iterations per leg:

| Leg | Before | After |
|---|---:|---:|
| iOS latest | 12/50 red (24%) | **0/25** |
| tvOS latest | 4/50 red (8%) | **0/25** |
| iOS 18.5 | 3/49 red (6%) | **0/25** |
| macOS latest | 1/50 red (2%) | **0/25** |
| watchOS, visionOS | 0 | 0/25 |

If iOS latest's 20% per-iteration rate were unchanged, P(0 red in 25) ≈ 0.4%. Locally, the test
fails 100% of the time on `main` with a 200 ms sleep injected between `init` and the assertions,
and passes 5/5 with this change.

The other flaky tests — `AutocaptureRemoteConfigTests`, `WebViewDeadClickTests`,
`EventPipelineTests`, `NetworkConnectivityCheckerPluginTests` — are untouched. At their ~2% rate,
25 iterations can't confirm their absence, so the residual red rate for a full 6-leg run is
roughly 5–12%, down from 36%.

### Not included

`Configuration.identify` from the proposal. `Sessions.processEvent` returns
`[session_start, event]`, so a `$identify` tracked during `init` would land *after*
`session_start` — the opposite of the proposal's intent. That needs a change to session-event
ordering and belongs in its own PR. This fix doesn't depend on it: `userId`/`deviceId` go
through `_identity`, which is in place before any event exists, so no ordering is involved.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No — both parameters default to `nil`, which leaves the existing code path bit-identical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core init and identity stamping for all new SDK instances; behavior is additive (nil defaults) but changes which user/device ids appear on early autocaptured events when config is set.
> 
> **Overview**
> Adds optional **`userId`** and **`deviceId`** on `Configuration` (Swift initializer + Obj-C `AMPConfiguration` properties) so callers can supply identity at construction time instead of racing `setUserId` / `setDeviceId` after `init`.
> 
> During **`Amplitude` initialization**, identity is built from persisted storage, then configuration values **override** stored ids and are **written back** to storage **before any plugin is registered**. Autocaptured events emitted during setup (e.g. `session_start`, app lifecycle when already active) therefore inherit the configured ids.
> 
> Tests now pass identity via `Configuration` (including the previously flaky iOS autocapture identity test) and add coverage for override vs persisted values, persistence, and identity on the first events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 459ff3de940b891ba0fa66aa525e9748bad006f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->