### PR TITLE
test: make unit tests deterministic on slow CI runners

### DIFF
--- a/Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist
+++ b/Amplitude-Swift.xcodeproj/Amplitude_SwiftTests_Info.plist
@@ -20,6 +20,6 @@
   <key>CFBundleVersion</key>
   <string>$(CURRENT_PROJECT_VERSION)</string>
   <key>NSPrincipalClass</key>
-  <string></string>
+  <string>AMPTestBundlePrincipal</string>
 </dict>
 </plist>

--- a/Amplitude-Swift.xcodeproj/project.pbxproj
+++ b/Amplitude-Swift.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 		OBJ_150 /* RevenueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* RevenueTests.swift */; };
 		OBJ_151 /* PersistentStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_65 /* PersistentStorageTests.swift */; };
 		OBJ_152 /* TestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_67 /* TestUtilities.swift */; };
+		A7C0FF1E2E6F0001000000A2 /* RemoteConfigMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C0FF1E2E6F0001000000A1 /* RemoteConfigMockServer.swift */; };
 		OBJ_153 /* TimelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_68 /* TimelineTests.swift */; };
 		OBJ_154 /* TypesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_69 /* TypesTests.swift */; };
 		OBJ_155 /* EventPipelineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_71 /* EventPipelineTests.swift */; };
@@ -367,6 +368,7 @@
 		OBJ_63 /* RevenueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevenueTests.swift; sourceTree = "<group>"; };
 		OBJ_65 /* PersistentStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentStorageTests.swift; sourceTree = "<group>"; };
 		OBJ_67 /* TestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestUtilities.swift; sourceTree = "<group>"; };
+		A7C0FF1E2E6F0001000000A1 /* RemoteConfigMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigMockServer.swift; sourceTree = "<group>"; };
 		OBJ_68 /* TimelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineTests.swift; sourceTree = "<group>"; };
 		OBJ_69 /* TypesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypesTests.swift; sourceTree = "<group>"; };
 		OBJ_71 /* EventPipelineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventPipelineTests.swift; sourceTree = "<group>"; };
@@ -661,6 +663,7 @@
 			children = (
 				EAE891862DA83B6600AB97D0 /* FakeURLProtocol.swift */,
 				OBJ_67 /* TestUtilities.swift */,
+				A7C0FF1E2E6F0001000000A1 /* RemoteConfigMockServer.swift */,
 			);
 			path = Supports;
 			sourceTree = "<group>";
@@ -1018,6 +1021,7 @@
 				OBJ_151 /* PersistentStorageTests.swift in Sources */,
 				4E654DE12D9B60E700BCAA85 /* IdentityTests.swift in Sources */,
 				OBJ_152 /* TestUtilities.swift in Sources */,
+				A7C0FF1E2E6F0001000000A2 /* RemoteConfigMockServer.swift in Sources */,
 				6C23EF162C38AD31000DC8C8 /* UIKitUserInteractionPluginTest.swift in Sources */,
 				AB03FE202E58AC34000DC8CA /* WebViewDeadClickTests.swift in Sources */,
 				OBJ_153 /* TimelineTests.swift in Sources */,

--- a/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
+++ b/Tests/AmplitudeTests/AutocaptureRemoteConfigTests.swift
@@ -8,38 +8,29 @@
 import AmplitudeCore
 @testable
 import AmplitudeSwift
-import ObjectiveC
 import XCTest
 
+// Each test follows the same shape, and the order matters:
+//
+//   1. queue the remote config for this test's API key -- the mock holds it;
+//   2. init Amplitude and assert the *local* defaults -- the remote config provably
+//      has not arrived, because nothing has released it;
+//   3. register `remoteConfigAppliedExpectation()`, release the mock, wait;
+//   4. assert the remote values.
+//
+// Nothing here depends on how long any step takes. See RemoteConfigMockServer.
 class AutocaptureRemoteConfigTests: XCTestCase {
-
-    private static func swizzleEphemeral() {
-        let metaClass: AnyClass = object_getClass(URLSessionConfiguration.self)!
-        let originalSel = #selector(getter: URLSessionConfiguration.ephemeral)
-        let swizzledSel = #selector(URLSessionConfiguration.amp_ephemeral)
-
-        guard let original = class_getClassMethod(metaClass, originalSel),
-              let swizzled = class_getClassMethod(metaClass, swizzledSel) else {
-            return
-        }
-
-        method_exchangeImplementations(original, swizzled)
-    }
 
     override class func setUp() {
         super.setUp()
-        swizzleEphemeral()
-    }
-
-    override class func tearDown() {
-        // Swizzle again to restore original behavior
-        swizzleEphemeral()
-        super.tearDown()
+        // Already done by TestBundlePrincipal under xcodebuild; idempotent safety net
+        // for runners that ignore NSPrincipalClass, such as `swift test`.
+        RemoteConfigMockServer.install()
     }
 
     private func uniqueApiKey(_ function: String = #function) -> String {
         let cleanName = function.replacingOccurrences(of: "()", with: "")
-        return "\(RemoteConfigUrlProtocol.testApiKeyPrefix)\(cleanName)"
+        return "\(RemoteConfigMockServer.testApiKeyPrefix)\(cleanName)"
     }
 
     private func uniqueInstanceName(_ function: String = #function) -> String {
@@ -68,7 +59,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: []))
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be on from remote config")
     }
@@ -89,7 +82,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         let amplitude = Amplitude(configuration: Configuration(apiKey: apiKey, instanceName: uniqueInstanceName(), autocapture: [.sessions]))
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.sessions), "Sessions should be off from remote config")
     }
@@ -121,7 +116,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be on from remote config")
     }
@@ -152,7 +149,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.screenViews), "Screen views should be off from remote config")
     }
@@ -183,7 +182,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be on from remote config")
     }
@@ -214,7 +215,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.elementInteractions), "Element interactions should be off from remote config")
     }
@@ -263,7 +266,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertFalse(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be off by default")
         XCTAssertFalse(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on from remote config")
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on from remote config")
@@ -308,7 +313,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")
         XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be off from remote config")
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should still be on from local config")
@@ -358,7 +365,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertTrue(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be on by default")
         XCTAssertTrue(amplitude.autocaptureManager.deadClickEnabled, "Dead click should be on by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(amplitude.autocaptureManager.isEnabled(.frustrationInteractions), "Frustration interactions should be on by default")
         XCTAssertFalse(amplitude.autocaptureManager.rageClickEnabled, "Rage click should be off from remote config")
@@ -396,7 +405,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertTrue(networkTrackingPlugin.optOut, "Network tracking should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertFalse(networkTrackingPlugin.optOut, "Network tracking should be on from remote config")
     }
@@ -431,7 +442,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
 
         XCTAssertFalse(networkTrackingPlugin.optOut, "Network tracking should be off by default")
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         XCTAssertTrue(networkTrackingPlugin.optOut, "Network tracking should be on from remote config")
     }
@@ -491,7 +504,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         // Verify the plugin is enabled
         XCTAssertFalse(networkTrackingPlugin.optOut)
@@ -575,7 +590,9 @@ class AutocaptureRemoteConfigTests: XCTestCase {
             return
         }
 
-        wait(for: [amplitude.amplitudeContext.remoteConfigClient.didFetchRemoteExpectation], timeout: 15)
+        let remoteConfigApplied = amplitude.remoteConfigAppliedExpectation()
+        RemoteConfigMockServer.release(apiKey: apiKey)
+        wait(for: [remoteConfigApplied], timeout: 15)
 
         // Verify the plugin is enabled from remote config
         XCTAssertFalse(networkTrackingPlugin.optOut)
@@ -591,122 +608,4 @@ class AutocaptureRemoteConfigTests: XCTestCase {
         XCTAssertEqual(networkTrackingPlugin.originalOptions?.ignoreAmplitudeRequests, false)
     }
 #endif
-}
-
-extension RemoteConfigClient {
-
-    private final class SubscriptionHolder: @unchecked Sendable {
-        @AtomicRef var subscription: Any?
-    }
-
-    nonisolated var didFetchRemoteExpectation: XCTestExpectation {
-        let expectation = XCTestExpectation(description: "didFetchRemote")
-
-        let subscriptionHolder = SubscriptionHolder()
-        subscriptionHolder.subscription = subscribe(deliveryMode: .waitForRemote(timeout: 1.8)) { [weak self] _, _, _ in
-            if let subscription = subscriptionHolder.subscription {
-                self?.unsubscribe(subscription)
-            }
-            // Add a small delay to ensure other subscription callbacks complete.
-            // Callbacks are processed asynchronously, so even though this subscription
-            // was registered after the plugin's subscription, there's no guarantee
-            // about callback execution order.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                expectation.fulfill()
-            }
-        }
-
-        return expectation
-    }
-
-    static func setNextFetchedRemoteConfig(_ remoteConfig: RemoteConfigClient.RemoteConfig, forApiKey apiKey: String) {
-        RemoteConfigUrlProtocol.setConfig(remoteConfig, forApiKey: apiKey)
-    }
-
-    static func resetStorage(instanceName: String) {
-        let suiteName = "com.amplitude.remoteconfig.cache.\(instanceName)"
-        UserDefaults.standard.removePersistentDomain(forName: suiteName)
-    }
-}
-
-extension URLSessionConfiguration {
-
-    @objc class func amp_ephemeral() -> URLSessionConfiguration {
-        // This is swizzled, so amp_ephemeral actually calls the original ephemeral
-        let config = amp_ephemeral()
-        config.protocolClasses = [RemoteConfigUrlProtocol.self] + (config.protocolClasses ?? [])
-        return config
-    }
-}
-
-class RemoteConfigUrlProtocol: URLProtocol {
-
-    static let testApiKeyPrefix = "remote-config-test-"
-    // Configs keyed by API key for test isolation
-    static var configsByApiKey: [String: [RemoteConfigClient.RemoteConfig]] = [:]
-
-    private static let responseQueue = DispatchQueue(label: "RemoteConfigUrlProtocol.responseQueue")
-
-    static func setConfig(_ config: RemoteConfigClient.RemoteConfig, forApiKey apiKey: String) {
-        configsByApiKey[apiKey, default: []].append(config)
-    }
-
-    static func popConfig(forApiKey apiKey: String) -> RemoteConfigClient.RemoteConfig? {
-        guard var configs = configsByApiKey[apiKey], !configs.isEmpty else {
-            return nil
-        }
-        let config = configs.removeFirst()
-        configsByApiKey[apiKey] = configs
-        return config
-    }
-
-    private static func extractApiKey(from url: URL) -> String? {
-        // URL format: https://sr-client-cfg.amplitude.com/config/{apiKey}
-        return url.pathComponents.last?.components(separatedBy: "?").first
-    }
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        guard let url = request.url,
-              url.absoluteString.hasPrefix("https://sr-client-cfg."),
-              let apiKey = extractApiKey(from: url) else {
-            return false
-        }
-        // Only intercept requests with our test API key prefix
-        return apiKey.hasPrefix(testApiKeyPrefix)
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        return request
-    }
-
-    override func startLoading() {
-        guard let url = request.url,
-              let apiKey = Self.extractApiKey(from: url),
-              let config = Self.popConfig(forApiKey: apiKey) else {
-            client?.urlProtocol(self, didFailWithError: NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown))
-            return
-        }
-
-        print("RemoteConfigUrlProtocol: Starting to load \(url)")
-
-        let response = HTTPURLResponse(url: url,
-                                       statusCode: 200,
-                                       httpVersion: nil,
-                                       headerFields: ["Content-Type": "application/json"])!
-        let data = try? JSONSerialization.data(withJSONObject: ["configs": config])
-
-        Self.responseQueue.asyncAfter(deadline: .now() + DispatchTimeInterval.milliseconds(500)) { [self] in
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            if let data {
-                client?.urlProtocol(self, didLoad: data)
-            }
-            client?.urlProtocolDidFinishLoading(self)
-
-            print("RemoteConfigUrlProtocol: Finished loading \(url): \(config)")
-        }
-    }
-
-    override func stopLoading() {
-        // no-op
-    }
 }

