### PR TITLE
ci: remove test retries and retry only runner failures

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -79,50 +79,57 @@ jobs:
         run: |
           xcrun simctl list
       - name: List Project Configuration
+        # Informational only. Package resolution runs here too and has failed on a bad release
+        # download; the test step retries that case, this step must not fail the job by itself.
+        continue-on-error: true
         run: |
           xcodebuild -list
       - name: ${{ matrix.platform }} Tests
+        env:
+          XCODEBUILD_LOG_DIR: ${{ runner.temp }}/xcodebuild-logs
         run: |
+          # No -retry-tests-on-failure: a failing test fails the leg. The script retries only
+          # runner failures (package download, test host launch, xcodebuild aborting) -- see its
+          # header for the exact signatures.
           case "${{ matrix.platform }}" in
             iOS)
-              xcodebuild test \
+              scripts/ci_xcodebuild_test.sh test \
                 -scheme Amplitude-Swift-Package \
                 -sdk iphonesimulator \
-                -retry-tests-on-failure \
                 -destination 'platform=iOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}'
               ;;
             macOS)
-              xcodebuild test \
+              scripts/ci_xcodebuild_test.sh test \
                 -scheme Amplitude-Swift-Package \
                 -sdk macosx \
-                -retry-tests-on-failure \
                 -destination 'platform=macOS'
               ;;
             tvOS)
-              xcodebuild \
+              scripts/ci_xcodebuild_test.sh test \
                 -scheme Amplitude-Swift-Package \
                 -sdk appletvsimulator \
-                -retry-tests-on-failure \
-                -destination 'platform=tvOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
-                test
+                -destination 'platform=tvOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}'
               ;;
             watchOS)
-              xcodebuild \
+              scripts/ci_xcodebuild_test.sh test \
                 -scheme Amplitude-Swift-Package \
                 -sdk watchsimulator \
-                -retry-tests-on-failure \
-                -destination 'platform=watchOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
-                test
+                -destination 'platform=watchOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}'
               ;;
             visionOS)
-              xcodebuild \
+              scripts/ci_xcodebuild_test.sh test \
                 -scheme Amplitude-Swift-Package \
                 -sdk xrsimulator \
-                -retry-tests-on-failure \
-                -destination 'platform=visionOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
-                test
+                -destination 'platform=visionOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}'
               ;;
           esac
+      - name: Upload xcodebuild logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: xcodebuild-logs-${{ matrix.platform }}-${{ matrix.test-destination-os }}
+          path: ${{ runner.temp }}/xcodebuild-logs
+          if-no-files-found: ignore
   objc-example-test:
     runs-on: macos-15
     steps:
@@ -139,9 +146,17 @@ jobs:
           sudo xcodebuild -downloadPlatform iOS
       - name: Objective-C Example Tests (iOS)
         working-directory: Examples/AmplitudeObjCExample
+        env:
+          XCODEBUILD_LOG_DIR: ${{ runner.temp }}/xcodebuild-logs
         run: |
-          xcodebuild test \
+          "$GITHUB_WORKSPACE/scripts/ci_xcodebuild_test.sh" test \
             -scheme AmplitudeObjCExample \
             -sdk iphonesimulator \
-            -retry-tests-on-failure \
             -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16'
+      - name: Upload xcodebuild logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: xcodebuild-logs-objc-example
+          path: ${{ runner.temp }}/xcodebuild-logs
+          if-no-files-found: ignore

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -11,6 +11,8 @@ jobs:
   unit-test:
     name: Unit ${{ matrix.platform }} - Xcode ${{ matrix.xcode }} - OS ${{ matrix.test-destination-os }}
     runs-on: ${{ matrix.runs-on }}
+    # A leg takes 10-15 minutes; three attempts of the test step fit comfortably, a hung test does not.
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false
@@ -132,6 +134,7 @@ jobs:
           if-no-files-found: ignore
   objc-example-test:
     runs-on: macos-15
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/scripts/ci_xcodebuild_test.sh
+++ b/scripts/ci_xcodebuild_test.sh
@@ -8,17 +8,26 @@
 # leg has to mean something again.)
 #
 # A runner failure is one where the tests were never reached, or all passed and xcodebuild died