--- a/Tests/AmplitudeTests/Plugins/NetworkConnectivityCheckerPluginTests.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkConnectivityCheckerPluginTests.swift
@@ -17,7 +17,12 @@ final class NetworkConnectivityCheckerPluginTests: XCTestCase {
     override func setUp() {
         super.setUp()
         mockPathCreation = MockPathCreation()
-        amplitude = Amplitude(configuration: Configuration(apiKey: "test-api-key"))
+        // Disabled keeps Amplitude.init from installing its own NetworkConnectivityCheckerPlugin,
+        // whose real NWPathMonitor also writes configuration.offline from the tracking queue --
+        // a second writer racing the mock-driven plugin under test, which on a busy runner
+        // flipped the value back between simulateNetworkChange and the assertion.
+        amplitude = Amplitude(configuration: Configuration(apiKey: "test-api-key",
+                                                           offline: NetworkConnectivityCheckerPlugin.Disabled))
         plugin = NetworkConnectivityCheckerPlugin(pathCreation: mockPathCreation)
         plugin.setup(amplitude: amplitude)
     }

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -450,8 +450,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: [expectation3], timeout: 30)
 
         try waitForCollectedEvents(2)
-        plugin.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2)
@@ -542,9 +541,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 30)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(1)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1, "Should capture only matching URLs")
@@ -682,9 +680,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 30)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(4)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 4, "Should capture only URLs matching the anchored regex patterns")
@@ -736,8 +733,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(1)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1, "URL patterns should take priority over host patterns")

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -47,6 +47,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
     override func tearDown() {
         super.tearDown()
         eventCollector.events.removeAll()
+        FakeURLProtocol.clearMockResponses()
         // Only invalidate custom timeout sessions - shared session is reused
         customTimeoutSessions.forEach { $0.invalidateAndCancel() }
         customTimeoutSessions.removeAll()
@@ -159,7 +160,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
     func testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude() throws {
         setupAmplitude()
 
-        FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
+        FakeURLProtocol.amplitudeResponses = [.init(statusCode: 500)]
 
         amplitude.track(eventType: "Test")
         amplitude.flush()
@@ -178,7 +179,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         options.ignoreAmplitudeRequests = false
         setupAmplitude(with: options)
 
-        FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
+        FakeURLProtocol.amplitudeResponses = [.init(statusCode: 500)]
 
         // Two events reach the collector: the tracked "Test" event, then the network event for
         // the flush that uploads it (ignoreAmplitudeRequests is off; flushMaxRetries is 0, so

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -155,9 +155,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation], timeout: 30)
 
-        wait()
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 0, "Should not capture network request event with status code 200")
@@ -166,14 +164,17 @@ final class NetworkTrackingPluginTest: XCTestCase {
     func testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude() throws {
         setupAmplitude()
 
+        // A 500 would be captured if the upload were not ignored, so this test only proves
+        // anything once that upload has actually been answered.
         FakeURLProtocol.amplitudeResponses = [.init(statusCode: 500)]
+        let uploaded = expectAmplitudeUpload()
 
         amplitude.track(eventType: "Test")
         amplitude.flush()
 
+        wait(for: [uploaded], timeout: 30)
         try waitForCollectedEvents(1)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -193,6 +194,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         amplitude.track(eventType: "Test")
         amplitude.flush()
         try waitForCollectedEvents(2)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2)
@@ -217,8 +219,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: expectations, timeout: 30)
 
-        amplitude.waitForTrackingQueue()
-        wait()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 0)
@@ -278,8 +279,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: expectations, timeout: 30)
 
-        amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(2)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture two network requests")
@@ -606,9 +607,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 30)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(3)
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 3, "Should capture only regex matching URLs")
@@ -790,8 +790,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(2)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture only GET and POST requests")
@@ -936,8 +935,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(2)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture only requests matching both URL and method criteria")
@@ -1203,8 +1201,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(3)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        settleUncapturedRequests()
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 3, "Should capture requests matching any of the rules")
@@ -1221,12 +1218,35 @@ final class NetworkTrackingPluginTest: XCTestCase {
     }
 #endif
 
-    /// Fixed sleep. Only for asserting that *nothing* was captured -- a sleep that is too short
-    /// can make such a test pass wrongly, but cannot make it fail. For "N events captured" use
-    /// `waitForCollectedEvents`.
+    /// Fixed sleep. Only needed for requests a test expects NOT to be captured -- a sleep
+    /// that is too short can make such an assertion pass wrongly, but cannot make it fail. For
+    /// "N events captured" use `waitForCollectedEvents`; a test that has both waits for the N
+    /// first and then calls `settleUncapturedRequests`.
     func wait(for interval: TimeInterval = 0.1) {
         let expectation = XCTestExpectation(description: "Wait for time interval")
         XCTWaiter().wait(for: [expectation], timeout: interval)
+    }
+
+    /// Call before asserting that some request was NOT captured. The plugin records a request
+    /// from its `setState(.completed)` hook, and URLSession runs that after the completion
+    /// handler that fulfilled the test's expectation -- so when every expected event has
+    /// arrived, the event for a wrongly captured request may still be a few hops away. The
+    /// queue drains alone cannot help (they only flush work already enqueued); the sleep
+    /// gives that work time to be enqueued, the drains then push it through to the collector.
+    func settleUncapturedRequests() {
+        wait()
+        networkTrackingPlugin?.waitforNetworkTrackingQueue()
+        amplitude.waitForTrackingQueue()
+    }
+
+    /// Expectation fulfilled once the mock has answered the SDK's own upload to api2. A test
+    /// asserting that this upload was NOT captured must wait for it first: before the request
+    /// has completed, "no network event yet" proves nothing.
+    func expectAmplitudeUpload() -> XCTestExpectation {
+        let uploaded = XCTestExpectation(description: "amplitude upload answered")
+        uploaded.assertForOverFulfill = false
+        FakeURLProtocol.onAmplitudeRequestFinished = { _ in uploaded.fulfill() }
+        return uploaded
     }
 
     private struct CollectedEventsTimeout: Error {}

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -173,25 +173,32 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertFalse(events[0] is NetworkRequestEvent)
     }
 
-    func testNetworkTrackingOptionsIgnoreAmplitudeRequestsFalse() {
+    func testNetworkTrackingOptionsIgnoreAmplitudeRequestsFalse() throws {
         var options = NetworkTrackingOptions.default
         options.ignoreAmplitudeRequests = false
         setupAmplitude(with: options)
 
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
 
+        // Two events reach the collector: the tracked "Test" event, then the network event for
+        // the flush that uploads it (ignoreAmplitudeRequests is off; flushMaxRetries is 0, so
+        // exactly one request). Wait for both rather than sleeping -- this used to be
+        // `wait(for: 0.1)` followed by `events[1] as!`, which on a slow runner found one event
+        // and took the whole test bundle down with an index-out-of-range trap.
+        let collected = expectation(description: "test event and network event collected")
+        collected.expectedFulfillmentCount = 2
+        collected.assertForOverFulfill = false
+        eventCollector.onEvent = { _ in collected.fulfill() }
+
         amplitude.track(eventType: "Test")
         amplitude.flush()
-
-        wait(for: 0.1)
-        networkTrackingPlugin?.waitforNetworkTrackingQueue()
-        amplitude.waitForTrackingQueue()
-        amplitude.waitForTrackingQueue()
+        wait(for: [collected], timeout: 10)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2)
-        let event = events[1] as! NetworkRequestEvent
-        XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as! String, "https://api2.amplitude.com/2/httpapi")
+        let event = try XCTUnwrap(events.compactMap { $0 as? NetworkRequestEvent }.first)
+        XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_URL_PROPERTY] as? String,
+                       "https://api2.amplitude.com/2/httpapi")
     }
 
     func testNetworkTrackingOptionsIgnoreHosts() {

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -108,7 +108,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
     }
 
 #if !os(watchOS)
-    func testDefaultNetworkTrackingOptionsShouldCapture500() {
+    func testDefaultNetworkTrackingOptionsShouldCapture500() throws {
         setupAmplitude()
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
 
@@ -118,7 +118,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation], timeout: 2)
 
-        wait()
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -156,7 +156,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(events.count, 0, "Should not capture network request event with status code 200")
     }
 
-    func testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude() {
+    func testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude() throws {
         setupAmplitude()
 
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
@@ -164,7 +164,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         amplitude.track(eventType: "Test")
         amplitude.flush()
 
-        wait()
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -182,17 +182,10 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         // Two events reach the collector: the tracked "Test" event, then the network event for
         // the flush that uploads it (ignoreAmplitudeRequests is off; flushMaxRetries is 0, so
-        // exactly one request). Wait for both rather than sleeping -- this used to be
-        // `wait(for: 0.1)` followed by `events[1] as!`, which on a slow runner found one event
-        // and took the whole test bundle down with an index-out-of-range trap.
-        let collected = expectation(description: "test event and network event collected")
-        collected.expectedFulfillmentCount = 2
-        collected.assertForOverFulfill = false
-        eventCollector.onEvent = { _ in collected.fulfill() }
-
+        // exactly one request).
         amplitude.track(eventType: "Test")
         amplitude.flush()
-        wait(for: [collected], timeout: 10)
+        try waitForCollectedEvents(2)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2)
@@ -224,7 +217,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(events.count, 0)
     }
 