-# afterwards. Seen on GitHub-hosted macOS runners, once each per few hundred jobs:
-#   - package resolution: "Could not resolve package dependencies: failed downloading
-#     https://github.com/.../releases/download/.../AmplitudeCore.zip" (binary target), exit 74
-#   - test host launch: "Failed to send signal 19 ... ESRCH", the test runner never started
-#   - xcodebuild aborting with SIGABRT (exit 134) after every test case had passed
-# These are retried, up to MAX_ATTEMPTS in total, with the reason printed as a workflow warning.
+# afterwards. Only failures observed on GitHub-hosted macOS runners are retried, each listed with
+# the run it was seen in. Add a signature only with the same evidence, and keep it specific: a
+# string that a broken test bundle or example app could also produce must not be retried.
+#   - package resolution: "failed downloading 'https://github.com/.../releases/download/.../
+#     AmplitudeCore.zip' ... already exists in file system" (binary target, stale SwiftPM
+#     artifact cache), exit 74 -- run 33817758147, tvOS and visionOS legs. The cache is
+#     cleared before the retry.
+#   - test host launch: DTServiceHub "Failed to send signal 19 to process N: 3" (errno 3 is
+#     ESRCH), after which xcodebuild itself dies with SIGSEGV, exit 139 -- run 33712638521, objc.
+#   - xcodebuild aborting with SIGABRT, exit 134, after every test case had passed
+#     (DVTAssertions failure inside DVTiPhoneSimulator) -- run 33819412376, objc, and once before.
 # Anything else non-zero is reported and not retried, so a new failure mode is seen, not hidden.
 #
 # Usage:  scripts/ci_xcodebuild_test.sh test -scheme <scheme> -destination <dest> [...]
-# Env:    MAX_ATTEMPTS        total attempts, default 3
-#         XCODEBUILD_LOG_DIR  where attempt logs go, default a temp dir; upload it on failure
+#         Do not pass -resultBundlePath; the script sets one per attempt under the log dir.
+# Env:    MAX_ATTEMPTS            total attempts, default 3
+#         XCODEBUILD_LOG_DIR      where attempt logs and result bundles go, default a temp dir;
+#                                 upload it when the step fails
+#         SWIFTPM_ARTIFACT_CACHE  SwiftPM binary-artifact cache cleared before retrying a
+#                                 download failure; default ~/Library/Caches/org.swift.swiftpm/artifacts
 #
 # The runner's /bin/bash is 3.2: no associative arrays, no ${var,,}, no mapfile.
 
@@ -26,20 +35,42 @@ set -u
 set -o pipefail
 
 MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+case "$MAX_ATTEMPTS" in
+  ''|*[!0-9]*|0)
+    echo "::error::MAX_ATTEMPTS must be a positive integer, got '$MAX_ATTEMPTS'"
+    exit 2
+    ;;
+esac
+
 LOG_DIR="${XCODEBUILD_LOG_DIR:-$(mktemp -d)}"
 mkdir -p "$LOG_DIR"
 
-# A test-side result. Any match makes the outcome final, whatever the exit code.
-TEST_FAILURE_PATTERN="Test Case '-\[.*\]' failed|\.swift:[0-9]+(:[0-9]+)?: error:|Restarting after unexpected exit|\*\* BUILD FAILED \*\*"
+if [ -z "${SWIFTPM_ARTIFACT_CACHE:-}" ]; then
+  if [ -n "${HOME:-}" ]; then
+    SWIFTPM_ARTIFACT_CACHE="$HOME/Library/Caches/org.swift.swiftpm/artifacts"
+  else
+    SWIFTPM_ARTIFACT_CACHE=""
+  fi
+fi
 