-    func testNetworkTrackingOptionsCaptureHosts() {
+    func testNetworkTrackingOptionsCaptureHosts() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [.init(hosts: ["*.example.com", "example2.com"])]
         setupAmplitude(with: options)
@@ -245,7 +238,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
 
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(2)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture two network requests")
@@ -258,7 +251,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(urls.contains(url1), "Should capture requests to the specified hosts")
     }
 
-    func testNetworkTrackingOptionsCaptureStatusCode() {
+    func testNetworkTrackingOptionsCaptureStatusCode() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [.init(hosts: ["*"], statusCodeRange: "413,500-599")]
         setupAmplitude(with: options)
@@ -279,7 +272,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
 
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(2)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 2, "Should capture two network requests")
@@ -292,7 +285,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(statusCodes.contains(500), "Should capture requests with status codes inside the specified range")
     }
 
-    func testNetworkTrackingOptionsCaptureLocalError() {
+    func testNetworkTrackingOptionsCaptureLocalError() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [.init(hosts: ["*"], statusCodeRange: "0")]
         setupAmplitude(with: options)
@@ -306,7 +299,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: [expectation], timeout: 2)
 
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(1)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -318,7 +311,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_ERROR_MESSAGE_PROPERTY] as! String, "The request timed out.")
     }
 
-    func testCapturingAsyncTasks() {
+    func testCapturingAsyncTasks() throws {
         setupAmplitude()
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
 
@@ -329,10 +322,8 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
+        try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
-
-        wait(for: 1)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -346,7 +337,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(event.eventProperties?[Constants.AMP_DURATION_PROPERTY] as! Int64 > 0)
     }
 
-    func testCapturingUploadTask() {
+    func testCapturingUploadTask() throws {
         setupAmplitude()
         let responseBodyData = "Bar".data(using: .utf8)!
         FakeURLProtocol.mockResponses = [.init(statusCode: 500, data: responseBodyData)]
@@ -362,7 +353,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }).resume()
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
+        try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -375,7 +366,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_RESPONSE_BODY_SIZE_PROPERTY] as! Int64, Int64(responseBodyData.count))
     }
 
-    func testCapturingDownloadTask() {
+    func testCapturingDownloadTask() throws {
         setupAmplitude()
 
         let responseBodyData = "Bar".data(using: .utf8)!
@@ -391,7 +382,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }).resume()
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
+        try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1)
@@ -401,7 +392,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(event.eventProperties?[Constants.AMP_NETWORK_RESPONSE_BODY_SIZE_PROPERTY] as! Int64, Int64(responseBodyData.count))
     }
 
-    func testRuleForHost() {
+    func testRuleForHost() throws {
         let options = NetworkTrackingOptions(captureRules: [
             .init(hosts: ["*.example.com"], statusCodeRange: "0,500-599"),
             .init(hosts: ["api.example.com"], statusCodeRange: "400-499"),
@@ -450,7 +441,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation3], timeout: 2)
 
-        wait()
+        try waitForCollectedEvents(2)
         plugin.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -466,7 +457,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(event2.eventProperties?[Constants.AMP_NETWORK_STATUS_CODE_PROPERTY] as! Int, 500)
     }
 
-    func testCaptureHeaderFields() {
+    func testCaptureHeaderFields() throws {
         let requestHeaders = ["custom-header-1": "value1", "custom-header-2": "value2", "other-header": "value-other"]
         let responseHeaders = ["custom-header-3": "value3", "custom-header-4": "value4", "other-header": "value-other"]
         let expectedRequestHeaders = requestHeaders.filter { ["custom-header-1", "custom-header-2"].contains($0.key) }
@@ -486,7 +477,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
         wait(for: [expectation], timeout: 2)
 
-        wait() // Wait for Autocapture works
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
         let events = eventCollector.events
@@ -509,7 +500,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
     // MARK: - URL Pattern Matching Tests
 
-    func testURLExactMatching() {
+    func testURLExactMatching() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -545,7 +536,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(1)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 1, "Should capture only matching URLs")
@@ -559,7 +550,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }
     }
 
-    func testURLRegexMatching() {
+    func testURLRegexMatching() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -610,7 +601,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(3)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 3, "Should capture only regex matching URLs")
@@ -624,7 +615,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(capturedURLs.contains("https://monitoring.example.com/health/status"))
     }
 