-# A runner failure. Kept narrow on purpose: a failure that matches nothing here is not retried.
-RUNNER_FAILURE_PATTERN='Could not resolve package dependencies|failed downloading .*/releases/download/|Failed to send signal .*ESRCH|Test runner never began executing tests|Unable to boot the Simulator|Failed to launch the test host|Simulator device failed to launch|Lost connection to the test manager|Timed out waiting for .*(test runner|test host|Simulator)'
+# A test-side result. Any match makes the outcome final, whatever the exit code. Covers XCTest's
+# serial format ("Test Case '-[...]' failed") and the parallel one the ObjC example scheme uses
+# ("Test case '-[...]' failed on 'Clone 1 of iPhone 16 ...'"), a compiler error in any source
+# file, a linker error, a test bundle that fails to load, a crashed or timed-out test, and both
+# build-failure banners (`xcodebuild test` prints "** TEST BUILD FAILED **").
+TEST_FAILURE_PATTERN="Test [Cc]ase '.*' failed|\.(swift|m|mm|h|c|cc|cpp)(:[0-9]+){1,2}: error:|Restarting after unexpected exit|\*\* (TEST )?BUILD FAILED \*\*|error: linker command failed|Undefined symbols for architecture|Failed to load the test bundle"
 
-# Exit codes that are a runner failure on their own: 134 is SIGABRT from xcodebuild itself,
-# 74 (EX_IOERR) is what package resolution returns when a download fails.
+# The observed runner failures and nothing generic. "Could not resolve package dependencies" is
+# also what a wrong version requirement prints, and "Failed to launch the test host" is also what
+# a crashing example app prints, so neither is here.
+RUNNER_FAILURE_PATTERN="failed downloading .*/releases/download/|Failed to send signal [0-9]+ to process [0-9]+"
+
+# xcodebuild itself dying is a runner failure when the log carries no test-side result: 134 is
+# SIGABRT, 139 is SIGSEGV. Exit 74 (package resolution) is deliberately not here: a wrong version
+# requirement exits 74 too, and only the download failure above is worth a retry.
 is_runner_exit_code() {
   case "$1" in
-    134|74) return 0 ;;
+    134|139) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -47,8 +78,9 @@ is_runner_exit_code() {
 attempt=1
 while :; do
   log="$LOG_DIR/xcodebuild-attempt-$attempt.log"
+  result_bundle="$LOG_DIR/xcodebuild-attempt-$attempt.xcresult"
   echo "::group::xcodebuild attempt $attempt of $MAX_ATTEMPTS"
-  xcodebuild "$@" 2>&1 | tee "$log"
+  xcodebuild "$@" -resultBundlePath "$result_bundle" 2>&1 | tee "$log"
   status="${PIPESTATUS[0]}"
   echo "::endgroup::"
 
@@ -79,5 +111,15 @@ while :; do
   fi
 
   echo "::warning::runner failure on attempt $attempt (exit $status): $reason. Retrying."
+  case "$reason" in
+    "failed downloading"*)
+      # The observed failure left a half-written artifact behind ("already exists in file
+      # system"); a plain rerun would trip over the same directory.
+      if [ -n "$SWIFTPM_ARTIFACT_CACHE" ] && [ -d "$SWIFTPM_ARTIFACT_CACHE" ]; then
+        echo "Clearing the SwiftPM artifact cache at $SWIFTPM_ARTIFACT_CACHE before retrying"
+        rm -rf "$SWIFTPM_ARTIFACT_CACHE"
+      fi
+      ;;
+  esac
   attempt=$((attempt + 1))
 done

--- a/scripts/ci_xcodebuild_test.sh
+++ b/scripts/ci_xcodebuild_test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#
+# Runs `xcodebuild test` on CI, retrying only when the runner failed, never when a test did.
+#
+# A failing test case, a crashed test bundle or a build error is final: the job goes red on the
+# first attempt, and no test-level retry is passed to xcodebuild. (-retry-tests-on-failure used
+# to hide a ~30% red rate behind a second run of the failed cases; with the tests fixed, a red
+# leg has to mean something again.)
+#
+# A runner failure is one where the tests were never reached, or all passed and xcodebuild died
+# afterwards. Seen on GitHub-hosted macOS runners, once each per few hundred jobs:
+#   - package resolution: "Could not resolve package dependencies: failed downloading
+#     https://github.com/.../releases/download/.../AmplitudeCore.zip" (binary target), exit 74
+#   - test host launch: "Failed to send signal 19 ... ESRCH", the test runner never started
+#   - xcodebuild aborting with SIGABRT (exit 134) after every test case had passed
+# These are retried, up to MAX_ATTEMPTS in total, with the reason printed as a workflow warning.
+# Anything else non-zero is reported and not retried, so a new failure mode is seen, not hidden.
+#
+# Usage:  scripts/ci_xcodebuild_test.sh test -scheme <scheme> -destination <dest> [...]
+# Env:    MAX_ATTEMPTS        total attempts, default 3
+#         XCODEBUILD_LOG_DIR  where attempt logs go, default a temp dir; upload it on failure
+#
+# The runner's /bin/bash is 3.2: no associative arrays, no ${var,,}, no mapfile.
+
+set -u
+set -o pipefail
+
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+LOG_DIR="${XCODEBUILD_LOG_DIR:-$(mktemp -d)}"
+mkdir -p "$LOG_DIR"
+
+# A test-side result. Any match makes the outcome final, whatever the exit code.
+TEST_FAILURE_PATTERN="Test Case '-\[.*\]' failed|\.swift:[0-9]+(:[0-9]+)?: error:|Restarting after unexpected exit|\*\* BUILD FAILED \*\*"
+
+# A runner failure. Kept narrow on purpose: a failure that matches nothing here is not retried.
+RUNNER_FAILURE_PATTERN='Could not resolve package dependencies|failed downloading .*/releases/download/|Failed to send signal .*ESRCH|Test runner never began executing tests|Unable to boot the Simulator|Failed to launch the test host|Simulator device failed to launch|Lost connection to the test manager|Timed out waiting for .*(test runner|test host|Simulator)'
+
+# Exit codes that are a runner failure on their own: 134 is SIGABRT from xcodebuild itself,
+# 74 (EX_IOERR) is what package resolution returns when a download fails.
+is_runner_exit_code() {
+  case "$1" in
+    134|74) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+attempt=1
+while :; do
+  log="$LOG_DIR/xcodebuild-attempt-$attempt.log"
+  echo "::group::xcodebuild attempt $attempt of $MAX_ATTEMPTS"
+  xcodebuild "$@" 2>&1 | tee "$log"
+  status="${PIPESTATUS[0]}"
+  echo "::endgroup::"
+
+  if [ "$status" -eq 0 ]; then
+    exit 0
+  fi
+
+  if grep -qaE "$TEST_FAILURE_PATTERN" "$log"; then
+    echo "::error::xcodebuild exited $status with a test or build failure (attempt $attempt); not retrying"
+    grep -aE "$TEST_FAILURE_PATTERN" "$log" | head -20
+    exit "$status"
+  fi
+
+  reason="$(grep -aoE "$RUNNER_FAILURE_PATTERN" "$log" | head -1)"
+  if [ -z "$reason" ] && is_runner_exit_code "$status"; then
+    reason="exit code $status with no test failure in the log"
+  fi
+
+  if [ -z "$reason" ]; then
+    echo "::error::xcodebuild exited $status for a reason this script does not recognise (attempt $attempt); not retrying. Log: $log"
+    tail -40 "$log"
+    exit "$status"
+  fi
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "::error::runner failure on all $MAX_ATTEMPTS attempts, last: $reason (exit $status)"
+    exit "$status"
+  fi
+
+  echo "::warning::runner failure on attempt $attempt (exit $status): $reason. Retrying."
+  attempt=$((attempt + 1))
+done

--- a/scripts/ci_xcodebuild_test.sh
+++ b/scripts/ci_xcodebuild_test.sh
@@ -15,11 +15,16 @@
 #     AmplitudeCore.zip' ... already exists in file system" (binary target, stale SwiftPM
 #     artifact cache), exit 74 -- run 33817758147, tvOS and visionOS legs. The cache is
 #     cleared before the retry.