-    func testURLRegexAnchors() {
+    func testURLRegexAnchors() throws {
         // Test regex patterns with ^ (start) and $ (end) anchors
         var options = NetworkTrackingOptions.default
         options.captureRules = [
@@ -686,7 +677,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         wait(for: expectations, timeout: 2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
-        wait()
+        try waitForCollectedEvents(4)
 
         let events = eventCollector.events
         XCTAssertEqual(events.count, 4, "Should capture only URLs matching the anchored regex patterns")
@@ -708,7 +699,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertFalse(capturedURLs.contains("https://other.exact.example.com/path"), "Should not match different subdomain")
     }
 
-    func testURLPatternPriority() {
+    func testURLPatternPriority() throws {
         // Test that URL patterns take priority over host patterns when both are specified
         var options = NetworkTrackingOptions.default
         options.captureRules = [
@@ -737,7 +728,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -750,7 +741,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
     // MARK: - HTTP Method Matching Tests
 
-    func testHTTPMethodMatching() {
+    func testHTTPMethodMatching() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -791,7 +782,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -806,7 +797,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(capturedMethods.contains("POST"))
     }
 
-    func testHTTPMethodWildcard() {
+    func testHTTPMethodWildcard() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -839,7 +830,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -847,7 +838,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(events.count, 3, "Should capture all HTTP methods with wildcard")
     }
 
-    func testHTTPMethodCaseInsensitive() {
+    func testHTTPMethodCaseInsensitive() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -880,7 +871,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -888,7 +879,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertEqual(events.count, 3, "Method matching should be case-insensitive")
     }
 
-    func testCombinedURLAndMethodFiltering() {
+    func testCombinedURLAndMethodFiltering() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             .init(
@@ -937,7 +928,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -958,7 +949,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         XCTAssertTrue(capturedRequests.contains { $0.url == "https://store.example.com/products/123" && $0.method == "PUT" })
     }
 
-    func testResponseBodyCapture() {
+    func testResponseBodyCapture() throws {
         // Setup network tracking with response body capture
         let options = NetworkTrackingOptions(
             captureRules: [
@@ -1018,7 +1009,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         task.resume()
 
         wait(for: [expectation], timeout: 2.0)
-        wait(for: 0.2)
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -1056,7 +1047,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }
     }
 
-    func testResponseBodyCaptureWithURL() {
+    func testResponseBodyCaptureWithURL() throws {
         // Test response body capture with dataTask(with: URL, completionHandler:)
         let options = NetworkTrackingOptions(
             captureRules: [
@@ -1109,7 +1100,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         task.resume()
 
         wait(for: [expectation], timeout: 2.0)
-        wait()
+        try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -1151,7 +1142,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }
     }
 
-    func testMultipleRulesWithDifferentPatterns() {
+    func testMultipleRulesWithDifferentPatterns() throws {
         var options = NetworkTrackingOptions.default
         options.captureRules = [
             // Rule 1: Specific API endpoints with POST only
@@ -1204,7 +1195,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         }.resume()
 
         wait(for: expectations, timeout: 2)
-        wait()
+        try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
 
@@ -1223,9 +1214,32 @@ final class NetworkTrackingPluginTest: XCTestCase {
     }
 #endif
 
+    /// Fixed sleep. Only for asserting that *nothing* was captured -- a sleep that is too short
+    /// can make such a test pass wrongly, but cannot make it fail. For "N events captured" use
+    /// `waitForCollectedEvents`.
     func wait(for interval: TimeInterval = 0.1) {
         let expectation = XCTestExpectation(description: "Wait for time interval")
         XCTWaiter().wait(for: [expectation], timeout: interval)
+    }
+
+    private struct CollectedEventsTimeout: Error {}
+
+    /// Waits until the collector holds at least `count` events, then returns. On timeout it
+    /// records a failure and throws, so the caller never reaches `events[i]` with too few
+    /// events. This replaces the fixed `wait()` sleeps that, on a slow CI runner, let a test
+    /// index past the end of the array and take the whole bundle down.
+    func waitForCollectedEvents(_ count: Int,
+                                timeout: TimeInterval = 10,
+                                file: StaticString = #filePath,
+                                line: UInt = #line) throws {
+        let collected = XCTestExpectation(description: "\(count) events collected")
+        eventCollector.fulfill(collected, whenCollected: count)
+        guard XCTWaiter().wait(for: [collected], timeout: timeout) == .completed else {
+            XCTFail("Timed out after \(timeout)s waiting for \(count) collected events; have \(eventCollector.events.count)",
+                    file: file,
+                    line: line)
+            throw CollectedEventsTimeout()
+        }
     }
 }
 // swiftlint:enable force_cast

--- a/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
+++ b/Tests/AmplitudeTests/Plugins/NetworkTrackingPluginTest.swift
@@ -12,7 +12,13 @@ import XCTest
 // swiftlint:disable force_cast
 final class NetworkTrackingPluginTest: XCTestCase {
 
-    private static let defaultTimeout: TimeInterval = 2
+    // Request timeout for the shared session, and the budget every test gives its requests to
+    // complete. Loose on purpose: the mock answers in ~10 ms, so a green run never waits, but on
+    // a 3-vCPU CI simulator the URL loading system has stalled for over 2 s mid-test -- the
+    // session then timed the requests out, the error events carried no status code, matched no
+    // capture rule, and the test came up short. The one test that needs a timeout to fire passes
+    // its own short value to taskForRequest, which builds a separate session.
+    private static let defaultTimeout: TimeInterval = 30
     private var amplitude: Amplitude!
     private var storageMem: FakeInMemoryStorage!
     private var eventCollector = EventCollectorPlugin()
@@ -117,7 +123,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://example.com?test=1#hash") { _, _, _ in
             expectation.fulfill()
         }.resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
@@ -147,7 +153,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest { _, _, _ in
             expectation.fulfill()
         }.resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         wait()
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
@@ -209,7 +215,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://example2.com/api") { _, _, _ in
             expectations[1].fulfill()
         }.resume()
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
 
         amplitude.waitForTrackingQueue()
         wait()
@@ -236,7 +242,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest(url1) { _, _, _ in
             expectations[1].fulfill()
         }.resume()
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
 
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(2)
@@ -270,7 +276,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest { _, _, _ in
             expectations[2].fulfill()
         }.resume()
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
 
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(2)
@@ -297,7 +303,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest(timeout: 0.1) { _, _, _ in
             expectation.fulfill()
         }.resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(1)
@@ -321,7 +327,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             try await request("https://example.com")
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
@@ -352,7 +358,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         Self.sharedSession.uploadTask(with: request, from: requestBodyData, completionHandler: { _, _, _ in
             expectation.fulfill()
         }).resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
@@ -381,7 +387,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         Self.sharedSession.downloadTask(with: request, completionHandler: { _, _, _ in
             expectation.fulfill()
         }).resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         amplitude.waitForTrackingQueue()
@@ -424,7 +430,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://api.example.com") { _, _, _ in
             expectation1.fulfill()
         }.resume()
-        wait(for: [expectation1], timeout: 2)
+        wait(for: [expectation1], timeout: 30)
 
         // Request 2: api.example.com with 500 -> should NOT be captured (rule only allows 400-499)
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
@@ -432,7 +438,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://api.example.com") { _, _, _ in
             expectation2.fulfill()
         }.resume()
-        wait(for: [expectation2], timeout: 2)
+        wait(for: [expectation2], timeout: 30)
 
         // Request 3: api2.example.com with 500 -> should be captured (matches wildcard rule for 0,500-599)
         FakeURLProtocol.mockResponses = [.init(statusCode: 500)]
@@ -440,7 +446,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://api2.example.com") { _, _, _ in
             expectation3.fulfill()
         }.resume()
-        wait(for: [expectation3], timeout: 2)
+        wait(for: [expectation3], timeout: 30)
 
         try waitForCollectedEvents(2)
         plugin.waitforNetworkTrackingQueue()
@@ -476,7 +482,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
         taskForRequest("https://example.com?test=1#hash", requestHeaders: requestHeaders) { _, _, _ in
             expectation.fulfill()
         }.resume()
-        wait(for: [expectation], timeout: 2)
+        wait(for: [expectation], timeout: 30)
 
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
@@ -534,7 +540,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[2].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(1)
@@ -599,7 +605,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[4].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(3)
@@ -675,7 +681,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[7].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
         try waitForCollectedEvents(4)
@@ -728,7 +734,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[1].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -782,7 +788,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[3].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -830,7 +836,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[2].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -871,7 +877,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[2].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -928,7 +934,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[5].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(2)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -1009,7 +1015,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         task.resume()
 
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 30)
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -1100,7 +1106,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
 
         task.resume()
 
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 30)
         try waitForCollectedEvents(1)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()
@@ -1195,7 +1201,7 @@ final class NetworkTrackingPluginTest: XCTestCase {
             expectations[4].fulfill()
         }.resume()
 
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 30)
         try waitForCollectedEvents(3)
         networkTrackingPlugin?.waitforNetworkTrackingQueue()
         amplitude.waitForTrackingQueue()

--- a/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
+++ b/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
@@ -171,13 +171,13 @@ final class WebViewDeadClickTests: XCTestCase {
 
         // Four rapid taps inside the web view: rage click must still fire, dead click must not,
         // even though no interface change signal ever arrives.
-        for _ in 0..<4 {
-            fireTap(on: nestedInWebView)
-            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        }
+        let burstEnd = try fireRageClickBurst(on: nestedInWebView)
 
-        // Past the rage debounce (1 s) and the dead click timeout (3.5 s).
-        RunLoop.current.run(until: Date().addingTimeInterval(4.2))
+        // The rage click is reported by the detector's 1 s debounce timer: wait for the event, not
+        // for a fixed time. Then stay past the dead click timeout (3.5 s after the tap) so a dead
+        // click, had one been reported, would be in the collector as well.
+        runLoop(until: collector, has: 1, ofType: Constants.AMP_RAGE_CLICK_EVENT)
+        RunLoop.current.run(until: burstEnd.addingTimeInterval(4.2))
         amplitude.waitForTrackingQueue()
 
         XCTAssertEqual(events(in: collector, ofType: Constants.AMP_RAGE_CLICK_EVENT).count, 1,
@@ -188,7 +188,7 @@ final class WebViewDeadClickTests: XCTestCase {
         // Positive control: the same tap on a plain view IS reported dead, proving the detector
         // and provider wiring in this test are live.
         fireTap(on: plainView)
-        RunLoop.current.run(until: Date().addingTimeInterval(4.2))
+        runLoop(until: collector, has: 1, ofType: Constants.AMP_DEAD_CLICK_EVENT)
         amplitude.waitForTrackingQueue()
 
         XCTAssertEqual(events(in: collector, ofType: Constants.AMP_DEAD_CLICK_EVENT).count, 1,
@@ -216,11 +216,9 @@ final class WebViewDeadClickTests: XCTestCase {
         webView.amp_ignoreInteractionEvent(rageClick: true, deadClick: false)
 
         // Four rapid taps on web content the customer marked: enough to cross the rage threshold.
-        for _ in 0..<4 {
-            fireTap(on: nestedInWebView, at: CGPoint(x: 50, y: 50))
-            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        }
-        RunLoop.current.run(until: Date().addingTimeInterval(1.3))
+        let burstEnd = try fireRageClickBurst(on: nestedInWebView, at: CGPoint(x: 50, y: 50))
+        // Past the 1 s debounce, so a rage click, had one been detected, would have been reported.
+        RunLoop.current.run(until: burstEnd.addingTimeInterval(1.5))
         amplitude.waitForTrackingQueue()
 
         XCTAssertEqual(events(in: collector, ofType: Constants.AMP_RAGE_CLICK_EVENT).count, 0,
@@ -228,11 +226,8 @@ final class WebViewDeadClickTests: XCTestCase {
 
         // Positive control: the same taps on an unmarked view still do, proving the detector was
         // live and the taps really reached the swizzled path.
-        for _ in 0..<4 {
-            fireTap(on: plainView, at: CGPoint(x: 50, y: 650))
-            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
-        }
-        RunLoop.current.run(until: Date().addingTimeInterval(1.3))
+        try fireRageClickBurst(on: plainView, at: CGPoint(x: 50, y: 650))
+        runLoop(until: collector, has: 1, ofType: Constants.AMP_RAGE_CLICK_EVENT)
         amplitude.waitForTrackingQueue()
 
         XCTAssertEqual(events(in: collector, ofType: Constants.AMP_RAGE_CLICK_EVENT).count, 1,
@@ -389,6 +384,50 @@ final class WebViewDeadClickTests: XCTestCase {
         view.addGestureRecognizer(recognizer)
         recognizer.fireEnded()
         view.removeGestureRecognizer(recognizer)
+    }
+
+    /// Four taps on `view`, 10 ms apart: past the SDK's 5 ms physical-tap dedup window and well
+    /// inside the rage click detector's 1 s window. Click timestamps are taken synchronously in
+    /// `amp_setState`, so the spacing is exactly this loop's pacing and no run-loop turn is needed
+    /// between taps. Turning the run loop there let unrelated work (WebKit IPC, layout) stretch a
+    /// burst past 1 s on a loaded CI runner, and the detector then correctly saw no rage click.
+    /// Returns when the last tap was fired. Skips the test if the host stalled so badly that even
+    /// this burst exceeded the window: the SDK was then never given four taps within a second.
+    @discardableResult
+    private func fireRageClickBurst(on view: UIView,
+                                    at location: CGPoint = CGPoint(x: 50, y: 50),
+                                    file: StaticString = #filePath,
+                                    line: UInt = #line) throws -> Date {
+        let start = Date()
+        for i in 0..<4 {
+            if i > 0 {
+                Thread.sleep(forTimeInterval: 0.01)
+            }
+            fireTap(on: view, at: location)
+        }
+        let end = Date()
+        let elapsed = end.timeIntervalSince(start)
+        if elapsed > 0.9 {
+            throw XCTSkip("Host stalled: four taps took \(elapsed) s, longer than the 1 s rage click window",
+                          file: file, line: line)
+        }
+        return end
+    }
+
+    /// Turns the main run loop until `collector` holds `count` events of `eventType`, or `timeout`
+    /// passes. The detectors report from main-run-loop timers (rage click 1 s after the last tap,
+    /// dead click 3.5 s after the tap), so the loop has to turn while waiting; a fixed turn read
+    /// the collector before a late timer had fired on a loaded CI runner. The caller's assertion
+    /// still reports a missing event; this only removes the fixed budget.
+    private func runLoop(until collector: EventCollectorPlugin,
+                         has count: Int,
+                         ofType eventType: String,
+                         timeout: TimeInterval = 15) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline, events(in: collector, ofType: eventType).count < count {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+            Thread.sleep(forTimeInterval: 0.01)
+        }
     }
 
     private func events(in collector: EventCollectorPlugin, ofType eventType: String) -> [BaseEvent] {

--- a/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
+++ b/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
@@ -73,7 +73,7 @@ final class WebViewDeadClickTests: XCTestCase {
 
     func testDeadClickSuppressedInsideWebViewWhileRageClickStaysOn() throws {
         let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
-        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+        waitForTapRecognizers(in: webView)
 
         XCTAssertTrue(webView.amp_isInsideWebView, "The web view itself counts as web content")
         XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: webView))
@@ -283,7 +283,7 @@ final class WebViewDeadClickTests: XCTestCase {
     /// ancestors, `webView.amp_ignoreInteractionEvent()` was a silent no-op.
     func testIgnoreHookOnWebViewReachesTheRecognizerView() throws {
         let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
-        RunLoop.current.run(until: Date().addingTimeInterval(1.0))
+        waitForTapRecognizers(in: webView)
 
         let qualifying = allRecognizers(in: webView).filter { qualifiesAsPhysicalTap($0.recognizer) }
         XCTAssertFalse(qualifying.isEmpty)
@@ -416,6 +416,13 @@ final class WebViewDeadClickTests: XCTestCase {
         return (amplitude, collector)
     }
 
+    /// How long a load may take before the test gives up. A warm load finishes in ~0.4 s and a
+    /// cold one (first WebContent process of the test run) in ~1.3 s, on CI and locally alike --
+    /// but on a starved 3-vCPU CI simulator the same load has been seen to exceed 10 s, both
+    /// cold and warm, and load speed is not something any test here asserts. Generous on
+    /// purpose: a green run never comes near it, a red one stops being red for the wrong reason.
+    private static let loadTimeout: TimeInterval = 60
+
     private func loadedWebView(_ html: String) throws -> WKWebView {
         let webView = WKWebView(frame: window.bounds)
         window.addSubview(webView)
@@ -426,8 +433,21 @@ final class WebViewDeadClickTests: XCTestCase {
         navigationDelegate = delegate
         webView.navigationDelegate = delegate
         webView.loadHTMLString(html, baseURL: nil)
-        wait(for: [loaded], timeout: 10)
+        wait(for: [loaded], timeout: Self.loadTimeout)
         return webView
+    }
+
+    /// WebKit attaches its tap recognizers to `WKContentView` asynchronously, some time after
+    /// `didFinish`. Poll for the first qualifying one instead of sleeping a fixed second; the
+    /// caller's `XCTAssertFalse(qualifying.isEmpty)` still reports clearly if they never appear.
+    private func waitForTapRecognizers(in webView: WKWebView, timeout: TimeInterval = 30) {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if allRecognizers(in: webView).contains(where: { qualifiesAsPhysicalTap($0.recognizer) }) {
+                return
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
     }
 
     private final class NavigationDelegate: NSObject, WKNavigationDelegate {

--- a/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
+++ b/Tests/AmplitudeTests/Plugins/WebViewDeadClickTests.swift
@@ -24,9 +24,7 @@ import UIKit.UIGestureRecognizerSubclass
 final class WebViewDeadClickTests: XCTestCase {
 
     private var window: UIWindow!
-    /// `WKWebView.navigationDelegate` is weak; the delegate must outlive the navigation.
-    private var navigationDelegate: NavigationDelegate?
-    /// `Amplitude.interfaceSignalProvider` is weak too.
+    /// `Amplitude.interfaceSignalProvider` is weak; the provider must outlive the test body.
     private var interfaceSignalProvider: FakeInterfaceSignalProvider?
 
     override func setUp() {
@@ -38,7 +36,6 @@ final class WebViewDeadClickTests: XCTestCase {
 
     override func tearDown() {
         UIKitElementInteractions.resetPhysicalTapDedupCandidates()
-        navigationDelegate = nil
         interfaceSignalProvider = nil
         window = nil
         super.tearDown()
@@ -72,8 +69,7 @@ final class WebViewDeadClickTests: XCTestCase {
     // MARK: - Dead click is suppressed inside web views
 
     func testDeadClickSuppressedInsideWebViewWhileRageClickStaysOn() throws {
-        let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
-        waitForTapRecognizers(in: webView)
+        let webView = try attachedWebView()
 
         XCTAssertTrue(webView.amp_isInsideWebView, "The web view itself counts as web content")
         XCTAssertFalse(UIKitElementInteractions.shouldProcessDeadClick(for: webView))
@@ -282,8 +278,7 @@ final class WebViewDeadClickTests: XCTestCase {
     /// interactions to the private `WKContentView` two levels below it. Before the lookup walked
     /// ancestors, `webView.amp_ignoreInteractionEvent()` was a silent no-op.
     func testIgnoreHookOnWebViewReachesTheRecognizerView() throws {
-        let webView = try loadedWebView("<html><body style='font-size:64px'><p>tap here</p></body></html>")
-        waitForTapRecognizers(in: webView)
+        let webView = try attachedWebView()
 
         let qualifying = allRecognizers(in: webView).filter { qualifiesAsPhysicalTap($0.recognizer) }
         XCTAssertFalse(qualifying.isEmpty)
@@ -416,31 +411,31 @@ final class WebViewDeadClickTests: XCTestCase {
         return (amplitude, collector)
     }
 
-    /// How long a load may take before the test gives up. A warm load finishes in ~0.4 s and a
-    /// cold one (first WebContent process of the test run) in ~1.3 s, on CI and locally alike --
-    /// but on a starved 3-vCPU CI simulator the same load has been seen to exceed 10 s, both
-    /// cold and warm, and load speed is not something any test here asserts. Generous on
-    /// purpose: a green run never comes near it, a red one stops being red for the wrong reason.
-    private static let loadTimeout: TimeInterval = 60
-
-    private func loadedWebView(_ html: String) throws -> WKWebView {
+    /// A web view in the key window with WebKit's tap recognizers attached to its `WKContentView`.
+    ///
+    /// Nothing is loaded into it. The tests using this only inspect the view hierarchy WebKit
+    /// builds in this process, and `WKContentView` gets its recognizers in `didMoveToWindow`, so
+    /// they are present within milliseconds of `addSubview` (measured 0.1-6 ms on an iPhone 16 Pro
+    /// simulator). Earlier versions loaded an HTML string and waited for `didFinish`, which made
+    /// these tests depend on WebKit's WebContent and GPU processes launching. On a CI simulator
+    /// that has taken over six minutes (`GPU process took 366 seconds to launch`), so every load
+    /// timed out whatever the budget, while nothing here ever asserted on page content.
+    private func attachedWebView() throws -> WKWebView {
         let webView = WKWebView(frame: window.bounds)
         window.addSubview(webView)
         window.makeKeyAndVisible()
-
-        let loaded = expectation(description: "html loaded")
-        let delegate = NavigationDelegate { loaded.fulfill() }
-        navigationDelegate = delegate
-        webView.navigationDelegate = delegate
-        webView.loadHTMLString(html, baseURL: nil)
-        wait(for: [loaded], timeout: Self.loadTimeout)
+        try waitForTapRecognizers(in: webView)
         return webView
     }
 
-    /// WebKit attaches its tap recognizers to `WKContentView` asynchronously, some time after
-    /// `didFinish`. Poll for the first qualifying one instead of sleeping a fixed second; the
-    /// caller's `XCTAssertFalse(qualifying.isEmpty)` still reports clearly if they never appear.
-    private func waitForTapRecognizers(in webView: WKWebView, timeout: TimeInterval = 30) {
+    private struct TapRecognizersMissing: Error {}
+
+    /// Polls for the first recognizer that passes the SDK's physical-tap gate. Fails and throws if
+    /// none appears, so a caller never reaches its assertions with an empty hierarchy.
+    private func waitForTapRecognizers(in webView: WKWebView,
+                                       timeout: TimeInterval = 10,
+                                       file: StaticString = #filePath,
+                                       line: UInt = #line) throws {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if allRecognizers(in: webView).contains(where: { qualifiesAsPhysicalTap($0.recognizer) }) {
@@ -448,16 +443,10 @@ final class WebViewDeadClickTests: XCTestCase {
             }
             RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         }
-    }
-
-    private final class NavigationDelegate: NSObject, WKNavigationDelegate {
-        private let onFinish: () -> Void
-        init(onFinish: @escaping () -> Void) {
-            self.onFinish = onFinish
-        }
-        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            onFinish()
-        }
+        let present = allRecognizers(in: webView).map { "\($0.recognizer.descriptiveTypeName) on \($0.view.descriptiveTypeName)" }
+        XCTFail("No single-tap recognizer appeared on the web view within \(timeout)s; present: \(present)",
+                file: file, line: line)
+        throw TapRecognizersMissing()
     }
 }
 

--- a/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
+++ b/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
@@ -8,7 +8,49 @@
 import Foundation
 
 class FakeURLProtocol: URLProtocol {
-    static var mockResponses: [MockResponse] = []
+
+    /// Scripted responses for the requests a test issues itself, consumed in order.
+    static var mockResponses: [MockResponse] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _mockResponses
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _mockResponses = newValue
+        }
+    }
+
+    /// Scripted responses for the SDK's own uploads to api2 / api.eu.amplitude.com. Kept apart
+    /// from `mockResponses` because those uploads are not under the current test's control: an
+    /// Amplitude instance from an earlier test is still flushing while the next test runs, and
+    /// with one shared queue such a stray upload consumed a response the next test had queued
+    /// for its own request -- which then failed with "No mock responses available", carried
+    /// no status code, matched no capture rule, and left the test one event short. Uploads get
+    /// a plain 200 when nothing is queued here, and never touch `mockResponses`.
+    static var amplitudeResponses: [MockResponse] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _amplitudeResponses
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _amplitudeResponses = newValue
+        }
+    }
+
+    private static let amplitudeHosts: Set<String> = ["api2.amplitude.com", "api.eu.amplitude.com"]
+    private static let defaultAmplitudeResponse = MockResponse(statusCode: 200)
+
+    // startLoading runs on the URL loading system's threads, one per in-flight request, and a
+    // test with three parallel requests reaches the queue from three of them at once.
+    private static let lock = NSLock()
+    private static var _mockResponses: [MockResponse] = []
+    private static var _amplitudeResponses: [MockResponse] = []
 
     private static let responseQueue = DispatchQueue(label: "FakeURLProtocol.responseQueue")
 
@@ -43,6 +85,16 @@ class FakeURLProtocol: URLProtocol {
         return request
     }
 
+    /// Pops the next response for `url` under the lock; nil when a test request has nothing queued.
+    private static func dequeueResponse(for url: URL) -> MockResponse? {
+        lock.lock()
+        defer { lock.unlock() }
+        if amplitudeHosts.contains(url.host ?? "") {
+            return _amplitudeResponses.isEmpty ? defaultAmplitudeResponse : _amplitudeResponses.removeFirst()
+        }
+        return _mockResponses.isEmpty ? nil : _mockResponses.removeFirst()
+    }
+
     override func startLoading() {
         guard let url = request.url else {
             client?.urlProtocol(self, didFailWithError: NSError(domain: "FakeURLProtocol", code: -1, userInfo: nil))
@@ -51,12 +103,10 @@ class FakeURLProtocol: URLProtocol {
 
         print("FakeURLProtocol: Starting to load \(url)")
 
-        guard !Self.mockResponses.isEmpty else {
+        guard let mockResponse = Self.dequeueResponse(for: url) else {
             client?.urlProtocol(self, didFailWithError: NSError(domain: "FakeURLProtocol", code: -2, userInfo: [NSLocalizedDescriptionKey: "No mock responses available"]))
             return
         }
-
-        let mockResponse = Self.mockResponses.removeFirst()
 
         let response = HTTPURLResponse(
             url: url,
@@ -90,8 +140,13 @@ class FakeURLProtocol: URLProtocol {
         // Nothing to do here
     }
 
+    /// Call from tearDown: responses a test queued but never consumed would otherwise be served
+    /// to the next test's requests.
     static func clearMockResponses() {
-        mockResponses.removeAll()
+        lock.lock()
+        defer { lock.unlock() }
+        _mockResponses.removeAll()
+        _amplitudeResponses.removeAll()
     }
 }
 

--- a/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
+++ b/Tests/AmplitudeTests/Supports/FakeURLProtocol.swift
@@ -43,6 +43,22 @@ class FakeURLProtocol: URLProtocol {
         }
     }
 
+    /// Called, off the main thread, once a response to an SDK upload has been fully delivered.
+    /// A test that asserts its upload was *not* captured has to wait for this first: until the
+    /// request has completed, "no network event yet" proves nothing.
+    static var onAmplitudeRequestFinished: ((URL) -> Void)? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _onAmplitudeRequestFinished
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _onAmplitudeRequestFinished = newValue
+        }
+    }
+
     private static let amplitudeHosts: Set<String> = ["api2.amplitude.com", "api.eu.amplitude.com"]
     private static let defaultAmplitudeResponse = MockResponse(statusCode: 200)
 
@@ -51,6 +67,7 @@ class FakeURLProtocol: URLProtocol {
     private static let lock = NSLock()
     private static var _mockResponses: [MockResponse] = []
     private static var _amplitudeResponses: [MockResponse] = []
+    private static var _onAmplitudeRequestFinished: ((URL) -> Void)?
 
     private static let responseQueue = DispatchQueue(label: "FakeURLProtocol.responseQueue")
 
@@ -133,6 +150,10 @@ class FakeURLProtocol: URLProtocol {
             self.client?.urlProtocolDidFinishLoading(self)
 
             print("FakeURLProtocol: Finished loading \(url), response: \(mockResponse)")
+
+            if Self.amplitudeHosts.contains(url.host ?? "") {
+                Self.onAmplitudeRequestFinished?(url)
+            }
         }
     }
 
@@ -141,12 +162,13 @@ class FakeURLProtocol: URLProtocol {
     }
 
     /// Call from tearDown: responses a test queued but never consumed would otherwise be served
-    /// to the next test's requests.
+    /// to the next test's requests, and its upload hook would fire for the next test's uploads.
     static func clearMockResponses() {
         lock.lock()
         defer { lock.unlock() }
         _mockResponses.removeAll()
         _amplitudeResponses.removeAll()
+        _onAmplitudeRequestFinished = nil
     }
 }
 

--- a/Tests/AmplitudeTests/Supports/RemoteConfigMockServer.swift
+++ b/Tests/AmplitudeTests/Supports/RemoteConfigMockServer.swift
@@ -1,0 +1,263 @@
+//
+//  RemoteConfigMockServer.swift
+//  Amplitude-Swift
+//
+
+import AmplitudeCore
+@testable import AmplitudeSwift
+import Foundation
+import ObjectiveC
+import XCTest
+
+/// Process-wide, in-memory stand-in for the remote-config and diagnostics endpoints.
+///
+/// Installed once per test process by `TestBundlePrincipal`, it answers every
+/// `https://sr-client-cfg.*` and `https://diagnostics.prod.*` request made from a
+/// `URLSession` built on `URLSessionConfiguration.ephemeral` -- which is what
+/// `RemoteConfigClient` and `DiagnosticsClient` use -- so no test reaches the real
+/// services. `Configuration.init` constructs both clients unconditionally, so without
+/// this every `Configuration(...)` in the bundle (about a hundred) started a real
+/// HTTPS fetch with a made-up API key, got a 4xx, and retried with backoff in the
+/// background while later tests ran.
+///
+/// Two behaviours, keyed on the API key in the request path:
+///
+/// - Keys with `testApiKeyPrefix` (see `RemoteConfigClient.setNextFetchedRemoteConfig`):
+///   serve the config the test queued, but **hold the response until the test calls
+///   `release(apiKey:)`**. That gives a test a point at which the remote config
+///   provably has not arrived (assert defaults there) and a point after which it is on
+///   its way -- with no wall-clock delay to lose a race against. The previous mock
+///   answered after a fixed 500 ms, which the CI runners regularly beat.
+/// - Any other key: `200 {"configs":{}}` immediately. Subscribers see the same `nil`
+///   they saw when the real fetch failed; nothing else in the bundle observes remote
+///   config.
+enum RemoteConfigMockServer {
+
+    static let testApiKeyPrefix = "remote-config-test-"
+
+    private struct Entry {
+        var queued: [RemoteConfigClient.RemoteConfig] = []
+        var released = false
+        var waiting: [RemoteConfigUrlProtocol] = []
+    }
+
+    private static let lock = NSLock()
+    private static var entries: [String: Entry] = [:]
+    private static var installed = false
+
+    /// Puts `RemoteConfigUrlProtocol` in front of every `URLSession` created from
+    /// `URLSessionConfiguration.ephemeral` from now on. Idempotent: swizzling with
+    /// `method_exchangeImplementations` toggles, so a second call must be a no-op.
+    static func install() {
+        lock.withLock {
+            guard !installed else { return }
+            installed = true
+
+            let metaClass: AnyClass = object_getClass(URLSessionConfiguration.self)!
+            guard let original = class_getClassMethod(metaClass, #selector(getter: URLSessionConfiguration.ephemeral)),
+                  let swizzled = class_getClassMethod(metaClass, #selector(URLSessionConfiguration.amp_ephemeral)) else {
+                preconditionFailure("RemoteConfigMockServer: could not swizzle URLSessionConfiguration.ephemeral")
+            }
+            method_exchangeImplementations(original, swizzled)
+        }
+    }
+
+    /// Queue `config` as the next response for `apiKey`, held until `release(apiKey:)`.
+    static func enqueue(_ config: RemoteConfigClient.RemoteConfig, apiKey: String) {
+        lock.withLock {
+            var entry = entries[apiKey] ?? Entry()
+            entry.queued.append(config)
+            entry.released = false
+            entries[apiKey] = entry
+        }
+    }
+
+    /// Let the queued response for `apiKey` go out. Safe to call before the SDK has
+    /// started the request: the response is delivered as soon as it does.
+    static func release(apiKey: String) {
+        let toDeliver: [RemoteConfigUrlProtocol] = lock.withLock {
+            var entry = entries[apiKey] ?? Entry()
+            entry.released = true
+            let waiting = entry.waiting
+            entry.waiting = []
+            entries[apiKey] = entry
+            return waiting
+        }
+        toDeliver.forEach { $0.deliver() }
+    }
+
+    /// Called from `startLoading`. Non-test keys and released test keys deliver at
+    /// once; unreleased test keys park the protocol until `release(apiKey:)`.
+    fileprivate static func handle(_ urlProtocol: RemoteConfigUrlProtocol, apiKey: String) {
+        let deliverNow: Bool = lock.withLock {
+            guard apiKey.hasPrefix(testApiKeyPrefix) else {
+                return true
+            }
+            var entry = entries[apiKey] ?? Entry()
+            if entry.released {
+                return true
+            }
+            entry.waiting.append(urlProtocol)
+            entries[apiKey] = entry
+            return false
+        }
+        if deliverNow {
+            urlProtocol.deliver()
+        }
+    }
+
+    /// The config to serve, consumed at delivery time rather than at `startLoading`
+    /// so that a request retried before delivery still finds it. Non-test keys get an
+    /// empty config; a test key with nothing queued gets nil (a test-setup error).
+    fileprivate static func dequeue(apiKey: String) -> RemoteConfigClient.RemoteConfig? {
+        lock.withLock {
+            guard apiKey.hasPrefix(testApiKeyPrefix) else {
+                return [:]
+            }
+            guard var entry = entries[apiKey], !entry.queued.isEmpty else {
+                return nil
+            }
+            let config = entry.queued.removeFirst()
+            entries[apiKey] = entry
+            return config
+        }
+    }
+}
+
+/// Serves `RemoteConfigMockServer`'s responses. Consulted first by every ephemeral
+/// session once `RemoteConfigMockServer.install()` has run; declines everything that
+/// is not a remote-config or diagnostics request, so other protocols (`FakeURLProtocol`)
+/// and the network are unaffected.
+final class RemoteConfigUrlProtocol: URLProtocol {
+
+    private static let remoteConfigPrefix = "https://sr-client-cfg."
+    private static let diagnosticsPrefix = "https://diagnostics.prod."
+
+    // Deliveries hop through a queue so the URL loading system is never re-entered
+    // from inside startLoading, and so a delivery from the test thread (release) and
+    // one from the loading thread (immediate) never interleave.
+    private static let deliveryQueue = DispatchQueue(label: "com.amplitude.tests.RemoteConfigUrlProtocol")
+
+    private var stopped = false
+
+    override static func canInit(with request: URLRequest) -> Bool {
+        guard let url = request.url?.absoluteString else {
+            return false
+        }
+        return url.hasPrefix(remoteConfigPrefix) || url.hasPrefix(diagnosticsPrefix)
+    }
+
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    private var isRemoteConfig: Bool {
+        request.url?.absoluteString.hasPrefix(Self.remoteConfigPrefix) ?? false
+    }
+
+    // https://sr-client-cfg.amplitude.com/config/{apiKey}?config_keys=...
+    // pathComponents already excludes the query.
+    private var apiKey: String? {
+        request.url?.pathComponents.last
+    }
+
+    override func startLoading() {
+        guard isRemoteConfig, let apiKey else {
+            deliver()
+            return
+        }
+        RemoteConfigMockServer.handle(self, apiKey: apiKey)
+    }
+
+    override func stopLoading() {
+        Self.deliveryQueue.async { [self] in
+            stopped = true
+        }
+    }
+
+    fileprivate func deliver() {
+        Self.deliveryQueue.async { [self] in
+            guard !stopped, let url = request.url else {
+                return
+            }
+
+            let body: [String: Any]
+            if isRemoteConfig {
+                guard let config = RemoteConfigMockServer.dequeue(apiKey: apiKey ?? "") else {
+                    client?.urlProtocol(self, didFailWithError: NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown))
+                    return
+                }
+                body = ["configs": config]
+            } else {
+                body = [:]
+            }
+
+            let response = HTTPURLResponse(url: url,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: ["Content-Type": "application/json"])!
+            let data = (try? JSONSerialization.data(withJSONObject: body)) ?? Data()
+
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+    }
+}
+
+extension URLSessionConfiguration {
+
+    // Swizzled with `ephemeral`, so calling amp_ephemeral here runs the original.
+    @objc class func amp_ephemeral() -> URLSessionConfiguration {
+        let config = amp_ephemeral()
+        config.protocolClasses = [RemoteConfigUrlProtocol.self] + (config.protocolClasses ?? [])
+        return config
+    }
+}
+
+extension RemoteConfigClient {
+
+    static func setNextFetchedRemoteConfig(_ remoteConfig: RemoteConfig, forApiKey apiKey: String) {
+        RemoteConfigMockServer.enqueue(remoteConfig, apiKey: apiKey)
+    }
+
+    static func resetStorage(instanceName: String) {
+        let suiteName = "com.amplitude.remoteconfig.cache.\(instanceName)"
+        UserDefaults.standard.removePersistentDomain(forName: suiteName)
+    }
+}
+
+extension Amplitude {
+
+    /// Fulfilled once a non-nil autocapture remote config has been applied to this
+    /// instance's `AutocaptureManager` *and* handed to every plugin that registered an
+    /// `onChange` callback before this call. `AutocaptureManager.handleRemoteConfig`
+    /// updates its state, then runs the callbacks synchronously in registration order,
+    /// so by the time this fires `NetworkTrackingPlugin` and the lifecycle monitor have
+    /// consumed the config -- no sleep needed to "let other callbacks finish".
+    ///
+    /// Register after `init` (so the plugins are ahead of it) and before releasing the
+    /// mock response.
+    func remoteConfigAppliedExpectation() -> XCTestExpectation {
+        let expectation = XCTestExpectation(description: "autocapture remote config applied")
+        expectation.assertForOverFulfill = false
+        autocaptureManager.onChange { config in
+            if config != nil {
+                expectation.fulfill()
+            }
+        }
+        return expectation
+    }
+}
+
+/// Named as `NSPrincipalClass` in `Amplitude_SwiftTests_Info.plist`. XCTest instantiates
+/// it once, before any test class is loaded -- the only point early enough to put a
+/// URLProtocol in front of the sessions that `Configuration.init` creates.
+@objc(AMPTestBundlePrincipal)
+final class TestBundlePrincipal: NSObject {
+
+    override init() {
+        super.init()
+        RemoteConfigMockServer.install()
+    }
+}

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -34,15 +34,68 @@ class OutputReaderPlugin: DestinationPlugin {
 }
 
 class EventCollectorPlugin: DestinationPlugin {
-    var events: [BaseEvent] = Array()
-    /// Called on the tracking queue after each event is appended, so a test can wait
-    /// on a signal for "N events arrived" instead of sleeping and hoping.
-    var onEvent: ((BaseEvent) -> Void)?
+    private let lock = NSLock()
+    private var _events: [BaseEvent] = []
+    /// Returns true once it has fulfilled its expectation, so `execute` can drop it.
+    private var onCollected: ((Int) -> Bool)?
+
+    /// Appended on the tracking queue, read from wherever the test is -- so both go through
+    /// the lock.
+    var events: [BaseEvent] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _events
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            _events = newValue
+        }
+    }
 
     override func execute(event: BaseEvent) -> BaseEvent? {
-        events.append(event)
-        onEvent?(event)
+        lock.lock()
+        _events.append(event)
+        let count = _events.count
+        let callback = onCollected
+        lock.unlock()
+
+        if let callback, callback(count) {
+            lock.lock()
+            onCollected = nil
+            lock.unlock()
+        }
         return event
+    }
+
+    /// Fulfils `expectation` once at least `count` events have been collected: immediately if
+    /// they already have, otherwise from the tracking queue as they arrive. The check and the
+    /// registration happen under one lock, so an event landing in between cannot be missed.
+    /// Lets a test wait on "N events arrived" instead of sleeping and hoping.
+    func fulfill(_ expectation: XCTestExpectation, whenCollected count: Int) {
+        lock.lock()
+        if _events.count >= count {
+            lock.unlock()
+            expectation.fulfill()
+            return
+        }
+        onCollected = { collected in
+            guard collected >= count else {
+                return false
+            }
+            expectation.fulfill()
+            return true
+        }
+        lock.unlock()
+    }
+}
+
+extension Array {
+    /// nil instead of a trap when `index` is out of range -- for assertions on arrays whose
+    /// length is itself under test, so a wrong length fails the test rather than the bundle.
+    subscript(safe index: Int) -> Element? {
+        indices.contains(index) ? self[index] : nil
     }
 }
 

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -35,9 +35,13 @@ class OutputReaderPlugin: DestinationPlugin {
 
 class EventCollectorPlugin: DestinationPlugin {
     var events: [BaseEvent] = Array()
+    /// Called on the tracking queue after each event is appended, so a test can wait
+    /// on a signal for "N events arrived" instead of sleeping and hoping.
+    var onEvent: ((BaseEvent) -> Void)?
 
     override func execute(event: BaseEvent) -> BaseEvent? {
         events.append(event)
+        onEvent?(event)
         return event
     }
 }

--- a/Tests/AmplitudeTests/Supports/TestUtilities.swift
+++ b/Tests/AmplitudeTests/Supports/TestUtilities.swift
@@ -57,15 +57,13 @@ class EventCollectorPlugin: DestinationPlugin {
     override func execute(event: BaseEvent) -> BaseEvent? {
         lock.lock()
         _events.append(event)
-        let count = _events.count
-        let callback = onCollected
-        lock.unlock()
-
-        if let callback, callback(count) {
-            lock.lock()
+        // The callback only fulfils an expectation, so it can run under the lock. Clearing it in
+        // the same critical section means a callback the test registers in the meantime can
+        // never be wiped by this one's clean-up.
+        if let callback = onCollected, callback(_events.count) {
             onCollected = nil
-            lock.unlock()
         }
+        lock.unlock()
         return event
     }
 

--- a/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
+++ b/Tests/AmplitudeTests/Utilities/EventPipelineTests.swift
@@ -12,6 +12,12 @@ import XCTest
 final class EventPipelineTests: XCTestCase {
     private static let FLUSH_INTERVAL_SECONDS = 10.0
 
+    // Wait budgets here are deliberately loose (10 s; 15 s where the SDK's own 1 s + 2 s retry
+    // backoff is being waited out). Everything goes through FakeHttpClient in-process, so a
+    // green run returns as soon as the expectation fires; the budget only decides how long a
+    // genuinely broken run takes to report. The original 1-2 s budgets were exceeded on a
+    // 3-vCPU CI simulator, and the indexing that followed turned that into a bundle crash.
+
     private var configuration: Configuration!
     private var pipeline: EventPipeline!
     private var httpClient: FakeHttpClient!
@@ -56,12 +62,12 @@ final class EventPipelineTests: XCTestCase {
         }
         XCTAssertEqual(testEvent.attempts, 1)
 
-        let waitResult = XCTWaiter.wait(for: [eventExpectation], timeout: 1)
+        let waitResult = XCTWaiter.wait(for: [eventExpectation], timeout: 10)
         XCTAssertNotEqual(waitResult, .timedOut)
         XCTAssertEqual(pipeline.eventCount, 1)
     }
 
-    func testFlush() {
+    func testFlush() throws {
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
 
@@ -69,12 +75,12 @@ final class EventPipelineTests: XCTestCase {
         pipeline.flush {
             flushExpectation.fulfill()
         }
-        let waitResult = XCTWaiter.wait(for: [flushExpectation], timeout: 1)
+        let waitResult = XCTWaiter.wait(for: [flushExpectation], timeout: 10)
         XCTAssertNotEqual(waitResult, .timedOut)
         XCTAssertEqual(httpClient.uploadCount, 1)
-        let uploadedEvents = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
+        let uploadedEvents = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents.first))
         XCTAssertEqual(uploadedEvents?.count, 1)
-        XCTAssertEqual(uploadedEvents![0].eventType, "testEvent")
+        XCTAssertEqual(uploadedEvents?.first?.eventType, "testEvent")
     }
 
     func testFlushWhenOffline() {
@@ -93,7 +99,7 @@ final class EventPipelineTests: XCTestCase {
         XCTAssertEqual(httpClient.uploadCount, 0, "There should be no uploads when offline")
     }
 
-    func testSimultaneousFlush() {
+    func testSimultaneousFlush() throws {
         let testEvent = BaseEvent(userId: "unit-test", deviceId: "unit-test-machine", eventType: "testEvent")
         try? pipeline.storage?.write(key: StorageKey.EVENTS, value: testEvent)
 
@@ -108,13 +114,13 @@ final class EventPipelineTests: XCTestCase {
             return expectation
         }
 
-        wait(for: flushExpectations, timeout: 1)
-        wait(for: [httpResponseExpectation], timeout: 1)
+        wait(for: flushExpectations, timeout: 10)
+        wait(for: [httpResponseExpectation], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 1)
-        let uploadedEvents = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
+        let uploadedEvents = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents.first))
         XCTAssertEqual(uploadedEvents?.count, 1)
-        XCTAssertEqual(uploadedEvents![0].eventType, "testEvent")
+        XCTAssertEqual(uploadedEvents?.first?.eventType, "testEvent")
     }
 
     func testOneUploadAtATime() {
@@ -137,16 +143,16 @@ final class EventPipelineTests: XCTestCase {
             flushExpectation.fulfill()
         }
 
-        wait(for: [httpResponseExpectation1], timeout: 1)
+        wait(for: [httpResponseExpectation1], timeout: 10)
 
         httpResponseExpectation2.isInverted = false
 
-        wait(for: [httpResponseExpectation2, flushExpectation], timeout: 1)
+        wait(for: [httpResponseExpectation2, flushExpectation], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 2)
     }
 
-    func testInvalidEventUpload() {
+    func testInvalidEventUpload() throws {
         let invalidResponseData = "{\"events_with_invalid_fields\": {\"user_id\": [0]}}".data(using: .utf8)!
 
         httpClient.uploadResults = [
@@ -165,24 +171,24 @@ final class EventPipelineTests: XCTestCase {
         pipeline.flush {
             flushExpectation1.fulfill()
         }
-        wait(for: [uploadExpectations[0], flushExpectation1], timeout: 1)
+        wait(for: [uploadExpectations[0], flushExpectation1], timeout: 10)
 
         let flushExpectation2 = expectation(description: "flush-2")
         pipeline.flush {
             flushExpectation2.fulfill()
         }
-        wait(for: [uploadExpectations[1], flushExpectation2], timeout: 1)
+        wait(for: [uploadExpectations[1], flushExpectation2], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 2)
 
-        let uploadedEvents0 = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
+        let uploadedEvents0 = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents[safe: 0]))
         XCTAssertEqual(uploadedEvents0?.count, 2)
-        XCTAssertEqual(uploadedEvents0?[0].eventType, "testEvent-0")
-        XCTAssertEqual(uploadedEvents0?[1].eventType, "testEvent-1")
+        XCTAssertEqual(uploadedEvents0?[safe: 0]?.eventType, "testEvent-0")
+        XCTAssertEqual(uploadedEvents0?[safe: 1]?.eventType, "testEvent-1")
 
-        let uploadedEvents1 = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[1])
+        let uploadedEvents1 = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents[safe: 1]))
         XCTAssertEqual(uploadedEvents1?.count, 1)
-        XCTAssertEqual(uploadedEvents1?[0].eventType, "testEvent-1")
+        XCTAssertEqual(uploadedEvents1?[safe: 0]?.eventType, "testEvent-1")
     }
 
     // test continues to fail until the event is uploaded
@@ -205,13 +211,13 @@ final class EventPipelineTests: XCTestCase {
 
         pipeline.flush()
         // Expected: upload 0 (instant) + upload 1 (1s retry delay)
-        wait(for: [uploadExpectations[0], uploadExpectations[1]], timeout: 5)
+        wait(for: [uploadExpectations[0], uploadExpectations[1]], timeout: 15)
 
         XCTAssertEqual(httpClient.uploadCount, 2)
         XCTAssertEqual(pipeline.configuration.offline, false)
 
         // Expected: upload 2 (2s retry delay)
-        wait(for: [uploadExpectations[2]], timeout: 5)
+        wait(for: [uploadExpectations[2]], timeout: 15)
 
         XCTAssertEqual(httpClient.uploadCount, 3)
         XCTAssertEqual(pipeline.configuration.offline, true)
@@ -221,7 +227,7 @@ final class EventPipelineTests: XCTestCase {
         pipeline.flush {
             flushExpectation.fulfill()
         }
-        wait(for: [uploadExpectations[3], flushExpectation], timeout: 2)
+        wait(for: [uploadExpectations[3], flushExpectation], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 4)
     }
@@ -256,13 +262,13 @@ final class EventPipelineTests: XCTestCase {
         pipeline.flush {
             flushExpectation.fulfill()
         }
-        wait(for: [flushExpectation], timeout: 2)
+        wait(for: [flushExpectation], timeout: 10)
 
         // Pipeline must have walked past the two corrupt files and uploaded the third.
         XCTAssertEqual(httpClient.uploadCount, 1, "Pipeline should not stall on corrupt files")
-        let uploaded = BaseEvent.fromArrayString(jsonString: httpClient.uploadedEvents[0])
+        let uploaded = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(httpClient.uploadedEvents.first))
         XCTAssertEqual(uploaded?.count, 1)
-        XCTAssertEqual(uploaded?[0].eventType, "marker-2")
+        XCTAssertEqual(uploaded?.first?.eventType, "marker-2")
     }
 
     func testFlushKeepsSkippingUnreadableFilesAfterUpload() throws {
@@ -342,11 +348,11 @@ final class EventPipelineTests: XCTestCase {
         spyPipeline.flush {
             flushExpectation.fulfill()
         }
-        wait(for: [flushExpectation], timeout: 2)
+        wait(for: [flushExpectation], timeout: 10)
 
         XCTAssertEqual(spyHttp.uploadCount, 2, "Both good files should upload exactly once")
-        let uploaded0 = BaseEvent.fromArrayString(jsonString: spyHttp.uploadedEvents[0])
-        let uploaded1 = BaseEvent.fromArrayString(jsonString: spyHttp.uploadedEvents[1])
+        let uploaded0 = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(spyHttp.uploadedEvents[safe: 0]))
+        let uploaded1 = BaseEvent.fromArrayString(jsonString: try XCTUnwrap(spyHttp.uploadedEvents[safe: 1]))
         XCTAssertEqual(uploaded0?.first?.eventType, "marker-1")
         XCTAssertEqual(uploaded1?.first?.eventType, "marker-3")
 
@@ -398,7 +404,7 @@ final class EventPipelineTests: XCTestCase {
             flushExpectation.fulfill()
         }
 
-        wait(for: uploadExpectations + [flushExpectation], timeout: 1)
+        wait(for: uploadExpectations + [flushExpectation], timeout: 10)
 
         XCTAssertEqual(httpClient.uploadCount, 3)
         XCTAssertEqual(pipeline.configuration.offline, false)


### PR DESCRIPTION
## Summary

Test-only change; nothing under `Sources/` is modified.

With `-retry-tests-on-failure` removed, about 36% of full `Unit Test` runs had at
least one red leg (299 iterations on the repro branch, #434: 25 failing test cases
and 1 bundle crash, 18 of them one test). The causes were in
the tests: fixed 100 ms sleeps, a remote-config mock built on wall-clock delays,
one shared `URLProtocol` response queue, 2 s request budgets, and `events[i]`
after a failed count assertion, which crashed the bundle and restarted the run.

After the fixes: 0 red iterations in 150 (6 legs × 25, retries off), 0 crashes in
the 850 iterations since the crash fix, iOS suite 56 s → 43 s. Run 33794191994. Later measurement runs: 33817758147 (7 commits: 100 iterations on 4 legs, 0 failures; tvOS and
visionOS failed package resolution before any test ran), 33819412376 (8 commits: 150 iterations,
0 crashes, 1 failure, fixed by the last commit below) and 33821830485 (all 9 commits: all 7 jobs
green, 150 iterations, 0 failures, 0 crashes).

## Commits

| commit | change | cause removed |
|---|---|---|
| 7f6739c | `RemoteConfigMockServer` holds each response until the test releases it; tests wait on `AutocaptureManager.onChange` | 500 ms mock delay shorter than a slow `Amplitude.init`; `waitForRemote` fulfilling on its timeout fallback; 100 ms ordering sleep |
| 827cc96 | sleeps → `waitForCollectedEvents(N)`; WebView load 10 s → 60 s, poll for tap recognizers | 100 ms sleeps too short on a 3-vCPU runner |
| cd39c6a | throwing wait helper, `XCTUnwrap`, `[safe:]`; connectivity test disables the SDK's own connectivity plugin | index trap after a count assertion failed; two writers to `offline` |
| 39766fa | `FakeURLProtocol`: separate queue for api2 uploads, lock, cleared in tearDown | an earlier test's flush consumed the next test's queued response |
| 62a9dfd | request budget 2 s → 30 s | URL loading stalled over 2 s under load; the error events matched no capture rule |
| 3db054e | wait for the api2 upload before asserting it was not captured; settle after the positive wait in mixed tests | the signal rewrite had made one absence test vacuous (see below) |
| 7d9f1a2 | settle in the four remaining mixed tests (`testURLExactMatching`, `testURLRegexAnchors`, `testURLPatternPriority`, `testRuleForHost`) | same gap as above; three flagged by Cursor Bugbot, the fourth by scanning every test whose request count exceeds its wait N |
| defaa18 | web-view tests no longer load a page; they wait for `WKContentView`'s tap recognizers, which appear in `didMoveToWindow` | on the iOS leg of run 33816818185 WebKit's GPU process took 366 s to launch, so every page load timed out at 60 s across all retries; the tests never asserted on page content |
| 98dcb8d | rage-click tap bursts spaced by `Thread.sleep(10 ms)` instead of run-loop turns; positive assertions poll for the event | the detector needs four taps within 1 s; on a loaded runner the run-loop turns between taps stretched a burst past 1 s (1 of 150 iterations) |

## Notes for review

- `Amplitude_SwiftTests_Info.plist` sets `NSPrincipalClass` to `AMPTestBundlePrincipal`, which installs the remote-config mock for the whole bundle. Every `Configuration()` constructs a `RemoteConfigClient`; before this, about 100 of them fetched from `sr-client-cfg.amplitude.com` during a test run. Non-test API keys now get an empty config.
- `settleUncapturedRequests()` keeps a 100 ms sleep on purpose. `waitForCollectedEvents(N)` proves N events arrived; it cannot prove an (N+1)th is not in flight. The plugin records a request from its `setState(.completed)` hook, which URLSession runs after the completion handler the test waited on, so queue drains alone miss it. Two `wait()` calls remain in pure absence tests for the same reason.
- Commit 3db054e came from reviewing the first five for semantic equivalence. `testDefaultNetworkTrackingOptionsShouldNotCaptureAmplitude` had been rewritten to wait for the tracked event, which arrives before the upload starts. Checked with a mutation (`ignoreAmplitudeRequests` no longer appends `*.amplitude.com`): the original test failed 3/3, the first rewrite passed 3/3, the final version fails 3/3.

## Not in this PR

`objc-example-test` failed twice on runner infrastructure (test host launch `ESRCH`; xcodebuild exit 134). Test code cannot fix that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the test target and test support code; production SDK behavior is unchanged.
> 
> **Overview**
> **Test-only** hardening so the unit suite stops flaking and crashing on slow CI simulators. No production code under `Sources/` changes.
> 
> **Remote config mocking** moves out of `AutocaptureRemoteConfigTests` into shared `RemoteConfigMockServer` + `RemoteConfigUrlProtocol`, installed process-wide via `NSPrincipalClass` `AMPTestBundlePrincipal`. Test API keys get configs **held until** `release(apiKey:)`; other keys get an immediate empty `200`, avoiding real `sr-client-cfg` traffic from every `Configuration()` init. Autocapture tests assert local defaults before release, then wait on `remoteConfigAppliedExpectation()` instead of fixed delays or `didFetchRemote` timeouts.
> 
> **Network tracking tests** get a thread-safe `FakeURLProtocol` with separate queues for test traffic vs Amplitude `api2` uploads, tearDown cleanup, 30s request budgets, `waitForCollectedEvents(N)` on a lock-protected `EventCollectorPlugin`, and `settleUncapturedRequests()` / `expectAmplitudeUpload()` where absence assertions need the upload to finish first.
> 
> **WebView frustration tests** attach an empty `WKWebView` and poll for tap recognizers instead of loading HTML (avoiding WebKit GPU launch timeouts); rage bursts use `Thread.sleep(10ms)` between taps and poll the collector for rage/dead events.
> 
> **Other fixes:** disable the SDK’s built-in connectivity plugin in `NetworkConnectivityCheckerPluginTests` to remove a race on `offline`; loosen `EventPipelineTests` wait budgets and use `XCTUnwrap` / `[safe:]` to avoid bundle crashes after failed assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98dcb8d3c68143a9c21bf0947c2cae8e1ef84d54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