-#   - test host launch: DTServiceHub "Failed to send signal 19 to process N: 3" (errno 3 is
-#     ESRCH), after which xcodebuild itself dies with SIGSEGV, exit 139 -- run 33712638521, objc.
-#   - xcodebuild aborting with SIGABRT, exit 134, after every test case had passed
-#     (DVTAssertions failure inside DVTiPhoneSimulator) -- run 33819412376, objc, and once before.
+#   - xcodebuild dying by signal with no test-side result in the log: SIGSEGV (exit 139) after a
+#     test host failed to launch -- run 33712638521, objc; SIGABRT (exit 134) after every test
+#     case had passed, from a DVTAssertions failure inside DVTiPhoneSimulator -- runs 33791256663
+#     and 33819412376, objc. Recognised by the exit code, not by a log string.
 # Anything else non-zero is reported and not retried, so a new failure mode is seen, not hidden.
+#
+# Deliberately not a signature: DTServiceHub's "Failed to send signal 19 to process N: 3". It
+# reads like the launch failure above and is not one. It appears in 5 of the 11 objc job logs from
+# the measurement runs, and 4 of those 5 jobs passed, with "** TEST SUCCEEDED **" and exit 0.
+# Matching it would retry any objc failure that happened to carry the line.
 #
 # Usage:  scripts/ci_xcodebuild_test.sh test -scheme <scheme> -destination <dest> [...]
 #         Do not pass -resultBundlePath; the script sets one per attempt under the log dir.
@@ -60,10 +65,11 @@ fi
 # build-failure banners (`xcodebuild test` prints "** TEST BUILD FAILED **").
 TEST_FAILURE_PATTERN="Test [Cc]ase '.*' failed|\.(swift|m|mm|h|c|cc|cpp)(:[0-9]+){1,2}: error:|Restarting after unexpected exit|\*\* (TEST )?BUILD FAILED \*\*|error: linker command failed|Undefined symbols for architecture|Failed to load the test bundle"
 
-# The observed runner failures and nothing generic. "Could not resolve package dependencies" is
-# also what a wrong version requirement prints, and "Failed to launch the test host" is also what
-# a crashing example app prints, so neither is here.
-RUNNER_FAILURE_PATTERN="failed downloading .*/releases/download/|Failed to send signal [0-9]+ to process [0-9]+"
+# One observed runner failure that the exit code alone cannot identify, and nothing generic.
+# "Could not resolve package dependencies" is also what a wrong version requirement prints,
+# "Failed to launch the test host" is also what a crashing example app prints, and DTServiceHub's
+# "Failed to send signal" appears in passing jobs (see the header), so none of those are here.
+RUNNER_FAILURE_PATTERN="failed downloading .*/releases/download/"
 
 # xcodebuild itself dying is a runner failure when the log carries no test-side result: 134 is
 # SIGABRT, 139 is SIGSEGV. Exit 74 (package resolution) is deliberately not here: a wrong version


### PR DESCRIPTION
## Summary

Stacked on #436: base is `chore/deterministic-unit-tests`; GitHub retargets this PR to `main` when #436 merges. Workflow and one script only.

`-retry-tests-on-failure` is removed from all six `xcodebuild test` calls. It re-ran failed test cases and hid a ~36% red rate. With the tests fixed in #436 (550 iterations, 1 failure, 0 crashes across the last four measurement runs), a failing test should fail the leg on the first run.

The flag never covered runner failures, which happen outside test execution. Across the 11 measurement runs behind #436, 5 of 77 jobs failed that way. A run is 7 jobs: 6 platform legs plus the ObjC example app.

| failure | exit | recognised by | seen in |
|---|---|---|---|
| `failed downloading '…/releases/download/v1.5.1/AmplitudeCore.zip' … already exists in file system` (binary target, stale SwiftPM artifact cache) | 74 | log string | 33817758147, tvOS and visionOS, at `xcodebuild -list` before any test ran |
| xcodebuild killed by SIGSEGV after a test host failed to launch | 139 | exit code | 33712638521, objc |
| xcodebuild killed by SIGABRT after every test case had passed (DVTAssertions inside DVTiPhoneSimulator) | 134 | exit code | 33791256663 and 33819412376, objc |

## Change

- `scripts/ci_xcodebuild_test.sh` wraps `xcodebuild test`. Exit 0 returns. A test-side signature in the log is final on the first attempt: `Test Case`/`Test case '…' failed` (serial and parallel formats), `<file>.swift|m|mm|h|c|cc|cpp:N: error:`, `Restarting after unexpected exit`, `** BUILD FAILED **` / `** TEST BUILD FAILED **`, linker errors, `Failed to load the test bundle`. Only the download string above, or exit 134/139 with a clean log, are retried, up to 3 attempts, each announced as a workflow warning. Anything else non-zero is reported and not retried, so a new failure mode is seen rather than absorbed.
- Retrying a download failure clears the SwiftPM artifact cache first. The observed failure left a half-written artifact that a plain rerun would hit again.
- Each attempt gets its own `-resultBundlePath`, so the xcresult reaches the artifact and attempt 2 cannot collide with attempt 1.
- `xcodebuild -list` is informational and now `continue-on-error`. It was the step that went red on the package-download failure.
- `timeout-minutes: 60` on both jobs, down from the 360 default.
- Per-attempt logs and result bundles are uploaded when the test step fails.

Strings deliberately **not** treated as runner failures, because something other than the runner produces them: `Could not resolve package dependencies` (also printed for a wrong version requirement, which is why exit 74 alone does not retry), `Failed to launch the test host` and `Lost connection to the test manager` (also printed by a crashing app or a bundle that fails to load), and DTServiceHub's `Failed to send signal 19 to process N: 3`, which appears in 5 of the 11 ObjC job logs from the measurement runs, 4 of them from jobs that passed.

## Verification

Syntax-checked with `/bin/bash` 3.2, the runner's shell, then run against a fake `xcodebuild` on `PATH`.

| input | expected | result |
|---|---|---|
| success | exit 0, 1 attempt | pass |
| failed test case, compile error, build failure, bundle crash | exit 65, 1 attempt each | pass |
| download failure then success | exit 0, 2 attempts, cache cleared | pass |
| exit 134 then success | exit 0, 2 attempts | pass |
| launch failure three times | exit 139, 3 attempts | pass |
| unrecognised error | exit propagated, 1 attempt | pass |
| failed test plus abort | exit 134, 1 attempt | pass |
| benign DTServiceHub line plus unrecognised exit | exit 65, 1 attempt | pass |
| replay of the real ESRCH/139, abort/134 and download/74 job logs | retried | pass |
| replay of the real WebView failure and bundle crash logs, both exit 65 | 1 attempt | pass |

`MAX_ATTEMPTS=abc` exits 2 rather than looping. The CI run on this PR exercises the success path; the retry paths can only run when a runner actually fails.

## Review rounds

**First version**, independent review plus Codex: the ObjC scheme runs tests in parallel and prints `Test case '-[…]' failed on 'Clone 1 …'`, which the pattern missed, so a failing ObjC test followed by the abort seen twice in that job would have been retried and turned green. Also, the real launch failure exits 139 and never prints the word `ESRCH`; `xcodebuild test` prints `** TEST BUILD FAILED **`, not `** BUILD FAILED **`; the runner pattern held generic strings; a non-integer `MAX_ATTEMPTS` looped forever.

**Second version**: counting root causes across the measurement runs showed that the DTServiceHub line adopted as a signature in the first round appears in passing jobs, making it a false-retry path for any unrecognised ObjC failure. Removed, with no loss of coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect CI orchestration only; production SDK behavior is unchanged, with stricter signal on real test failures.
> 
> **Overview**
> CI unit tests no longer use **`xcodebuild -retry-tests-on-failure`**, so a real test or build failure fails the job on the first run instead of being masked by a second test pass.
> 
> All platform legs and the ObjC example job now run through **`scripts/ci_xcodebuild_test.sh`**, which retries **`xcodebuild test`** up to three times only for known **runner** issues (SwiftPM binary download/cache corruption, or exit **134/139** when the log shows no test failure). Test failures, compile/link errors, and unrecognized exits are not retried. Download retries clear the SwiftPM artifact cache; each attempt gets its own log and **`.xcresult`**.
> 
> The **`unit-test`** workflow adds a **60-minute** job timeout, marks **`xcodebuild -list`** as **`continue-on-error`** so package-resolution flakes there do not fail the job alone, sets **`XCODEBUILD_LOG_DIR`**, and uploads xcodebuild logs as artifacts when the test step fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40eeeb6f51170e81e4057d379f62d52601776826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

